### PR TITLE
Add recursion limit in eval of conditions

### DIFF
--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -366,7 +366,12 @@ pub(super) fn compile_expression(
 ) -> Result<Expr, CompilationError> {
     let span = expression.span;
 
-    match expression.expr {
+    compiler.condition_depth += 1;
+    if compiler.condition_depth >= compiler.params.max_condition_depth {
+        return Err(CompilationError::ConditionTooDeep { span });
+    }
+
+    let res = match expression.expr {
         parser::ExpressionKind::Filesize => Ok(Expr {
             expr: Expression::Filesize,
             ty: Type::Integer,
@@ -846,7 +851,9 @@ pub(super) fn compile_expression(
             ty: Type::Regex,
             span,
         }),
-    }
+    };
+    compiler.condition_depth -= 1;
+    res
 }
 
 fn compile_primary_op<F>(

--- a/boreal/src/compiler/params.rs
+++ b/boreal/src/compiler/params.rs
@@ -1,0 +1,19 @@
+//! Compilation parameters
+
+/// Parameters that can be modified during compilation.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Parameters {
+    /// Maximum depth in a rule's condition AST.
+    ///
+    /// Default value is `40`.
+    pub max_condition_depth: u32,
+}
+
+impl Default for Parameters {
+    fn default() -> Self {
+        Self {
+            max_condition_depth: 40,
+        }
+    }
+}

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -46,6 +46,7 @@ fn compile_expr(expression_str: &str, expected_type: Type) {
         &rule,
         &compiler.default_namespace,
         &compiler.external_symbols,
+        &compiler.params,
     )
     .unwrap();
     let res = compile_expression(&mut rule_compiler, rule.condition).unwrap();

--- a/boreal/tests/it/error.rs
+++ b/boreal/tests/it/error.rs
@@ -1,4 +1,4 @@
-use crate::utils::{check_err, check_err_without_yara};
+use crate::utils::{check_err, Compiler};
 
 #[test]
 fn test_invalid_files() {
@@ -12,7 +12,18 @@ fn test_invalid_files() {
 
         println!("checking file {:?}", file);
         if contents.starts_with("// [no libyara conformance]") {
-            check_err_without_yara(&contents, "");
+            #[cfg(debug_assertions)]
+            let compiler = {
+                let mut compiler = Compiler::new_without_yara();
+                let mut params = boreal::compiler::params::Parameters::default();
+                params.max_condition_depth = 15;
+                compiler.set_params(params);
+                compiler
+            };
+            #[cfg(not(debug_assertions))]
+            let compiler = Compiler::new_without_yara();
+
+            compiler.check_add_rules_err(&contents, "");
         } else {
             // Maybe including the expected prefix in each file (as a comment) would be a nice
             // addition.

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -390,12 +390,6 @@ pub fn check_err(rule: &str, expected_prefix: &str) {
     compiler.check_add_rules_err(rule, expected_prefix);
 }
 
-#[track_caller]
-pub fn check_err_without_yara(rule: &str, expected_prefix: &str) {
-    let compiler = Compiler::new_without_yara();
-    compiler.check_add_rules_err(rule, expected_prefix);
-}
-
 type FullMatches<'a> = Vec<(String, Vec<(&'a str, Vec<(&'a [u8], usize, usize)>)>)>;
 
 fn get_boreal_full_matches<'a>(res: &'a ScanResult<'a>) -> FullMatches<'a> {

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -132,6 +132,10 @@ impl Compiler {
     define_symbol_compiler_method!(define_symbol_str, &str);
     define_symbol_compiler_method!(define_symbol_bool, bool);
 
+    pub fn set_params(&mut self, params: boreal::compiler::params::Parameters) {
+        self.compiler.set_params(params);
+    }
+
     pub fn into_checker(self) -> Checker {
         Checker {
             scanner: self.compiler.into_scanner(),


### PR DESCRIPTION
There already is a limit during parsing for a condition.
However, it is still possible to generate an expression that is very deep, which would
trigger a stack overflow on evaluation, even without the parsing limit being reached.

Add a limit on this, test it, and make it configurable.