### PR TITLE
feat: remove use of bitflags, flatten var modifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,6 @@ dependencies = [
 name = "boreal-parser"
 version = "0.2.0"
 dependencies = [
- "bitflags",
  "codespan-reporting",
  "nom",
 ]

--- a/boreal-parser/Cargo.toml
+++ b/boreal-parser/Cargo.toml
@@ -15,8 +15,5 @@ rust-version = "1.62"
 # Parsing library
 nom = "7.1"
 
-# packing multiple flags together
-bitflags = "1.3"
-
 # Proper error reporting on parsing
 codespan-reporting = "0.11"

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -58,7 +58,8 @@ pub mod regex;
 pub use regex::Regex;
 mod rule;
 pub use rule::{
-    Metadata, Rule, VariableDeclaration, VariableDeclarationValue, VariableFlags, VariableModifiers,
+    Metadata, Rule, VariableDeclaration, VariableDeclarationValue, VariableModifierBase64,
+    VariableModifiers,
 };
 mod string;
 mod types;

--- a/boreal/tests/it/libyara_compat/rules.rs
+++ b/boreal/tests/it/libyara_compat/rules.rs
@@ -1070,7 +1070,7 @@ fn test_strings() {
       condition:
         $a
     }",
-        "mem:3:23: error: string modifier XOR appears multiple times",
+        "mem:3:23: error: string modifier xor appears multiple times",
     );
 
     // We should have no matches here because we are not generating the wide


### PR DESCRIPTION
This removes a dependency, and makes the code cleaner. There is no longer a possibility of having a xor range or base64 alphabet without the corresponding flag, and the code is globally simpler.