### PR TITLE
Remove logic errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ Main changes:
 ### Removed
 
 - `boreal::module::StaticValue::Regex` has been removed (a7e543b1dee).
+- Removed errors `VariableCompilationError::AtomsExtractionError` and
+  `VariableCompilationError::WidenError`. Those were logic errors that shouldn't
+  be exposed to users.
 
 ## [0.1.0] - 2022-12-04
 

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -443,27 +443,12 @@ fn string_to_wide(s: &[u8]) -> Vec<u8> {
 pub enum VariableCompilationError {
     /// Error when compiling a regex variable.
     Regex(crate::regex::Error),
-
-    /// Logic error while attempting to extract atoms from a variable.
-    ///
-    /// This really should not happen, and indicates a bug in the extraction code.
-    AtomsExtractionError,
-
-    /// Structural error when applying the `wide` modifier to a regex.
-    ///
-    /// This really should not happen, and indicates a bug in the code
-    /// applying this modifier.
-    WidenError,
 }
 
 impl std::fmt::Display for VariableCompilationError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Regex(e) => e.fmt(f),
-            // This should not happen. Please report it upstream if it does.
-            Self::AtomsExtractionError => write!(f, "unable to extract atoms"),
-            // This should not happen. Please report it upstream if it does.
-            Self::WidenError => write!(f, "unable to apply the wide modifier to the regex"),
         }
     }
 }
@@ -484,14 +469,8 @@ mod tests {
         test_type_traits_non_clonable(MatcherType::Literals);
         test_type_traits(AcMatchStatus::Unknown);
 
-        test_type_traits_non_clonable(VariableCompilationError::WidenError);
-        assert_eq!(
-            VariableCompilationError::AtomsExtractionError.to_string(),
-            "unable to extract atoms",
-        );
-        assert_eq!(
-            VariableCompilationError::WidenError.to_string(),
-            "unable to apply the wide modifier to the regex"
-        );
+        test_type_traits_non_clonable(VariableCompilationError::Regex(
+            Regex::from_str("{", true, true).unwrap_err(),
+        ));
     }
 }

--- a/boreal/src/regex.rs
+++ b/boreal/src/regex.rs
@@ -1,7 +1,6 @@
 //! YARA regex handling
 //!
 //! This module contains a set of types and helpers to handle the YARA regex syntax.
-use std::convert::Infallible;
 use std::fmt::Write;
 
 use regex::bytes::RegexBuilder;
@@ -61,7 +60,7 @@ impl Regex {
 
 /// Convert a yara regex AST into a rust regex expression.
 pub(crate) fn regex_ast_to_string(ast: &Node) -> String {
-    visit(ast, AstPrinter::default()).unwrap_or_else(|e| match e {})
+    visit(ast, AstPrinter::default())
 }
 
 #[derive(Default)]
@@ -71,9 +70,8 @@ struct AstPrinter {
 
 impl Visitor for AstPrinter {
     type Output = String;
-    type Err = Infallible;
 
-    fn visit_pre(&mut self, node: &Node) -> Result<VisitAction, Self::Err> {
+    fn visit_pre(&mut self, node: &Node) -> VisitAction {
         match node {
             Node::Assertion(AssertionKind::StartLine) => self.res.push('^'),
             Node::Assertion(AssertionKind::EndLine) => self.res.push('$'),
@@ -87,10 +85,10 @@ impl Visitor for AstPrinter {
             Node::Alternation(_) | Node::Concat(_) | Node::Empty | Node::Repetition { .. } => (),
         }
 
-        Ok(VisitAction::Continue)
+        VisitAction::Continue
     }
 
-    fn visit_post(&mut self, node: &Node) -> Result<(), Self::Err> {
+    fn visit_post(&mut self, node: &Node) {
         match node {
             Node::Alternation(_)
             | Node::Assertion(_)
@@ -122,16 +120,14 @@ impl Visitor for AstPrinter {
                 }
             }
         }
-
-        Ok(())
     }
 
     fn visit_alternation_in(&mut self) {
         self.res.push('|');
     }
 
-    fn finish(self) -> Result<Self::Output, Self::Err> {
-        Ok(self.res)
+    fn finish(self) -> Self::Output {
+        self.res
     }
 }
 


### PR DESCRIPTION
Remove errors that can only stem from logic errors (local runtime invariants not being upheld) that were exposed to the user.