### PR TITLE
Use dfa to validate AC matches

### DIFF
--- a/boreal/src/compiler/variable/matcher.rs
+++ b/boreal/src/compiler/variable/matcher.rs
@@ -5,7 +5,8 @@ use crate::regex::Regex;
 use super::AcMatchStatus;
 
 pub mod raw;
-pub mod widener;
+pub mod validator;
+mod widener;
 
 const MAX_SPLIT_MATCH_LENGTH: usize = 4096;
 
@@ -52,8 +53,8 @@ pub enum MatcherKind {
     Literals,
     /// The regex can confirm matches from AC literal matches.
     Atomized {
-        left_validator: Option<Regex>,
-        right_validator: Option<Regex>,
+        left_validator: Option<validator::Validator>,
+        right_validator: Option<validator::Validator>,
     },
 
     /// The regex cannot confirm matches from AC literal matches.
@@ -122,7 +123,7 @@ impl Matcher {
                             mem.len(),
                             mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH),
                         );
-                        match validator.find_anchored_at(&mem[0..end], mat.start) {
+                        match validator.find_anchored_fwd(mem, mat.start, end) {
                             Some(m) => m.end,
                             None => return AcMatchStatus::None,
                         }

--- a/boreal/src/compiler/variable/matcher.rs
+++ b/boreal/src/compiler/variable/matcher.rs
@@ -5,7 +5,7 @@ use crate::regex::Regex;
 use super::AcMatchStatus;
 
 pub mod raw;
-mod widener;
+pub mod widener;
 
 const MAX_SPLIT_MATCH_LENGTH: usize = 4096;
 

--- a/boreal/src/compiler/variable/matcher.rs
+++ b/boreal/src/compiler/variable/matcher.rs
@@ -53,8 +53,8 @@ pub enum MatcherKind {
     Literals,
     /// The regex can confirm matches from AC literal matches.
     Atomized {
-        left_validator: Option<validator::Validator>,
-        right_validator: Option<validator::Validator>,
+        left_validator: Option<validator::ReverseValidator>,
+        right_validator: Option<validator::ForwardValidator>,
     },
 
     /// The regex cannot confirm matches from AC literal matches.
@@ -124,7 +124,7 @@ impl Matcher {
                             mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH),
                         );
                         match validator.find_anchored_fwd(mem, mat.start, end) {
-                            Some(m) => m.end,
+                            Some(end) => end,
                             None => return AcMatchStatus::None,
                         }
                     }
@@ -150,8 +150,8 @@ impl Matcher {
                             start_position,
                             mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                         );
