### PR TITLE
Support wide keyword and word boundaries in validators

### DIFF
--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -4,7 +4,6 @@ use boreal_parser::VariableModifiers;
 use boreal_parser::{VariableDeclaration, VariableDeclarationValue};
 
 use crate::atoms::{atoms_rank, pick_atom_in_literal};
-use crate::regex::Regex;
 use crate::statistics;
 
 use super::base64::encode_base64;
@@ -120,7 +119,6 @@ pub(crate) fn compile_variable(
         Ok(CompiledVariable {
             literals,
             matcher_kind,
-            non_wide_regex,
         }) => Variable {
             name,
             is_private: modifiers.private,
@@ -133,7 +131,6 @@ pub(crate) fn compile_variable(
                     nocase: modifiers.nocase,
                 },
                 kind: matcher_kind,
-                non_wide_regex,
             },
         },
         Err(error) => {
@@ -180,7 +177,6 @@ pub(crate) fn compile_variable(
 struct CompiledVariable {
     literals: Vec<Vec<u8>>,
     matcher_kind: matcher::MatcherKind,
-    non_wide_regex: Option<Regex>,
 }
 
 fn compile_bytes(
@@ -220,7 +216,6 @@ fn compile_bytes(
         return Ok(CompiledVariable {
             literals: new_literals,
             matcher_kind: matcher::MatcherKind::Literals,
-            non_wide_regex: None,
         });
     }
 
@@ -255,7 +250,6 @@ fn compile_bytes(
     Ok(CompiledVariable {
         literals,
         matcher_kind: matcher::MatcherKind::Literals,
-        non_wide_regex: None,
     })
 }
 
@@ -291,7 +285,10 @@ impl std::fmt::Display for VariableCompilationError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
+    use crate::{
+        regex::Regex,
+        test_helpers::{test_type_traits, test_type_traits_non_clonable},
+    };
 
     #[test]
     fn test_types_traits() {

--- a/boreal/src/compiler/variable/matcher.rs
+++ b/boreal/src/compiler/variable/matcher.rs
@@ -8,7 +8,7 @@ pub mod validator;
 mod widener;
 
 #[derive(Debug)]
-pub struct Matcher {
+pub(crate) struct Matcher {
     /// Set of literals extracted from the variable.
     ///
     /// Will be used by the AC pass to scan for the variable.
@@ -45,7 +45,7 @@ pub struct Flags {
 }
 
 #[derive(Debug)]
-pub enum MatcherKind {
+pub(crate) enum MatcherKind {
     /// The literals cover entirely the variable.
     Literals,
     /// The regex can confirm matches from AC literal matches.

--- a/boreal/src/compiler/variable/matcher/raw.rs
+++ b/boreal/src/compiler/variable/matcher/raw.rs
@@ -1,24 +1,22 @@
 use std::ops::Range;
 
-use boreal_parser::VariableModifiers;
 use regex_automata::Input;
 
-use crate::regex::{regex_hir_to_string, Hir, Regex};
+use crate::{
+    compiler::variable::RegexModifiers,
+    regex::{regex_hir_to_string, Hir, Regex},
+};
 
 use super::{widener::widen_hir, Flags, MatchType};
 
 #[derive(Debug)]
-pub struct RawMatcher {
+pub(crate) struct RawMatcher {
     regex: regex_automata::meta::Regex,
 }
 
 impl RawMatcher {
-    pub fn new(
-        hir: &Hir,
-        modifiers: &VariableModifiers,
-        dot_all: bool,
-    ) -> Result<Self, crate::regex::Error> {
-        let builder = Regex::builder(modifiers.nocase, dot_all);
+    pub(crate) fn new(hir: &Hir, modifiers: RegexModifiers) -> Result<Self, crate::regex::Error> {
+        let builder = Regex::builder(modifiers.nocase, modifiers.dot_all);
 
         let res = match (modifiers.ascii, modifiers.wide) {
             (true, true) => {
@@ -41,7 +39,7 @@ impl RawMatcher {
         })
     }
 
-    pub(super) fn find_next_match_at(
+    pub(crate) fn find_next_match_at(
         &self,
         mem: &[u8],
         offset: usize,
@@ -71,7 +69,7 @@ mod tests {
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(
-            RawMatcher::new(&Hir::Empty, &VariableModifiers::default(), true).unwrap(),
+            RawMatcher::new(&Hir::Empty, RegexModifiers::default()).unwrap(),
         );
     }
 }

--- a/boreal/src/compiler/variable/matcher/raw.rs
+++ b/boreal/src/compiler/variable/matcher/raw.rs
@@ -2,20 +2,42 @@ use std::ops::Range;
 
 use regex_automata::Input;
 
-use crate::{
-    compiler::variable::RegexModifiers,
-    regex::{regex_hir_to_string, Hir, Regex},
-};
+use crate::compiler::variable::analysis::HirAnalysis;
+use crate::compiler::variable::RegexModifiers;
+use crate::regex::{regex_hir_to_string, Hir, Regex};
 
 use super::{widener::widen_hir, Flags, MatchType};
 
 #[derive(Debug)]
 pub(crate) struct RawMatcher {
     regex: regex_automata::meta::Regex,
+
+    /// Regex of the non wide version of the regex.
+    ///
+    /// This is only set for the specific case of a regex variable, with a wide modifier, that
+    /// contains word boundaries.
+    /// In this case, the regex expression cannot be "widened", and this regex is used to post
+    /// check matches.
+    pub non_wide_regex: Option<Regex>,
 }
 
 impl RawMatcher {
-    pub(crate) fn new(hir: &Hir, modifiers: RegexModifiers) -> Result<Self, crate::regex::Error> {
+    pub(crate) fn new(
+        hir: &Hir,
+        analysis: &HirAnalysis,
+        modifiers: RegexModifiers,
+    ) -> Result<Self, crate::regex::Error> {
+        let non_wide_regex = if analysis.has_word_boundaries && modifiers.wide {
+            let expr = regex_hir_to_string(hir);
+            Some(Regex::from_string(
+                expr,
+                modifiers.nocase,
+                modifiers.dot_all,
+            )?)
+        } else {
+            None
+        };
+
         let builder = Regex::builder(modifiers.nocase, modifiers.dot_all);
 
         let res = match (modifiers.ascii, modifiers.wide) {
@@ -36,40 +58,111 @@ impl RawMatcher {
 
         Ok(Self {
             regex: res.map_err(crate::regex::Error::from)?,
+            non_wide_regex,
         })
     }
 
     pub(crate) fn find_next_match_at(
         &self,
         mem: &[u8],
-        offset: usize,
+        mut offset: usize,
         flags: Flags,
     ) -> Option<(Range<usize>, MatchType)> {
-        self.regex
-            .find(Input::new(mem).span(offset..mem.len()))
-            .map(|m| {
-                let match_type = match (flags.ascii, flags.wide, m.pattern().as_u32()) {
-                    (false, true, _) => MatchType::WideStandard,
-                    // First pattern is ascii, Second one is wide
-                    (true, true, 0) => MatchType::Ascii,
-                    (true, true, _) => MatchType::WideAlternate,
-                    _ => MatchType::Ascii,
-                };
+        loop {
+            let m = self.regex.find(Input::new(mem).span(offset..mem.len()))?;
+            let mat = m.range();
 
-                (m.range(), match_type)
-            })
+            let match_type = match (flags.ascii, flags.wide, m.pattern().as_u32()) {
+                (false, true, _) => MatchType::WideStandard,
+                // First pattern is ascii, Second one is wide
+                (true, true, 0) => MatchType::Ascii,
+                (true, true, _) => MatchType::WideAlternate,
+                _ => MatchType::Ascii,
+            };
+
+            match self.non_wide_regex.as_ref() {
+                Some(regex) => {
+                    // TODO: avoid this for the raw matcher too. Use a dfa validator?
+                    match apply_wide_word_boundaries(mat.clone(), mem, regex, match_type) {
+                        Some(new_mat) => return Some((new_mat, match_type)),
+                        None => offset = mat.start + 1,
+                    }
+                }
+                None => return Some((mat, match_type)),
+            }
+        }
     }
 }
 
+/// Check the match respects the word boundaries inside the variable.
+fn apply_wide_word_boundaries(
+    mut mat: Range<usize>,
+    mem: &[u8],
+    regex: &Regex,
+    match_type: MatchType,
+) -> Option<Range<usize>> {
+    match match_type {
+        MatchType::WideStandard | MatchType::WideAlternate => (),
+        MatchType::Ascii => return Some(mat),
+    }
+
+    // Take the previous and next byte, so that word boundaries placed at the beginning or end of
+    // the regex can be checked.
+    // Note that we must check that the previous/next byte is "wide" as well, otherwise it is not
+    // valid.
+    let start = if mat.start >= 2 && mem[mat.start - 1] == b'\0' {
+        mat.start - 2
+    } else {
+        mat.start
+    };
+
+    // Remove the wide bytes, and then use the non wide regex to check for word boundaries.
+    // Since when checking word boundaries, we might match more than the initial match (because of
+    // non greedy repetitions bounded by word boundaries), we need to add more data at the end.
+    // How much? We cannot know, but including too much would be too much of a performance tank.
+    // This is arbitrarily capped at 500 for the moment (or until the string is no longer wide)...
+    let unwiden_mem = unwide(&mem[start..std::cmp::min(mem.len(), mat.end + 500)]);
+
+    #[allow(clippy::bool_to_int_with_if)]
+    let expected_start = if start < mat.start { 1 } else { 0 };
+    match regex.find(&unwiden_mem) {
+        Some(m) if m.start == expected_start => {
+            // Modify the match end. This is needed because the application of word boundary
+            // may modify the match. Since we matched on non wide mem though, double the size.
+            mat.end = mat.start + 2 * (m.end - m.start);
+            Some(mat)
+        }
+        _ => None,
+    }
+}
+
+fn unwide(mem: &[u8]) -> Vec<u8> {
+    let mut res = Vec::new();
+
+    for b in mem.chunks_exact(2) {
+        if b[1] != b'\0' {
+            break;
+        }
+        res.push(b[0]);
+    }
+
+    res
+}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::variable::analysis::analyze_hir;
     use crate::test_helpers::test_type_traits_non_clonable;
 
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(
-            RawMatcher::new(&Hir::Empty, RegexModifiers::default()).unwrap(),
+            RawMatcher::new(
+                &Hir::Empty,
+                &analyze_hir(&Hir::Empty, true),
+                RegexModifiers::default(),
+            )
+            .unwrap(),
         );
     }
 }

--- a/boreal/src/compiler/variable/matcher/validator.rs
+++ b/boreal/src/compiler/variable/matcher/validator.rs
@@ -7,7 +7,7 @@ use regex_automata::util::pool::Pool;
 use regex_automata::util::syntax;
 use regex_automata::{Anchored, Input, MatchKind, PatternID};
 
-use crate::compiler::variable::analysis::analyze_hir;
+use crate::compiler::variable::analysis::{analyze_hir, HirAnalysis};
 use crate::compiler::variable::RegexModifiers;
 use crate::regex::{regex_hir_to_string, Hir};
 
@@ -37,31 +37,36 @@ impl Validator {
         full: &Hir,
         modifiers: RegexModifiers,
     ) -> Result<Self, crate::regex::Error> {
-        if let Some(pre) = pre {
-            let left_analysis = analyze_hir(pre, modifiers.dot_all);
-
-            // XXX: If the left HIR has greedy repetitions, then the HIR cannot be split into a
-            // (left, literals, right) triplet. This is because the greedy repetitions can
-            // "eat" the literals, leading to incorrect matches.
-            //
-            // For example, a regex that looks like: `a.+foo.b` will extract the literal foo,
-            // but against the string `aafoobbaafoobb`, it will match on the entire string,
-            // while a (pre, post) matching would match twice.
-            if left_analysis.has_greedy_repetitions {
-                let reverse = DfaValidator::new(pre, modifiers, true)?;
-                let full = DfaValidator::new(full, modifiers, false)?;
-
-                return Ok(Self::Greedy { reverse, full });
-            }
-        }
-
         let reverse = match pre {
-            Some(hir) => Some(DfaValidator::new(hir, modifiers, true)?),
+            Some(pre) => {
+                let left_analysis = analyze_hir(pre, modifiers.dot_all);
+
+                // XXX: If the left HIR has greedy repetitions, then the HIR cannot be split into a
+                // (left, literals, right) triplet. This is because the greedy repetitions can
+                // "eat" the literals, leading to incorrect matches.
+                //
+                // For example, a regex that looks like: `a.+foo.b` will extract the literal foo,
+                // but against the string `aafoobbaafoobb`, it will match on the entire string,
+                // while a (pre, post) matching would match twice.
+                if left_analysis.has_greedy_repetitions {
+                    let reverse = DfaValidator::new(pre, &left_analysis, modifiers, true)?;
+
+                    let full_analysis = analyze_hir(full, modifiers.dot_all);
+                    let full = DfaValidator::new(full, &full_analysis, modifiers, false)?;
+
+                    return Ok(Self::Greedy { reverse, full });
+                }
+
+                Some(DfaValidator::new(pre, &left_analysis, modifiers, true)?)
+            }
             None => None,
         };
 
         let forward = match post {
-            Some(hir) => Some(DfaValidator::new(hir, modifiers, false)?),
+            Some(hir) => {
+                let analysis = analyze_hir(hir, modifiers.dot_all);
+                Some(DfaValidator::new(hir, &analysis, modifiers, false)?)
+            }
             None => None,
         };
 
@@ -75,8 +80,6 @@ impl Validator {
         start_position: usize,
         match_type: MatchType,
     ) -> Matches {
-        let pattern_index = match_type_to_pattern_index(match_type);
-
         match self {
             Self::NonGreedy { forward, reverse } => {
                 let end = match forward {
@@ -85,7 +88,7 @@ impl Validator {
                             mem.len(),
                             mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH),
                         );
-                        match validator.find_anchored_fwd(mem, mat.start, end, pattern_index) {
+                        match validator.find_anchored_fwd(mem, mat.start, end, match_type) {
                             Some(end) => end,
                             None => return Matches::None,
                         }
@@ -105,10 +108,13 @@ impl Validator {
                             mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                         );
                         while let Some(s) =
-                            validator.find_anchored_rev(mem, start, mat.end, pattern_index)
+                            validator.find_anchored_rev(mem, start, mat.end, match_type)
                         {
                             matches.push(s..end);
                             start = s + 1;
+                            if start > mat.end {
+                                break;
+                            }
                         }
                         Matches::Multiple(matches)
                     }
@@ -124,11 +130,14 @@ impl Validator {
                 let end =
                     std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
 
-                while let Some(s) = reverse.find_anchored_rev(mem, start, mat.end, pattern_index) {
-                    if let Some(e) = full.find_anchored_fwd(mem, s, end, pattern_index) {
+                while let Some(s) = reverse.find_anchored_rev(mem, start, mat.end, match_type) {
+                    if let Some(e) = full.find_anchored_fwd(mem, s, end, match_type) {
                         matches.push(s..e);
                     }
                     start = s + 1;
+                    if start > mat.end {
+                        break;
+                    }
                 }
 
                 Matches::Multiple(matches)
@@ -139,19 +148,40 @@ impl Validator {
 
 #[derive(Debug)]
 pub(crate) struct DfaValidator {
+    /// Anchored lazy DFA, used to validate an AC match.
     dfa: Arc<DFA>,
     // TODO: Taking the cache out of the pool when starting scanning (and putting them in the scan
     // data) would avoid the get/drop on every validation, and only do it once per scan.
     // Not sure how much improvements this would be, to test.
     pool: Pool<Cache, PoolCreateFn>,
+
+    /// Use the custom wide routine to validate wide matches.
+    ///
+    /// If true, a custom routine is used to run the dfa (with the ascii pattern) step by step on
+    /// "unwidened" input.
+    ///
+    /// This is only used when the regex contains word boundaries, which cannot be translated into
+    /// a corresponding "widened" HIR.
+    use_custom_wide_runner: bool,
 }
 
 impl DfaValidator {
     pub(crate) fn new(
         hir: &Hir,
-        modifiers: RegexModifiers,
+        analysis: &HirAnalysis,
+        mut modifiers: RegexModifiers,
         reverse: bool,
     ) -> Result<Self, crate::regex::Error> {
+        let mut use_custom_wide_runner = false;
+
+        if analysis.has_word_boundaries && modifiers.wide {
+            use_custom_wide_runner = true;
+            // Do not built the wide version of the regex, since it will not be used, only
+            // the ascii version will be, either normally for ascii matches (if modifiers.ascii
+            // is also true), or with the custom routine for wide matches.
+            modifiers.wide = false;
+        }
+
         let dfa = Arc::new(build_dfa(hir, modifiers, reverse).map_err(crate::regex::Error::from)?);
         let pool = {
             let dfa = Arc::clone(&dfa);
@@ -159,7 +189,11 @@ impl DfaValidator {
             Pool::new(create)
         };
 
-        Ok(Self { dfa, pool })
+        Ok(Self {
+            dfa,
+            pool,
+            use_custom_wide_runner,
+        })
     }
 
     pub(crate) fn find_anchored_fwd(
@@ -167,19 +201,25 @@ impl DfaValidator {
         haystack: &[u8],
         start: usize,
         end: usize,
-        pattern_index: PatternID,
+        match_type: MatchType,
     ) -> Option<usize> {
         let mut cache = self.pool.get();
-        self.dfa
-            .try_search_fwd(
-                &mut cache,
-                &Input::new(haystack)
-                    .span(start..end)
-                    .anchored(Anchored::Pattern(pattern_index)),
-            )
-            .ok()
-            .flatten()
-            .map(|m| m.offset())
+
+        if self.use_custom_wide_runner && match_type.is_wide() {
+            self.find_wide_anchored_fwd(&mut cache, haystack, start, end)
+        } else {
+            let pattern_index = match_type_to_pattern_index(match_type);
+            self.dfa
+                .try_search_fwd(
+                    &mut cache,
+                    &Input::new(haystack)
+                        .span(start..end)
+                        .anchored(Anchored::Pattern(pattern_index)),
+                )
+                .ok()
+                .flatten()
+                .map(|m| m.offset())
+        }
     }
 
     pub(crate) fn find_anchored_rev(
@@ -187,19 +227,150 @@ impl DfaValidator {
         haystack: &[u8],
         start: usize,
         end: usize,
-        pattern_index: PatternID,
+        match_type: MatchType,
     ) -> Option<usize> {
         let mut cache = self.pool.get();
-        self.dfa
-            .try_search_rev(
-                &mut cache,
-                &Input::new(haystack)
-                    .span(start..end)
-                    .anchored(Anchored::Pattern(pattern_index)),
-            )
-            .ok()
-            .flatten()
-            .map(|m| m.offset())
+
+        if self.use_custom_wide_runner && match_type.is_wide() {
+            self.find_wide_anchored_rev(&mut cache, haystack, start, end)
+        } else {
+            let pattern_index = match_type_to_pattern_index(match_type);
+            self.dfa
+                .try_search_rev(
+                    &mut cache,
+                    &Input::new(haystack)
+                        .span(start..end)
+                        .anchored(Anchored::Pattern(pattern_index)),
+                )
+                .ok()
+                .flatten()
+                .map(|m| m.offset())
+        }
+    }
+
+    // Custom runner that steps through the DFA automaton, skipping the nul bytes of
+    // the wide input.
+    //
+    // XXX: this uses the example seen in
+    // <https://docs.rs/regex-automata/latest/regex_automata/dfa/trait.Automaton.html#tymethod.is_special_state>
+    // to run the automaton correctly.
+    fn find_wide_anchored_fwd(
+        &self,
+        cache: &mut Cache,
+        mem: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Option<usize> {
+        let start_input = get_unwidened_start(mem, start);
+        let input = match start_input.as_ref() {
+            None => Input::new("").anchored(Anchored::Yes),
+            Some(v) => Input::new(v).span(1..2).anchored(Anchored::Yes),
+        };
+        let mut state = self.dfa.start_state_forward(cache, &input).ok()?;
+
+        let mut last_match = None;
+        let mut i = start;
+        while i < end {
+            // Ensure the current byte is a wide byte, otherwise is input is no longer wide,
+            // and we must end the search.
+            if i + 1 < end && mem[i + 1] != b'\0' {
+                break;
+            }
+            let b = mem[i];
+            state = self.dfa.next_state(cache, state, b).ok()?;
+            if state.is_tagged() {
+                if state.is_match() {
+                    last_match = Some(i);
+                } else if state.is_dead() {
+                    return last_match;
+                }
+            }
+
+            i += 2;
+        }
+        // Matches are always delayed by 1 byte, so we must explicitly walk
+        // the special "EOI" transition at the end of the search.
+        state = self.dfa.next_eoi_state(cache, state).ok()?;
+        if state.is_match() {
+            last_match = Some(end);
+        }
+
+        last_match
+    }
+
+    // Custom runner that steps through the DFA automaton, skipping the nul bytes of
+    // the wide input.
+    //
+    // XXX: this uses the example seen in
+    // <https://docs.rs/regex-automata/latest/regex_automata/dfa/trait.Automaton.html#tymethod.is_special_state>
+    // to run the automaton correctly.
+    fn find_wide_anchored_rev(
+        &self,
+        cache: &mut Cache,
+        mem: &[u8],
+        start: usize,
+        end: usize,
+    ) -> Option<usize> {
+        let end_input = get_unwidened_end(mem, end);
+        let input = match end_input.as_ref() {
+            None => Input::new("").anchored(Anchored::Yes),
+            Some(v) => Input::new(v).anchored(Anchored::Yes),
+        };
+        let mut state = self.dfa.start_state_reverse(cache, &input).ok()?;
+
+        if end - start < 2 {
+            state = self.dfa.next_eoi_state(cache, state).ok()?;
+            return state.is_match().then_some(end);
+        }
+
+        let mut last_match = None;
+        let mut i = end;
+        loop {
+            // Ensure the current byte is a wide byte, otherwise is input is no longer wide,
+            // and we must end the search.
+            if i - start < 2 || mem[i - 1] != b'\0' {
+                break;
+            }
+            i -= 2;
+
+            let b = mem[i];
+            state = self.dfa.next_state(cache, state, b).ok()?;
+            if state.is_tagged() {
+                if state.is_match() {
+                    // We need to add 2, since the match state is 1 byte past the real match.
+                    last_match = Some(i + 2);
+                } else if state.is_dead() {
+                    return last_match;
+                }
+            }
+        }
+        // Matches are always delayed by 1 byte, so we must explicitly walk
+        // the special "EOI" transition at the end of the search.
+        state = self.dfa.next_eoi_state(cache, state).ok()?;
+        if state.is_match() {
+            last_match = Some(i);
+        }
+
+        last_match
+    }
+}
+
+// Return an input that can be used to start the DFA on wide input.
+//
+// To handle word boundaries, the input must be created to reflect the previous byte.
+fn get_unwidened_start(mem: &[u8], start: usize) -> Option<[u8; 2]> {
+    if start < 2 || mem[start - 1] != b'\0' {
+        None
+    } else {
+        Some([mem[start - 2], mem[start]])
+    }
+}
+
+fn get_unwidened_end(mem: &[u8], end: usize) -> Option<[u8; 2]> {
+    if end + 2 >= mem.len() || mem[end + 1] != b'\0' {
+        None
+    } else {
+        Some([mem[end], mem[end + 2]])
     }
 }
 
@@ -260,15 +431,201 @@ fn build_dfa(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::test_type_traits_non_clonable;
+    use crate::test_helpers::{parse_regex_string, test_type_traits_non_clonable};
 
     #[test]
     fn test_types_traits() {
+        let analysis = analyze_hir(&Hir::Empty, false);
         test_type_traits_non_clonable(
-            DfaValidator::new(&Hir::Empty, RegexModifiers::default(), false).unwrap(),
+            DfaValidator::new(&Hir::Empty, &analysis, RegexModifiers::default(), false).unwrap(),
         );
         test_type_traits_non_clonable(
             Validator::new(None, None, &Hir::Empty, RegexModifiers::default()).unwrap(),
+        );
+    }
+
+    #[test]
+    fn test_find_wide_anchored_fwd() {
+        fn build(expr: &str, ascii: bool) -> DfaValidator {
+            let regex = parse_regex_string(expr);
+            let hir = regex.ast.into();
+            let analysis = analyze_hir(&hir, false);
+            DfaValidator::new(
+                &hir,
+                &analysis,
+                RegexModifiers {
+                    ascii,
+                    wide: true,
+                    ..Default::default()
+                },
+                false,
+            )
+            .unwrap()
+        }
+
+        let validator = build(r"a\b", false);
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0.\0a\0.\0", 0, 10, MatchType::WideStandard),
+            None
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0.\0a\0.\0", 6, 10, MatchType::WideStandard),
+            Some(8)
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard),
+            Some(2)
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"aa\0", 0, 3, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"aa\0", 1, 3, MatchType::WideStandard),
+            Some(3)
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0.\0", 4, 4, MatchType::WideStandard),
+            None
+        );
+
+        let validator = build(r"\bb", false);
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"b\0b\0", 0, 4, MatchType::WideStandard),
+            Some(2),
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"b\0b\0", 2, 4, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b".\0b\0", 2, 4, MatchType::WideStandard),
+            Some(4),
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"\0b\0", 1, 3, MatchType::WideStandard),
+            Some(3),
+        );
+
+        // Ensure the validator does not confuse ascii and wide
+        let validator = build(r"a\x00b\b", true);
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b", 0, 3, MatchType::Ascii),
+            Some(3)
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::Ascii),
+            Some(3)
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0b\0b\0", 0, 6, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0\0\0b\0", 0, 6, MatchType::WideStandard),
+            Some(6),
+        );
+
+        let validator = build(r"\b", false);
+        assert_eq!(
+            validator.find_anchored_fwd(b"", 0, 0, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard),
+            Some(0),
+        );
+    }
+
+    #[test]
+    fn test_find_wide_anchored_rev() {
+        fn build(expr: &str, ascii: bool) -> DfaValidator {
+            let regex = parse_regex_string(expr);
+            let hir = regex.ast.into();
+            let analysis = analyze_hir(&hir, false);
+            DfaValidator::new(
+                &hir,
+                &analysis,
+                RegexModifiers {
+                    ascii,
+                    wide: true,
+                    ..Default::default()
+                },
+                true,
+            )
+            .unwrap()
+        }
+
+        let validator = build(r"a\b", false);
+        assert_eq!(
+            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 10, MatchType::WideStandard),
+            None
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 9, MatchType::WideStandard),
+            None
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 8, MatchType::WideStandard),
+            Some(6)
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"a\0", 0, 2, MatchType::WideStandard),
+            Some(0)
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"aa\0", 0, 3, MatchType::WideStandard),
+            Some(1),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"aa\0", 0, 2, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"aa\0", 0, 1, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"", 0, 0, MatchType::WideStandard),
+            None,
+        );
+
+        let validator = build(r"\bb", false);
+        assert_eq!(
+            validator.find_anchored_rev(b"a\0b\0", 0, 4, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b".\0b\0", 0, 4, MatchType::WideStandard),
+            Some(2),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"b\0b\0", 0, 4, MatchType::WideStandard),
+            None,
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"b\0b\0", 2, 4, MatchType::WideStandard),
+            Some(2),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"b\0b\0", 0, 2, MatchType::WideStandard),
+            Some(0),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"\0b\0", 0, 3, MatchType::WideStandard),
+            Some(1),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"b\0", 0, 2, MatchType::WideStandard),
+            Some(0),
+        );
+        assert_eq!(
+            validator.find_anchored_rev(b"b", 0, 1, MatchType::WideStandard),
+            None,
         );
     }
 }


### PR DESCRIPTION
Handle in validators the tricky combination of the wide modifier with regexes containing word boundaries. This is done by running the DFA automaton manually, allowing us to "unwide" the input on the fly.

This allows removing the "non_wide_regex" hack... at least for the very vast majority of cases. It still exists for the raw matcher, and removing it for this case may not even really be possible. However, this is a practically non existent situation in real use-cases.