### PR TITLE
feat: make max nb matches per string a u32

### DIFF
--- a/boreal/src/evaluator/ac_scan.rs
+++ b/boreal/src/evaluator/ac_scan.rs
@@ -192,7 +192,7 @@ impl AcScan {
         };
 
         if let AcResult::Matches(matches) = &mut matches[variable_index] {
-            matches.truncate(params.string_max_nb_matches);
+            matches.truncate(params.string_max_nb_matches as usize);
         }
     }
 }

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -171,7 +171,7 @@ impl<'a> ScanData<'a> {
 #[derive(Copy, Clone, Debug)]
 pub struct Params {
     /// Max number of matches for a given string.
-    pub string_max_nb_matches: usize,
+    pub string_max_nb_matches: u32,
 }
 
 /// Evaluates an expression on a given byte slice.
@@ -347,9 +347,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                         let var = get_var!(self, *variable_index);
                         let count = var.count_matches_in(self.mem, from, to);
 
-                        i64::try_from(count)
-                            .map(Value::Integer)
-                            .map_err(|_| PoisonKind::Undefined)
+                        Ok(Value::Integer(count.into()))
                     }
                     _ => Err(PoisonKind::Undefined),
                 }
@@ -357,9 +355,8 @@ impl Evaluator<'_, '_, '_, '_, '_> {
             Expression::Count(variable_index) => {
                 let var = get_var!(self, *variable_index);
                 let count = var.count_matches(self.mem);
-                i64::try_from(count)
-                    .map(Value::Integer)
-                    .map_err(|_| PoisonKind::Undefined)
+
+                Ok(Value::Integer(count.into()))
             }
             Expression::Offset {
                 variable_index,

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -83,18 +83,23 @@ impl<'a> VariableEvaluation<'a> {
     }
 
     /// Count number of matches.
-    pub fn count_matches(&mut self, mem: &[u8]) -> u64 {
+    pub fn count_matches(&mut self, mem: &[u8]) -> u32 {
         loop {
             if self.get_next_match(mem).is_none() {
                 break;
             }
         }
 
-        self.matches.len() as u64
+        // This is safe to allow because the number of matches is guaranteed to be capped by the
+        // string_max_nb_matches parameter, which is a u32.
+        #[allow(clippy::cast_possible_truncation)]
+        {
+            self.matches.len() as u32
+        }
     }
 
     /// Count number of matches in between two bounds.
-    pub fn count_matches_in(&mut self, mem: &[u8], from: usize, to: usize) -> u64 {
+    pub fn count_matches_in(&mut self, mem: &[u8], from: usize, to: usize) -> u32 {
         if from >= mem.len() {
             return 0;
         }
@@ -176,7 +181,10 @@ impl<'a> VariableEvaluation<'a> {
     ///
     /// If the closure returns false, the search ends. Otherwise, the search continues.
     fn get_next_match(&mut self, mem: &[u8]) -> Option<Match> {
-        if self.matches.len() >= self.params.string_max_nb_matches {
+        // This is safe to allow because this is called on every iterator of self.matches, so once
+        // it cannot overflow u32 before this condition is true.
+        #[allow(clippy::cast_possible_truncation)]
+        if (self.matches.len() as u32) >= self.params.string_max_nb_matches {
             return None;
         }
 

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -12,7 +12,7 @@ pub struct ScanParams {
     pub(crate) match_max_length: usize,
 
     /// Max number of matches for a given string.
-    pub(crate) string_max_nb_matches: usize,
+    pub(crate) string_max_nb_matches: u32,
 
     /// Max duration for a scan before it is aborted.
     pub(crate) timeout_duration: Option<Duration>,
@@ -67,7 +67,7 @@ impl ScanParams {
     ///
     /// The default value is `1_000`.
     #[must_use]
-    pub fn string_max_nb_matches(mut self, string_max_nb_matches: usize) -> Self {
+    pub fn string_max_nb_matches(mut self, string_max_nb_matches: u32) -> Self {
         self.string_max_nb_matches = string_max_nb_matches;
         self
     }


### PR DESCRIPTION
This allows to generate a Value during evaluation safely, and avoid some unreachable poison case.