### PR TITLE
Add compilation and scan statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ dependencies = [
  "difflib",
  "itertools",
  "predicates-core",
+ "regex",
 ]
 
 [[package]]

--- a/boreal-cli/Cargo.toml
+++ b/boreal-cli/Cargo.toml
@@ -44,4 +44,4 @@ walkdir = "2.3"
 # Testing for the CLI
 assert_cmd = "2.0"
 tempfile = "3.5"
-predicates = { version = "3.0", default-features = false }
+predicates = { version = "3.0", default-features = false, features = ["regex"] }

--- a/boreal-cli/Cargo.toml
+++ b/boreal-cli/Cargo.toml
@@ -14,7 +14,13 @@ name = "boreal"
 path = "src/main.rs"
 
 [features]
+default = ["authenticode", "profiling"]
+
+# Enable authenticode parsing in boreal, requires OpenSSL
 authenticode = ["boreal/authenticode"]
+# Enables scan statistics. Should not impact performances
+# significantly, and very useful in a CLI tool to debug rules.
+profiling = ["boreal/profiling"]
 
 [dependencies]
 boreal = { path = "../boreal", version = "0.2.0" }

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
-    let scanner = {
+    let mut scanner = {
         let rules_file: &PathBuf = args.get_one("rules_file").unwrap();
 
         #[cfg(feature = "authenticode")]
@@ -136,6 +136,9 @@ fn main() -> ExitCode {
 
         compiler.into_scanner()
     };
+    scanner.set_scan_params(
+        boreal::scanner::ScanParams::default().compute_statistics(args.get_flag("statistics")),
+    );
 
     let input: &PathBuf = args.get_one("input").unwrap();
     if input.is_dir() {
@@ -209,6 +212,9 @@ fn scan_file(scanner: &Scanner, path: &Path, print_module_data: bool) -> std::io
     }
     for rule in res.matched_rules {
         println!("{} {}", &rule.name, path.display());
+    }
+    if let Some(stats) = res.statistics {
+        println!("{}: {:#?}", path.display(), stats);
     }
 
     Ok(())

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -283,10 +283,9 @@ fn print_module_value(value: &ModuleValue, indent: usize) {
     match value {
         ModuleValue::Integer(i) => println!(" = {i} (0x{i:x})"),
         ModuleValue::Float(v) => println!(" = {v}"),
-        ModuleValue::Bytes(bytes) => match std::str::from_utf8(bytes) {
-            Ok(s) => println!(" = {s:?}"),
-            Err(_) => println!(" = {{ {} }}", hex::encode(bytes)),
-        },
+        ModuleValue::Bytes(bytes) => {
+            println!(" = {}", ByteString(bytes));
+        }
         ModuleValue::Regex(regex) => println!(" = /{}/", regex.as_regex().as_str()),
         ModuleValue::Boolean(b) => println!(" = {b:?}"),
         ModuleValue::Object(obj) => {
@@ -331,15 +330,23 @@ fn print_module_value(value: &ModuleValue, indent: usize) {
             let mut keys: Vec<_> = dict.keys().collect();
             keys.sort_unstable();
             for key in keys {
-                match std::str::from_utf8(key) {
-                    Ok(s) => print!("{:indent$}[{:?}]", "", s),
-                    Err(_) => print!("{:indent$}[{{ {} }}]", "", hex::encode(key)),
-                };
+                print!("{:indent$}[{}]", "", ByteString(key));
                 print_module_value(&dict[key], indent + 4);
             }
         }
         ModuleValue::Function(_) => println!("[function]"),
         ModuleValue::Undefined => println!("[undef]"),
+    }
+}
+
+struct ByteString<'a>(&'a [u8]);
+
+impl std::fmt::Display for ByteString<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match std::str::from_utf8(self.0) {
+            Ok(s) => write!(f, "{s:?}"),
+            Err(_) => write!(f, "{{ {} }}", hex::encode(self.0)),
+        }
     }
 }
 

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -295,7 +295,7 @@ fn display_rule_stats(stats: &statistics::CompiledRule) {
     for var in &stats.strings {
         let lits: Vec<_> = var.literals.iter().map(|v| ByteString(v)).collect();
         let atoms: Vec<_> = var.atoms.iter().map(|v| ByteString(v)).collect();
-        println!("  ${}", var.name);
+        println!("  {}", var.expr);
         println!("    literals: {:?}", &lits);
         println!("    atoms: {:?}", &atoms);
         println!("    atoms quality: {}", var.atoms_quality);

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -79,11 +79,16 @@ fn build_command() -> Command {
                 .help("Display the names of all available modules"),
         )
         .arg(
-            Arg::new("statistics")
-                .short('S')
-                .long("print-stats")
+            Arg::new("string_statistics")
+                .long("string-stats")
                 .action(ArgAction::SetTrue)
-                .help("Display statistics on rules' compilation and evaluation"),
+                .help("Display statistics on rules' compilation"),
+        )
+        .arg(
+            Arg::new("scan_statistics")
+                .long("scan-stats")
+                .action(ArgAction::SetTrue)
+                .help("Display statistics on rules' evaluation"),
         )
 }
 
@@ -116,7 +121,7 @@ fn main() -> ExitCode {
         compiler.set_params(
             boreal::compiler::CompilerParams::default()
                 .fail_on_warnings(args.get_flag("fail_on_warnings"))
-                .compute_statistics(args.get_flag("statistics")),
+                .compute_statistics(args.get_flag("string_statistics")),
         );
 
         match compiler.add_rules_file(rules_file) {
@@ -137,7 +142,7 @@ fn main() -> ExitCode {
         compiler.into_scanner()
     };
     scanner.set_scan_params(
-        boreal::scanner::ScanParams::default().compute_statistics(args.get_flag("statistics")),
+        boreal::scanner::ScanParams::default().compute_statistics(args.get_flag("scan_statistics")),
     );
 
     let input: &PathBuf = args.get_one("input").unwrap();

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -27,6 +27,9 @@ object = ["dep:object"]
 # The `object` feature must also be enabled to get access to the "pe" module.
 authenticode = ["dep:authenticode-parser"]
 
+# Enables computating of statistics during scanning.
+profiling = []
+
 [dependencies]
 boreal-parser = { path = "../boreal-parser", version = "0.2.0" }
 

--- a/boreal/src/atoms.rs
+++ b/boreal/src/atoms.rs
@@ -1,0 +1,70 @@
+//! Utilities related to the extraction of atoms.
+//!
+//! An atom is a byte string that is contained in a rule's variable, with additional
+//! constraints:
+//!
+//! - If an atom is found, then the variable may be present.
+//! - If no atoms are found, then the variable cannot be found.
+//!
+//! That is, for any possible match of a variable, an atom in the set of the variable must be
+//! contained in the match.
+//!
+//! Atoms are selected by computing a rank for each atom: the higher the rank, the preferred the
+//! atom. This rank is related to how rare the atom should be found during scanning, and thus
+//! the rate of false positive matches.
+
+/// Maximum size of an atom extracted from a literal and used in the AC scan.
+const ATOM_SIZE: usize = 4;
+
+/// Pick a shorter atom from a literal.
+///
+/// This returns a tuple of:
+/// - the offset to add to the start of the literal, in order to get the start of the atom.
+/// - the offset to substract from the end of the literal, in order to get the end of the atom.
+pub fn pick_atom_in_literal(lit: &[u8]) -> (usize, usize) {
+    if lit.len() <= ATOM_SIZE {
+        return (0, 0);
+    }
+
+    lit.windows(ATOM_SIZE)
+        .enumerate()
+        .max_by_key(|(_, s)| atom_rank(s))
+        .map_or((0, 0), |(i, _)| (i, lit.len() - i - ATOM_SIZE))
+}
+
+/// Compute the rank of an atom.
+///
+/// The higher the value, the best quality (i.e., the less false positives).
+pub fn atom_rank(atom: &[u8]) -> u32 {
+    // This algorithm is straight copied from libyara.
+    // TODO: Probably want to revisit this.
+    let mut quality = 0_u32;
+    let mut bitmask = [false; 256];
+    let mut nb_uniq = 0;
+
+    for b in atom {
+        match *b {
+            0x00 | 0x20 | 0xCC | 0xFF => quality += 12,
+            v if v.is_ascii_lowercase() => quality += 18,
+            _ => quality += 20,
+        }
+
+        if !bitmask[*b as usize] {
+            bitmask[*b as usize] = true;
+            nb_uniq += 1;
+        }
+    }
+
+    // If all the bytes in the atom are equal and very common, let's penalize
+    // it heavily.
+    if nb_uniq == 1 && (bitmask[0] || bitmask[0x20] || bitmask[0xCC] || bitmask[0xFF]) {
+        quality -= 10 * u32::try_from(atom.len()).unwrap_or(30);
+    }
+    // In general atoms with more unique bytes have a better quality, so let's
+    // boost the quality in the amount of unique bytes.
+    else {
+        quality += 2 * nb_uniq;
+    }
+
+    quality
+}

--- a/boreal/src/atoms.rs
+++ b/boreal/src/atoms.rs
@@ -32,10 +32,19 @@ pub fn pick_atom_in_literal(lit: &[u8]) -> (usize, usize) {
         .map_or((0, 0), |(i, _)| (i, lit.len() - i - ATOM_SIZE))
 }
 
+/// Compute the rank of a set of atoms.
+///
+/// The higher the value, the best quality (i.e., the less false positives).
+pub fn atoms_rank(literals: &[Vec<u8>]) -> u32 {
+    // Get the min rank. This is probably the best solution, it isn't clear if a better one
+    // is easy to find.
+    literals.iter().map(|lit| atom_rank(lit)).min().unwrap_or(0)
+}
+
 /// Compute the rank of an atom.
 ///
 /// The higher the value, the best quality (i.e., the less false positives).
-pub fn atom_rank(atom: &[u8]) -> u32 {
+fn atom_rank(atom: &[u8]) -> u32 {
     // This algorithm is straight copied from libyara.
     // TODO: Probably want to revisit this.
     let mut quality = 0_u32;

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -283,7 +283,7 @@ impl Compiler {
             kind: AddRuleErrorKind::Parse(error),
         })?;
         for component in file.components {
-            self.add_component(component, namespace, current_filepath, status)?;
+            self.add_component(component, namespace, current_filepath, s, status)?;
         }
         Ok(())
     }
@@ -293,6 +293,7 @@ impl Compiler {
         component: parser::YaraFileComponent,
         namespace_name: Option<&str>,
         current_filepath: Option<&Path>,
+        parsed_contents: &str,
         status: &mut AddRuleStatus,
     ) -> Result<(), AddRuleError> {
         let namespace = match namespace_name {
@@ -392,11 +393,17 @@ impl Compiler {
                     variables,
                     variables_statistics,
                     warnings,
-                } = rule::compile_rule(*rule, namespace, &self.external_symbols, &self.params)
-                    .map_err(|error| AddRuleError {
-                        path: current_filepath.map(Path::to_path_buf),
-                        kind: AddRuleErrorKind::Compilation(error),
-                    })?;
+                } = rule::compile_rule(
+                    *rule,
+                    namespace,
+                    &self.external_symbols,
+                    &self.params,
+                    parsed_contents,
+                )
+                .map_err(|error| AddRuleError {
+                    path: current_filepath.map(Path::to_path_buf),
+                    kind: AddRuleErrorKind::Compilation(error),
+                })?;
 
                 if self.params.compute_statistics {
                     status.statistics.push(statistics::CompiledRule {

--- a/boreal/src/compiler/params.rs
+++ b/boreal/src/compiler/params.rs
@@ -8,6 +8,9 @@ pub struct CompilerParams {
 
     /// Fail adding rules on warnings.
     pub(crate) fail_on_warnings: bool,
+
+    /// Compute statistics when compiling rules.
+    pub(crate) compute_statistics: bool,
 }
 
 impl Default for CompilerParams {
@@ -15,6 +18,7 @@ impl Default for CompilerParams {
         Self {
             max_condition_depth: 40,
             fail_on_warnings: false,
+            compute_statistics: false,
         }
     }
 }
@@ -49,6 +53,18 @@ impl CompilerParams {
     #[must_use]
     pub fn fail_on_warnings(mut self, fail_on_warnings: bool) -> Self {
         self.fail_on_warnings = fail_on_warnings;
+        self
+    }
+
+    /// Compute statistics during compilation.
+    ///
+    /// This option allows retrieve statistics related to the compilation of strings.
+    /// See `AddRuleStatus::statistics`.
+    ///
+    /// Default value is false.
+    #[must_use]
+    pub fn compute_statistics(mut self, compute_statistics: bool) -> Self {
+        self.compute_statistics = compute_statistics;
         self
     }
 }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -206,6 +206,7 @@ pub(super) fn compile_rule(
     namespace: &mut Namespace,
     external_symbols: &Vec<ExternalSymbol>,
     params: &CompilerParams,
+    parsed_contents: &str,
 ) -> Result<CompiledRule, CompilationError> {
     let (condition, wildcards, vars, warnings) = {
         let mut compiler = RuleCompiler::new(&rule, namespace, external_symbols, params)?;
@@ -248,7 +249,8 @@ pub(super) fn compile_rule(
     let mut variables_statistics = Vec::new();
 
     for var in rule.variables {
-        let (var, stats) = variable::compile_variable(var, params.compute_statistics)?;
+        let (var, stats) =
+            variable::compile_variable(var, parsed_contents, params.compute_statistics)?;
         if let Some(stats) = stats {
             variables_statistics.push(stats);
         }

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -287,5 +287,6 @@ fn test_types_traits() {
     test_type_traits(CompilerParams::default());
     test_type_traits_non_clonable(AddRuleStatus {
         warnings: Vec::new(),
+        statistics: Vec::new(),
     });
 }

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -9,7 +9,6 @@ use super::base64::encode_base64;
 use super::CompilationError;
 
 mod atom;
-pub use atom::atom_rank;
 mod hex_string;
 mod regex;
 

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -90,6 +90,7 @@ pub enum AcMatchStatus {
 
 pub(crate) fn compile_variable(
     decl: VariableDeclaration,
+    parsed_contents: &str,
     compute_statistics: bool,
 ) -> Result<(Variable, Option<statistics::CompiledString>), CompilationError> {
     let VariableDeclaration {
@@ -174,6 +175,7 @@ pub(crate) fn compile_variable(
 
         Some(statistics::CompiledString {
             name: res.name.clone(),
+            expr: parsed_contents[span.start..span.end].to_owned(),
             literals: res.literals.clone(),
             atoms,
             atoms_quality,
@@ -516,6 +518,7 @@ mod tests {
                     modifiers: VariableModifiers::default(),
                     span: 0..1,
                 },
+                "",
                 false,
             )
             .unwrap()

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -8,8 +8,8 @@ use crate::regex::Regex;
 use super::base64::encode_base64;
 use super::CompilationError;
 
-mod atom;
 mod hex_string;
+mod literals;
 mod regex;
 
 /// A compiled variable used in a rule.

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -526,6 +526,12 @@ mod tests {
         );
         test_type_traits_non_clonable(MatcherType::Literals);
         test_type_traits(AcMatchStatus::Unknown);
+        test_type_traits(Flags {
+            fullword: false,
+            ascii: false,
+            wide: false,
+            nocase: false,
+        });
 
         test_type_traits_non_clonable(VariableCompilationError::Regex(
             Regex::from_str("{", true, true).unwrap_err(),

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -348,7 +348,7 @@ impl Variable {
         let atoms_quality = atoms_rank(&atoms);
 
         statistics::CompiledString {
-            string_name: self.name.clone(),
+            name: self.name.clone(),
             literals: self.literals.clone(),
             atoms,
             atoms_quality,

--- a/boreal/src/compiler/variable/literals.rs
+++ b/boreal/src/compiler/variable/literals.rs
@@ -1,7 +1,7 @@
 //! Literal extraction and computation from variable expressions.
 use boreal_parser::regex::{AssertionKind, Node};
 
-use crate::atoms::atom_rank;
+use crate::atoms::atoms_rank;
 use crate::regex::{visit, VisitAction, Visitor};
 
 pub fn get_literals_details(node: &Node) -> LiteralsDetails {
@@ -200,13 +200,7 @@ struct LiteralSet {
 
 impl LiteralSet {
     fn add_literals(&mut self, literals: Vec<Vec<u8>>, start_position: usize, end_position: usize) {
-        // Get the min rank. This is probably the best solution, it isn't clear if a better one
-        // is easy to find.
-        let rank = literals
-            .iter()
-            .map(|lit| atom_rank(lit))
-            .min()
-            .unwrap_or(0);
+        let rank = atoms_rank(&literals);
 
         // this.literals is one possible set, and the provided literals are another one.
         // Keep the one with the best rank.
@@ -228,7 +222,9 @@ impl LiteralSet {
                 nodes.push(Node::Group(Box::new(Node::Alternation(
                     literals
                         .iter()
-                        .map(|literal| Node::Concat(literal.iter().copied().map(Node::Literal).collect()))
+                        .map(|literal| {
+                            Node::Concat(literal.iter().copied().map(Node::Literal).collect())
+                        })
                         .collect(),
                 ))));
             }

--- a/boreal/src/compiler/variable/regex.rs
+++ b/boreal/src/compiler/variable/regex.rs
@@ -3,7 +3,7 @@ use boreal_parser::VariableModifiers;
 
 use crate::regex::{regex_ast_to_string, visit, Regex, VisitAction, Visitor};
 
-use super::atom::AtomsDetails;
+use super::literals::LiteralsDetails;
 use super::{CompiledVariable, MatcherType, VariableCompilationError};
 
 /// Build a matcher for the given regex and string modifiers.
@@ -22,11 +22,11 @@ pub(super) fn compile_regex(
         case_insensitive = true;
     }
 
-    let AtomsDetails {
+    let LiteralsDetails {
         mut literals,
         pre_ast,
         post_ast,
-    } = super::atom::get_atoms_details(ast);
+    } = super::literals::get_literals_details(ast);
 
     let use_ac = !literals.is_empty()
         && literals.iter().all(|lit| lit.len() >= 2)

--- a/boreal/src/evaluator/ac_scan.rs
+++ b/boreal/src/evaluator/ac_scan.rs
@@ -4,7 +4,8 @@ use std::ops::Range;
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
 
 use super::{EvalError, Params, ScanData};
-use crate::compiler::variable::{atom_rank, AcMatchStatus, Variable};
+use crate::atoms::pick_atom_in_literal;
+use crate::compiler::variable::{AcMatchStatus, Variable};
 
 /// Factorize atoms from all variables, to scan for them in a single pass.
 ///
@@ -61,7 +62,7 @@ impl AcScan {
                 non_handled_var_indexes.push(variable_index);
             } else {
                 for (literal_index, lit) in var.literals.iter().enumerate() {
-                    let (start, end) = pick_best_atom_in_literal(lit);
+                    let (start, end) = pick_atom_in_literal(lit);
                     aho_index_to_literal_info.push(LiteralInfo {
                         variable_index,
                         literal_index,
@@ -195,17 +196,6 @@ impl AcScan {
             matches.truncate(params.string_max_nb_matches as usize);
         }
     }
-}
-
-fn pick_best_atom_in_literal(lit: &[u8]) -> (usize, usize) {
-    if lit.len() <= 4 {
-        return (0, 0);
-    }
-
-    lit.windows(4)
-        .enumerate()
-        .max_by_key(|(_, s)| atom_rank(s))
-        .map_or((0, 0), |(i, _)| (i, lit.len() - i - 4))
 }
 
 #[derive(Clone, Debug)]

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -346,13 +346,13 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                 let to = usize::try_from(to).unwrap_or(0);
 
                 let var = get_var!(self, *variable_index);
-                let count = var.count_matches_in(self.mem, from, to);
+                let count = var.count_matches_in(self.scan_data, from, to);
 
                 Ok(Value::Integer(count.into()))
             }
             Expression::Count(variable_index) => {
                 let var = get_var!(self, *variable_index);
-                let count = var.count_matches(self.mem);
+                let count = var.count_matches(self.scan_data);
 
                 Ok(Value::Integer(count.into()))
             }
@@ -365,7 +365,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                 match usize::try_from(occurence_number) {
                     Ok(v) if v != 0 => {
                         let var = get_var!(self, *variable_index);
-                        var.find_match_occurence(self.mem, v - 1)
+                        var.find_match_occurence(self.scan_data, v - 1)
                             .map(|mat| Value::Integer(mat.start as i64))
                             .ok_or(PoisonKind::Undefined)
                     }
@@ -381,7 +381,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                 match usize::try_from(occurence_number) {
                     Ok(v) if v != 0 => {
                         let var = get_var!(self, *variable_index);
-                        var.find_match_occurence(self.mem, v - 1)
+                        var.find_match_occurence(self.scan_data, v - 1)
                             .map(|mat| Value::Integer(mat.len() as i64))
                             .ok_or(PoisonKind::Undefined)
                     }
@@ -611,7 +611,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                 // For this expression, we can use the variables set to retrieve the truth value,
                 // no need to rescan.
                 let var = get_var!(self, *variable_index);
-                Ok(Value::Boolean(var.find(self.mem)))
+                Ok(Value::Boolean(var.find(self.scan_data)))
             }
 
             Expression::VariableAt {
@@ -623,7 +623,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                 match usize::try_from(offset) {
                     Ok(offset) => {
                         let var = get_var!(self, *variable_index);
-                        Ok(Value::Boolean(var.find_at(self.mem, offset)))
+                        Ok(Value::Boolean(var.find_at(self.scan_data, offset)))
                     }
                     Err(_) => Ok(Value::Boolean(false)),
                 }
@@ -641,7 +641,7 @@ impl Evaluator<'_, '_, '_, '_, '_> {
                     (Ok(from), Ok(to)) if from <= to => {
                         let var = get_var!(self, *variable_index);
 
-                        Ok(Value::Boolean(var.find_in(self.mem, from, to)))
+                        Ok(Value::Boolean(var.find_in(self.scan_data, from, to)))
                     }
                     _ => Ok(Value::Boolean(false)),
                 }

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -41,6 +41,7 @@ use std::time::Duration;
 use crate::compiler::expression::{Expression, ForIterator, ForSelection, VariableIndex};
 use crate::compiler::rule::Rule;
 use crate::regex::Regex;
+use crate::statistics;
 use memchr::memmem;
 
 use crate::compiler::ExternalValue;
@@ -123,6 +124,9 @@ pub struct ScanData<'a> {
 
     // Object used to check if the scan times out.
     timeout_checker: Option<timeout::TimeoutChecker>,
+
+    // Statistics related to the scan.
+    pub statistics: Option<statistics::Evaluation>,
 }
 
 impl<'a> ScanData<'a> {
@@ -131,6 +135,7 @@ impl<'a> ScanData<'a> {
         modules: &[Box<dyn Module>],
         external_symbols: &'a [ExternalValue],
         timeout: Option<Duration>,
+        statistics: Option<statistics::Evaluation>,
     ) -> Self {
         // Create the timeout checker first. This starts the timer, and thus includes the modules
         // evaluation.
@@ -157,6 +162,7 @@ impl<'a> ScanData<'a> {
             module_ctx,
             external_symbols,
             timeout_checker,
+            statistics,
         }
     }
 
@@ -1050,6 +1056,7 @@ mod tests {
             },
             external_symbols: &[],
             timeout_checker: None,
+            statistics: None,
         });
         test_type_traits_non_clonable(ForSelectionEvaluation::Value(Value::Integer(0)));
         test_type_traits_non_clonable(ForSelectionEvaluator::None);

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -225,13 +225,17 @@ mod tests {
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(VariableEvaluation {
-            var: &compile_variable(VariableDeclaration {
-                name: "a".to_owned(),
-                value: VariableDeclarationValue::Bytes(Vec::new()),
-                modifiers: VariableModifiers::default(),
-                span: 0..1,
-            })
-            .unwrap(),
+            var: &compile_variable(
+                VariableDeclaration {
+                    name: "a".to_owned(),
+                    value: VariableDeclarationValue::Bytes(Vec::new()),
+                    modifiers: VariableModifiers::default(),
+                    span: 0..1,
+                },
+                false,
+            )
+            .unwrap()
+            .0,
             params: Params {
                 string_max_nb_matches: 100,
             },

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -232,6 +232,7 @@ mod tests {
                     modifiers: VariableModifiers::default(),
                     span: 0..1,
                 },
+                "",
                 false,
             )
             .unwrap()

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -1,6 +1,5 @@
 //! Implement scanning for variables
 use std::cmp::Ordering;
-use std::time::Instant;
 
 use super::ac_scan::AcResult;
 use super::{Params, ScanData};
@@ -198,8 +197,12 @@ impl<'a> VariableEvaluation<'a> {
             Some(v) => v,
         };
 
-        let start = Instant::now();
+        #[cfg(feature = "profiling")]
+        let start = std::time::Instant::now();
+
         let mat = self.var.find_next_match_at(scan_data.mem, offset);
+
+        #[cfg(feature = "profiling")]
         if let Some(stats) = scan_data.statistics.as_mut() {
             stats.raw_regexes_eval_duration += start.elapsed();
         }

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -79,6 +79,7 @@ use tempfile as _;
 #[cfg(test)]
 use yara as _;
 
+pub(crate) mod atoms;
 pub mod compiler;
 pub use compiler::Compiler;
 mod evaluator;

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -87,6 +87,7 @@ pub mod module;
 pub mod regex;
 pub mod scanner;
 pub use scanner::Scanner;
+pub mod statistics;
 
 #[cfg(test)]
 mod test_helpers;

--- a/boreal/src/scanner.rs
+++ b/boreal/src/scanner.rs
@@ -315,7 +315,7 @@ impl Inner {
                 matched_rules.push(build_matched_rule(
                     rule,
                     var_evals,
-                    mem,
+                    &scan_data,
                     params.compute_full_matches,
                     params.match_max_length,
                 ));
@@ -354,7 +354,7 @@ impl Inner {
                         matched_rules.push(build_matched_rule(
                             rule,
                             Vec::new(),
-                            scan_data.mem,
+                            scan_data,
                             false,
                             params.match_max_length,
                         ));
@@ -379,7 +379,7 @@ impl Inner {
                 matched_rules.push(build_matched_rule(
                     rule,
                     Vec::new(),
-                    scan_data.mem,
+                    scan_data,
                     false,
                     params.match_max_length,
                 ));
@@ -405,13 +405,13 @@ fn collect_nb_elems<I: Iterator<Item = T>, T>(iter: &mut I, nb: usize) -> Vec<T>
 fn build_matched_rule<'a>(
     rule: &'a Rule,
     mut var_evals: Vec<VariableEvaluation<'a>>,
-    mem: &[u8],
+    scan_data: &ScanData,
     compute_full_matches: bool,
     match_max_length: usize,
 ) -> MatchedRule<'a> {
     if compute_full_matches {
         for var_eval in &mut var_evals {
-            var_eval.compute_all_matches(mem);
+            var_eval.compute_all_matches(scan_data);
         }
     }
 
@@ -433,7 +433,7 @@ fn build_matched_rule<'a>(
                         StringMatch {
                             offset: mat.start,
                             length: mat.end - mat.start,
-                            data: mem[mat.start..]
+                            data: scan_data.mem[mat.start..]
                                 .iter()
                                 .take(capped_length)
                                 .copied()

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -18,6 +18,8 @@ pub struct ScanParams {
     pub(crate) timeout_duration: Option<Duration>,
 
     /// Compute statistics on scanning.
+    ///
+    /// This requires the `profiling` feature.
     pub(crate) compute_statistics: bool,
 }
 

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -16,6 +16,9 @@ pub struct ScanParams {
 
     /// Max duration for a scan before it is aborted.
     pub(crate) timeout_duration: Option<Duration>,
+
+    /// Compute statistics on scanning.
+    pub(crate) compute_statistics: bool,
 }
 
 impl Default for ScanParams {
@@ -25,6 +28,7 @@ impl Default for ScanParams {
             match_max_length: 512,
             string_max_nb_matches: 1_000,
             timeout_duration: None,
+            compute_statistics: false,
         }
     }
 }
@@ -81,6 +85,18 @@ impl ScanParams {
     #[must_use]
     pub fn timeout_duration(mut self, timeout_duration: Option<Duration>) -> Self {
         self.timeout_duration = timeout_duration;
+        self
+    }
+
+    /// Compute statistics during scanning.
+    ///
+    /// This option allows retrieve statistics related to the scanning of bytes.
+    /// See `AddRuleStatus::statistics`.
+    ///
+    /// Default value is false.
+    #[must_use]
+    pub fn compute_statistics(mut self, compute_statistics: bool) -> Self {
+        self.compute_statistics = compute_statistics;
         self
     }
 }

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -1,6 +1,6 @@
 //! Statistics used to investigate performance of rules.
 
-use std::path::PathBuf;
+use std::{path::PathBuf, time::Duration};
 
 /// Compilation statistics for a rule.
 #[derive(Clone, Debug)]
@@ -65,6 +65,26 @@ pub enum MatchingKind {
     Regex,
 }
 
+/// Statistics on the evaluation of a byte string.
+#[derive(Clone, Debug, Default)]
+pub struct Evaluation {
+    /// Time spent evaluating rules before any scanning.
+    ///
+    /// This is used for the no-scan optimization.
+    pub no_scan_eval_duration: Duration,
+
+    /// Time spent running the Aho-Corasick algorithm.
+    pub ac_duration: Duration,
+
+    /// Time spent evaluation rules.
+    pub rules_eval_duration: Duration,
+
+    /// Time spent evaluating singled regexes.
+    ///
+    /// This is an aggregation of the time spent evaluating "raw" variables regexes.
+    pub raw_regexes_eval_duration: Duration,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +107,6 @@ mod tests {
             matching_kind: MatchingKind::Literals,
         });
         test_type_traits(MatchingKind::Atomized);
+        test_type_traits(Evaluation::default());
     }
 }

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -76,6 +76,14 @@ pub struct Evaluation {
     /// Time spent running the Aho-Corasick algorithm.
     pub ac_duration: Duration,
 
+    /// Time spent confirming matches of the Aho-Corasick algorithm.
+    ///
+    /// This is a subtotal of `ac_duration`.
+    pub ac_confirm_duration: Duration,
+
+    /// Number of matches done by the Aho-Corasick algorithm.
+    pub nb_ac_matches: u64,
+
     /// Time spent evaluation rules.
     pub rules_eval_duration: Duration,
 

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -66,6 +66,8 @@ pub enum MatchingKind {
 }
 
 /// Statistics on the evaluation of a byte string.
+///
+/// This is only filled if the `profiling` feature is enabled.
 #[derive(Clone, Debug, Default)]
 pub struct Evaluation {
     /// Time spent evaluating rules before any scanning.

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -1,0 +1,87 @@
+//! Statistics used to investigate performance of rules.
+
+use std::path::PathBuf;
+
+/// Compilation statistics for a rule.
+#[derive(Clone, Debug)]
+pub struct CompiledRule {
+    /// Path to the file containing the rule.
+    ///
+    /// None if the rule was added directly as a string.
+    pub filepath: Option<PathBuf>,
+
+    /// Namespace containing the rule.
+    ///
+    /// None for the default namespace.
+    pub namespace: Option<String>,
+
+    /// Name of the rule.
+    pub name: String,
+
+    /// Statistics on the compiled strings.
+    ///
+    /// The order in which the strings are declared in the rule is preserved in this array.
+    pub strings: Vec<CompiledString>,
+}
+
+/// Details on the compilation of a string.
+#[derive(Clone, Debug)]
+pub struct CompiledString {
+    /// Name of the string in the rule, without the leading `$`.
+    pub name: String,
+
+    /// Literals extracted from the string.
+    pub literals: Vec<Vec<u8>>,
+
+    /// Atoms picked out of those literals.
+    pub atoms: Vec<Vec<u8>>,
+
+    /// Quality of the atoms.
+    pub atoms_quality: u32,
+
+    /// Matching kind for the string.
+    pub matching_kind: MatchingKind,
+}
+
+/// Kind of matching for a string.
+#[derive(Clone, Debug)]
+pub enum MatchingKind {
+    /// Literals cover the entire string.
+    ///
+    /// AC hits from atoms are confirmed using the literals.
+    Literals,
+
+    /// Atoms are used in AC pass and confirmed by left and right regexes.
+    Atomized,
+
+    /// The AC hits are not confirmed, and the regex is run on its own.
+    ///
+    /// If the string has atoms, those are used to detect whether the string is certain to
+    /// hits or not. If a single atom hits during the AC pass (or if there are no atoms), the
+    /// regex will have to be run on its own.
+    Regex,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_type_traits;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits(CompiledRule {
+            filepath: Some(PathBuf::new()),
+            namespace: Some(String::new()),
+            name: String::new(),
+            strings: Vec::new(),
+        });
+        test_type_traits(CompiledString {
+            name: String::new(),
+            literals: Vec::new(),
+            atoms: Vec::new(),
+            atoms_quality: 0,
+            matching_kind: MatchingKind::Literals,
+        });
+        test_type_traits(MatchingKind::Atomized);
+    }
+}

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -30,6 +30,9 @@ pub struct CompiledString {
     /// Name of the string in the rule, without the leading `$`.
     pub name: String,
 
+    /// Expression of the string, as it is declared in the rule.
+    pub expr: String,
+
     /// Literals extracted from the string.
     pub literals: Vec<Vec<u8>>,
 
@@ -77,6 +80,7 @@ mod tests {
         });
         test_type_traits(CompiledString {
             name: String::new(),
+            expr: String::new(),
             literals: Vec::new(),
             atoms: Vec::new(),
             atoms_quality: 0,


### PR DESCRIPTION
Compilation statistics are details about how strings are compiled. They can be retrieved with a new compiler params, and printed out in boreal-cli

Scan statistics are timing details about the scan of a file. They can be retrieved with a new scanner params, and printed out in boreal-cli as well. However, since it may have some impact on scanning performances, a feature flag is required to compute those timings. It is disabled by default on boreal the library, but enabled by default on boreal-cli.