-                        while let Some(m) = validator.find(&mem[start..mat.end]) {
-                            let m = (m.start + start)..end;
+                        while let Some(s) = validator.find_anchored_rev(mem, start, mat.end) {
+                            let m = s..end;
                             start = m.start + 1;
                             if let Some(m) = self.validate_and_update_match(mem, m, match_type) {
                                 matches.push(m);

--- a/boreal/src/compiler/variable/matcher/raw.rs
+++ b/boreal/src/compiler/variable/matcher/raw.rs
@@ -62,3 +62,16 @@ impl RawMatcher {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(
+            RawMatcher::new(&Hir::Empty, &VariableModifiers::default(), true).unwrap(),
+        );
+    }
+}

--- a/boreal/src/compiler/variable/matcher/raw.rs
+++ b/boreal/src/compiler/variable/matcher/raw.rs
@@ -51,10 +51,10 @@ impl RawMatcher {
             .find(Input::new(mem).span(offset..mem.len()))
             .map(|m| {
                 let match_type = match (flags.ascii, flags.wide, m.pattern().as_u32()) {
-                    (false, true, _) => MatchType::Wide,
+                    (false, true, _) => MatchType::WideStandard,
                     // First pattern is ascii, Second one is wide
                     (true, true, 0) => MatchType::Ascii,
-                    (true, true, _) => MatchType::Wide,
+                    (true, true, _) => MatchType::WideAlternate,
                     _ => MatchType::Ascii,
                 };
 

--- a/boreal/src/compiler/variable/matcher/validator.rs
+++ b/boreal/src/compiler/variable/matcher/validator.rs
@@ -8,6 +8,7 @@ use regex_automata::util::pool::Pool;
 use regex_automata::util::syntax;
 use regex_automata::{Anchored, Input, MatchKind, PatternID};
 
+use crate::compiler::variable::analysis::analyze_hir;
 use crate::regex::{regex_hir_to_string, Hir};
 
 use super::widener::widen_hir;
@@ -18,28 +19,54 @@ type PoolCreateFn = Box<dyn Fn() -> Cache + Send + Sync>;
 const MAX_SPLIT_MATCH_LENGTH: usize = 4096;
 
 #[derive(Debug)]
-pub struct Validator {
-    forward: Option<ForwardValidator>,
-    reverse: Option<ReverseValidator>,
+pub enum Validator {
+    NonGreedy {
+        forward: Option<ForwardValidator>,
+        reverse: Option<ReverseValidator>,
+    },
+    Greedy {
+        reverse: ReverseValidator,
+        full: ForwardValidator,
+    },
 }
 
 impl Validator {
     pub fn new(
         pre: Option<&Hir>,
         post: Option<&Hir>,
+        full: &Hir,
         modifiers: &VariableModifiers,
         dot_all: bool,
     ) -> Result<Self, crate::regex::Error> {
-        Ok(Self {
-            forward: match post {
-                Some(hir) => Some(ForwardValidator::new(hir, modifiers, dot_all)?),
-                None => None,
-            },
-            reverse: match pre {
-                Some(hir) => Some(ReverseValidator::new(hir, modifiers, dot_all)?),
-                None => None,
-            },
-        })
+        if let Some(pre) = pre {
+            let left_analysis = analyze_hir(pre, dot_all);
+
+            // XXX: If the left HIR has greedy repetitions, then the HIR cannot be split into a
+            // (left, literals, right) triplet. This is because the greedy repetitions can
+            // "eat" the literals, leading to incorrect matches.
+            //
+            // For example, a regex that looks like: `a.+foo.b` will extract the literal foo,
+            // but against the string `aafoobbaafoobb`, it will match on the entire string,
+            // while a (pre, post) matching would match twice.
+            if left_analysis.has_greedy_repetitions {
+                let reverse = ReverseValidator::new(pre, modifiers, dot_all)?;
+                let full = ForwardValidator::new(full, modifiers, dot_all)?;
+
+                return Ok(Self::Greedy { reverse, full });
+            }
+        }
+
+        let reverse = match pre {
+            Some(hir) => Some(ReverseValidator::new(hir, modifiers, dot_all)?),
+            None => None,
+        };
+
+        let forward = match post {
+            Some(hir) => Some(ForwardValidator::new(hir, modifiers, dot_all)?),
+            None => None,
+        };
+
+        Ok(Self::NonGreedy { forward, reverse })
     }
 
     pub fn validate_match(
@@ -51,36 +78,60 @@ impl Validator {
     ) -> Matches {
         let pattern_index = match_type_to_pattern_index(match_type);
 
-        let end = match &self.forward {
-            Some(validator) => {
-                let end =
-                    std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
-                match validator.find_anchored_fwd(mem, mat.start, end, pattern_index) {
-                    Some(end) => end,
-                    None => return Matches::None,
+        match self {
+            Self::NonGreedy { forward, reverse } => {
+                let end = match forward {
+                    Some(validator) => {
+                        let end = std::cmp::min(
+                            mem.len(),
+                            mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH),
+                        );
+                        match validator.find_anchored_fwd(mem, mat.start, end, pattern_index) {
+                            Some(end) => end,
+                            None => return Matches::None,
+                        }
+                    }
+                    None => mat.end,
+                };
+
+                match reverse {
+                    None => Matches::Single(mat.start..end),
+                    Some(validator) => {
+                        // The left validator can yield multiple matches.
+                        // For example, `a.?bb`, with the `bb` atom, can match as many times as there are
+                        // 'a' characters before the `bb` atom.
+                        let mut matches = Vec::new();
+                        let mut start = std::cmp::max(
+                            start_position,
+                            mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
+                        );
+                        while let Some(s) =
+                            validator.find_anchored_rev(mem, start, mat.end, pattern_index)
+                        {
+                            matches.push(s..end);
+                            start = s + 1;
+                        }
+                        Matches::Multiple(matches)
+                    }
                 }
             }
-            None => mat.end,
-        };
-
-        match &self.reverse {
-            None => Matches::Single(mat.start..end),
-            Some(validator) => {
-                // The left validator can yield multiple matches.
-                // For example, `a.?bb`, with the `bb` atom, can match as many times as there are
-                // 'a' characters before the `bb` atom.
-                //
-                // XXX: This only works if the left validator does not contain any greedy repetitions!
+            Self::Greedy { reverse, full } => {
                 let mut matches = Vec::new();
+
                 let mut start = std::cmp::max(
                     start_position,
                     mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                 );
-                while let Some(s) = validator.find_anchored_rev(mem, start, mat.end, pattern_index)
-                {
-                    matches.push(s..end);
+                let end =
+                    std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
+
+                while let Some(s) = reverse.find_anchored_rev(mem, start, mat.end, pattern_index) {
+                    if let Some(e) = full.find_anchored_fwd(mem, s, end, pattern_index) {
+                        matches.push(s..e);
+                    }
                     start = s + 1;
                 }
+
                 Matches::Multiple(matches)
             }
         }
@@ -88,7 +139,7 @@ impl Validator {
 }
 
 #[derive(Debug)]
-struct ForwardValidator {
+pub struct ForwardValidator {
     dfa: Arc<DFA>,
     // TODO: Taking the cache out of the pool when starting scanning (and putting them in the scan
     // data) would avoid the get/drop on every validation, and only do it once per scan.
@@ -142,7 +193,7 @@ fn match_type_to_pattern_index(match_type: MatchType) -> PatternID {
 }
 
 #[derive(Debug)]
-struct ReverseValidator {
+pub struct ReverseValidator {
     dfa: Arc<DFA>,
     pool: Pool<Cache, PoolCreateFn>,
 }
@@ -245,6 +296,9 @@ mod tests {
         );
         test_type_traits_non_clonable(
             ReverseValidator::new(&Hir::Empty, &VariableModifiers::default(), true).unwrap(),
+        );
+        test_type_traits_non_clonable(
+            Validator::new(None, None, &Hir::Empty, &VariableModifiers::default(), true).unwrap(),
         );
     }
 }

--- a/boreal/src/compiler/variable/matcher/validator.rs
+++ b/boreal/src/compiler/variable/matcher/validator.rs
@@ -1,0 +1,79 @@
+use std::ops::Range;
+
+use boreal_parser::VariableModifiers;
+use regex_automata::{meta, Anchored, Input};
+
+use crate::regex::{regex_hir_to_string, Hir, Regex};
+
+use super::widener::widen_hir;
+
+#[derive(Debug)]
+pub struct Validator {
+    regex: meta::Regex,
+}
+
+impl Validator {
+    pub fn new(
+        hir: &Hir,
+        modifiers: &VariableModifiers,
+        dot_all: bool,
+    ) -> Result<Self, crate::regex::Error> {
+        let expr = convert_hir_to_string_with_flags(hir, modifiers);
+        let builder = Regex::builder(modifiers.nocase, dot_all);
+
+        Ok(Self {
+            regex: builder.build(&expr).map_err(crate::regex::Error::from)?,
+        })
+    }
+
+    pub fn find_anchored_fwd(
+        &self,
+        haystack: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Option<Range<usize>> {
+        self.regex
+            .find(
+                Input::new(haystack)
+                    .span(start..end)
+                    .anchored(Anchored::Yes),
+            )
+            .map(|m| m.range())
+    }
+
+    pub fn find(&self, mem: &[u8]) -> Option<Range<usize>> {
+        self.regex.find(mem).map(|m| m.range())
+    }
+}
+
+/// Convert the AST of a regex variable to a string, taking into account variable modifiers.
+fn convert_hir_to_string_with_flags(hir: &Hir, modifiers: &VariableModifiers) -> String {
+    if modifiers.wide {
+        let wide_hir = widen_hir(hir);
+
+        if modifiers.ascii {
+            format!(
+                "{}|{}",
+                regex_hir_to_string(hir),
+                regex_hir_to_string(&wide_hir),
+            )
+        } else {
+            regex_hir_to_string(&wide_hir)
+        }
+    } else {
+        regex_hir_to_string(hir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(Validator {
+            regex: meta::Regex::new("a").unwrap(),
+        });
+    }
+}

--- a/boreal/src/compiler/variable/matcher/widener.rs
+++ b/boreal/src/compiler/variable/matcher/widener.rs
@@ -195,3 +195,16 @@ impl Visitor for HirWidener {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    use super::*;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(HirWidener::new());
+        test_type_traits_non_clonable(StackLevel::new(false));
+    }
+}

--- a/boreal/src/compiler/variable/regex.rs
+++ b/boreal/src/compiler/variable/regex.rs
@@ -1,11 +1,11 @@
-use boreal_parser::regex::AssertionKind;
 use boreal_parser::VariableModifiers;
 
-use crate::regex::{regex_hir_to_string, visit, Hir, Regex, VisitAction, Visitor};
+use crate::regex::{regex_hir_to_string, Hir, Regex};
 
 use super::analysis::analyze_hir;
 use super::literals::LiteralsDetails;
 use super::matcher;
+use super::matcher::widener::widen_hir;
 use super::{only_literals, CompiledVariable, VariableCompilationError};
 
 /// Build a matcher for the given regex and string modifiers.
@@ -149,7 +149,7 @@ fn widen_literal(literal: &[u8]) -> Vec<u8> {
 /// Convert the AST of a regex variable to a string, taking into account variable modifiers.
 fn convert_hir_to_string_with_flags(hir: &Hir, modifiers: &VariableModifiers) -> String {
     if modifiers.wide {
-        let wide_hir = visit(hir, HirWidener::new());
+        let wide_hir = widen_hir(hir);
 
         if modifiers.ascii {
             format!(
@@ -171,207 +171,4 @@ fn compile_regex_expr(
     dot_all: bool,
 ) -> Result<Regex, VariableCompilationError> {
     Regex::from_string(expr, case_insensitive, dot_all).map_err(VariableCompilationError::Regex)
-}
-
-/// Visitor used to transform a regex HIR to make the regex match "wide" characters.
-///
-/// This is intented to transform a regex with the "wide" modifier, that is make it so
-/// the regex will not match raw ASCII but UCS-2.
-///
-/// This means translating every match on a literal or class into this literal/class followed by a
-/// nul byte. See the implementation of the [`Visitor`] trait on [`NodeWidener`] for more details.
-#[derive(Debug)]
-struct HirWidener {
-    /// Top level HIR object
-    hir: Option<Hir>,
-
-    /// Stack of HIR objects built.
-    ///
-    /// Each visit to a compound HIR value (group, alternation, etc) will push a new level
-    /// to the stack. Then when we finish visiting the compound value, the level will be pop-ed,
-    /// and the new compound HIR value built.
-    stack: Vec<StackLevel>,
-}
-
-#[derive(Debug)]
-struct StackLevel {
-    /// HIR values built in this level.
-    hirs: Vec<Hir>,
-
-    /// Is this level for a concat HIR value.
-    in_concat: bool,
-}
-
-impl StackLevel {
-    fn new(in_concat: bool) -> Self {
-        Self {
-            hirs: Vec::new(),
-            in_concat,
-        }
-    }
-
-    fn push(&mut self, hir: Hir) {
-        self.hirs.push(hir);
-    }
-}
-
-impl HirWidener {
-    fn new() -> Self {
-        Self {
-            hir: None,
-            stack: Vec::new(),
-        }
-    }
-
-    fn add(&mut self, hir: Hir) {
-        if self.stack.is_empty() {
-            // Empty stack: we should only have a single HIR to set at top-level.
-            let res = self.hir.replace(hir);
-            assert!(res.is_none(), "top level HIR hir already set");
-        } else {
-            let pos = self.stack.len() - 1;
-            self.stack[pos].push(hir);
-        }
-    }
-
-    fn add_wide(&mut self, hir: Hir) {
-        let nul_byte = Hir::Literal(b'\0');
-
-        if self.stack.is_empty() {
-            let res = self.hir.replace(Hir::Concat(vec![hir, nul_byte]));
-            assert!(res.is_none(), "top level HIR hir already set");
-        } else {
-            let pos = self.stack.len() - 1;
-            let level = &mut self.stack[pos];
-            if level.in_concat {
-                level.hirs.push(hir);
-                level.hirs.push(nul_byte);
-            } else {
-                level
-                    .hirs
-                    .push(Hir::Group(Box::new(Hir::Concat(vec![hir, nul_byte]))));
-            }
-        }
-    }
-}
-
-impl Visitor for HirWidener {
-    type Output = Hir;
-
-    fn finish(self) -> Hir {
-        // Safety: there is a top-level node, the one we visit first.
-        self.hir.unwrap()
-    }
-
-    fn visit_pre(&mut self, node: &Hir) -> VisitAction {
-        match node {
-            Hir::Dot
-            | Hir::Empty
-            | Hir::Literal(_)
-            | Hir::Mask { .. }
-            | Hir::Class(_)
-            | Hir::Assertion(_) => (),
-
-            Hir::Repetition { .. } | Hir::Group(_) | Hir::Alternation(_) => {
-                self.stack.push(StackLevel::new(false));
-            }
-            Hir::Concat(_) => {
-                self.stack.push(StackLevel::new(true));
-            }
-        }
-        VisitAction::Continue
-    }
-
-    fn visit_post(&mut self, hir: &Hir) {
-        match hir {
-            Hir::Empty => self.add(Hir::Empty),
-
-            // Literal, dot or class: add a nul_byte after it
-            Hir::Dot => self.add_wide(Hir::Dot),
-            Hir::Literal(lit) => self.add_wide(Hir::Literal(*lit)),
-            Hir::Mask { .. } => self.add_wide(hir.clone()),
-            Hir::Class(cls) => self.add_wide(Hir::Class(cls.clone())),
-
-            // Anchor: no need to add anything
-            Hir::Assertion(AssertionKind::StartLine) | Hir::Assertion(AssertionKind::EndLine) => {
-                self.add(hir.clone());
-            }
-
-            // Boundary is tricky as it looks for a match between two characters:
-            // \b means: word on the left side, non-word on the right, or the opposite:
-            // - \ta, a\t, \0a, \t\0 matches
-            // - ab, \t\n does not match
-            // When the input is wide, this is harder:
-            // - \t\0a\0, a\0\t\0 matches
-            // - a\0b\0, \t\0\b\0 does not match
-            //
-            // This cannot be transformed properly. Instead, we have two possibilities:
-            // - Unwide the input, and run the regex on it.
-            // - widen the regex but without the word boundaries. On matches, unwide the match,
-            //   then use the non wide regex to check if the match is valid.
-            //
-            // We use the second solution. Note that there are some differences in results
-            // depending on which solution is picked. Those are mostly edge cases on carefully
-            // crafted regexes, so it should not matter, but the test
-            // `test_variable_regex_word_boundaries_edge_cases` tests some of those.
-            Hir::Assertion(AssertionKind::WordBoundary)
-            | Hir::Assertion(AssertionKind::NonWordBoundary) => {
-                self.add(Hir::Empty);
-            }
-
-            Hir::Repetition {
-                hir: _,
-                kind,
-                greedy,
-            } => {
-                // Safety:
-                // - first pop is guaranteed to contain an element, since this is a "post" visit,
-                //   and the pre visit push an element on the stack.
-                // - second pop is guaranteed to contain an element, since we walked into the
-                //   repetition node, which pushed an element into the stack.
-                let hir = self.stack.pop().unwrap().hirs.pop().unwrap();
-                self.add(Hir::Repetition {
-                    kind: kind.clone(),
-                    greedy: *greedy,
-                    hir: Box::new(hir),
-                });
-            }
-            Hir::Group(_) => {
-                // Safety:
-                // - first pop is guaranteed to contain an element, since this is a "post" visit,
-                //   and the pre visit push an element on the stack.
-                // - second pop is guaranteed to contain an element, since we walked into the
-                //   group node, which pushed an element into the stack.
-                let node = self.stack.pop().unwrap().hirs.pop().unwrap();
-                self.add(Hir::Group(Box::new(node)));
-            }
-            Hir::Concat(_) => {
-                // Safety:
-                // - pop is guaranteed to contain an element, since this is a "post" visit,
-                //   and the pre visit push an element on the stack.
-                let vec = self.stack.pop().unwrap().hirs;
-                self.add(Hir::Concat(vec));
-            }
-            Hir::Alternation(_) => {
-                // Safety:
-                // - pop is guaranteed to contain an element, since this is a "post" visit,
-                //   and the pre visit push an element on the stack.
-                let vec = self.stack.pop().unwrap().hirs;
-                self.add(Hir::Alternation(vec));
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::test_helpers::test_type_traits_non_clonable;
-
-    use super::*;
-
-    #[test]
-    fn test_types_traits() {
-        test_type_traits_non_clonable(HirWidener::new());
-        test_type_traits_non_clonable(StackLevel::new(false));
-    }
 }

--- a/boreal/src/regex.rs
+++ b/boreal/src/regex.rs
@@ -3,7 +3,7 @@
 //! This module contains a set of types and helpers to handle the YARA regex syntax.
 use std::{fmt::Write, ops::Range};
 
-use regex_automata::{meta, util::syntax, Anchored, Input};
+use regex_automata::{meta, util::syntax, Input};
 
 use boreal_parser::regex::{
     AssertionKind, BracketedClass, BracketedClassItem, ClassKind, Node, PerlClass, PerlClassKind,
@@ -80,16 +80,6 @@ impl Regex {
     #[must_use]
     pub fn find_at(&self, haystack: &[u8], offset: usize) -> Option<Range<usize>> {
         self.find_in_input(Input::new(haystack).span(offset..haystack.len()))
-    }
-
-    /// Find a match on the given haystack in the given range
-    #[must_use]
-    pub fn find_anchored_at(&self, haystack: &[u8], start: usize) -> Option<Range<usize>> {
-        self.find_in_input(
-            Input::new(haystack)
-                .span(start..haystack.len())
-                .anchored(Anchored::Yes),
-        )
     }
 
     /// Find a match on the given haystack in the given range

--- a/boreal/tests/it/regex.rs
+++ b/boreal/tests/it/regex.rs
@@ -206,3 +206,25 @@ fn test_regex_at_most_repetitions() {
     checker.check(br"<{{>", true);
     checker.check(br"<{{{>", false);
 }
+
+// Check the regex size is checked regardless of the matcher picked.
+#[test]
+fn test_regex_size() {
+    let check =
+        |regex| {
+            check_err(&format!("rule test {{ strings: $a = {regex} condition: $a }}"),
+        "mem:1:22: error: variable $a cannot be compiled: Compiled regex exceeds size limit");
+        };
+
+    // Raw matcher
+    check("/^a{2977952116}/");
+
+    // Right validator
+    check("/abcd a{2977952116}/");
+
+    // Left validator
+    check("/a{2977952116} abcd/");
+
+    // Wide regex with boundaries
+    check(r"/a{2977952116}\B abcd/ wide");
+}


### PR DESCRIPTION
Instead of using a high level regex to validate ac matches, use a lazy dfa directly. This brings multiple benefits:

- we can build a reverse dfa directly for the "pre" validator, making the anchored reverse search possible
- this reduces the memory usage
- it will allow using the Automaton trait to handle the wide w/ boundary edge case in the future

In addition, the validators are now also used in the presence of greedy repetitions. This greatly improves performances on some benchmarks, which the number of "raw" matchers getting smaller and smaller.
