### PR TITLE
fix invalid entrypoint values in pe module

### DIFF
--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1074,6 +1074,7 @@ fn parse_file<Pe: ImageNtHeaders>(
             "entry_point",
             sections
                 .and_then(|sections| va_to_file_offset(mem, &sections, ep))
+                .map_or(-1, i64::from)
                 .into(),
         ),
         ("entry_point_raw", ep.into()),

--- a/boreal/src/module/pe/debug.rs
+++ b/boreal/src/module/pe/debug.rs
@@ -23,7 +23,7 @@ pub fn pdb_path(data_dirs: &DataDirectories, mem: &[u8], sections: &SectionTable
         let raw_data_addr = debug_dir.address_of_raw_data.get(LE);
         let raw_data_ptr = debug_dir.pointer_to_raw_data.get(LE);
         if raw_data_addr != 0 {
-            if let Some(v) = super::va_to_file_offset(sections, raw_data_addr) {
+            if let Some(v) = super::va_to_file_offset(mem, sections, raw_data_addr) {
                 offset = v;
             }
         }

--- a/boreal/tests/it/pe.rs
+++ b/boreal/tests/it/pe.rs
@@ -266,8 +266,6 @@ fn test_coverage_pe_libyara_33fc70f9() {
         33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b",
         &[
             "pe.rich_signature",
-            // FIXME: this difference should not be
-            "pe.entry_point",
             #[cfg(not(feature = "openssl"))]
             "pe.number_of_signatures",
         ],


### PR DESCRIPTION
Invalid values for the entry point in the PE module were not correctly
detected. This is now fixed and the entrypoint has value -1 if we either
fail to retrieve it, or if the file offset is bigger than the file size.
