### PR TITLE
Compute bitmap on HIR class, use in different contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703642b98a00b3b90513279a8ede3fcfa479c126c5fb46e78f3051522f021403"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,7 @@ dependencies = [
  "aho-corasick",
  "authenticode-parser",
  "base64",
+ "bitmaps",
  "boreal-parser",
  "codespan-reporting",
  "crc32fast",

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -525,22 +525,22 @@ rule a {
     literals: ["abc"]
     atoms: ["abc"]
     atoms quality: 60
-    algo: literals
+    algo: Literals
   $b = { 01 ( FE | EF ) }
     literals: [{ 01fe }, { 01ef }]
     atoms: [{ 01fe }, { 01ef }]
     atoms quality: 44
-    algo: literals
+    algo: Literals
   $c = /foo\d??bar/ fullword
     literals: ["bar"]
     atoms: ["bar"]
     atoms quality: 60
-    algo: atomized
+    algo: Atomized { NonGreedy { reverse: Dfa, forward: none } }
   $d = /.{10}/ fullword
     literals: []
     atoms: []
     atoms quality: 0
-    algo: raw
+    algo: Raw
 "#;
 
     let input = test_file("");

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -45,6 +45,9 @@ regex-automata = { version = "0.3", default-features = false, features = ["std",
 # No default features to disable unicode, we do not need it
 regex-syntax = { version = "0.7", default-features = false }
 
+# Bitmap used during compilation of strings
+bitmaps = "3.2"
+
 # "hash" feature
 crc32fast = { version = "1.3", optional = true }
 hex = { version = "0.4", optional = true }

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -112,7 +112,7 @@ pub(crate) fn compile_variable(
             literals: res.matcher.literals.clone(),
             atoms,
             atoms_quality,
-            matching_algo: res.matcher.kind_to_string(),
+            matching_algo: res.matcher.to_desc(),
         })
     } else {
         None

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -343,13 +343,12 @@ impl Matcher {
         None
     }
 
-    pub fn kind_to_string(&self) -> String {
+    pub fn to_desc(&self) -> String {
         match &self.kind {
-            MatcherKind::Literals => "literals",
-            MatcherKind::Atomized { .. } => "atomized",
-            MatcherKind::Raw(_) => "raw",
+            MatcherKind::Literals => "Literals".to_owned(),
+            MatcherKind::Atomized { validator } => format!("Atomized {{ {validator} }}"),
+            MatcherKind::Raw(_) => "Raw".to_owned(),
         }
-        .to_owned()
     }
 
     fn validate_fullword(&self, mem: &[u8], mat: &Range<usize>, match_type: MatchType) -> bool {

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -150,6 +150,29 @@ impl Validator {
     }
 }
 
+impl std::fmt::Display for Validator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonGreedy { forward, reverse } => {
+                write!(f, "NonGreedy {{ ")?;
+                match reverse {
+                    Some(v) => write!(f, "reverse: {v}")?,
+                    None => write!(f, "reverse: none")?,
+                };
+                write!(f, ", ")?;
+                match forward {
+                    Some(v) => write!(f, "forward: {v}")?,
+                    None => write!(f, "forward: none")?,
+                };
+                write!(f, " }}")
+            }
+            Self::Greedy { .. } => {
+                write!(f, "Greedy {{ reverse: Dfa, full: Dfa }}")
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub(super) enum HalfValidator {
     // Simplified validator for very simple regex expressions.
@@ -196,6 +219,15 @@ impl HalfValidator {
         match self {
             Self::Simple(validator) => validator.find_anchored_rev(haystack, start, end),
             Self::Dfa(validator) => validator.find_anchored_rev(haystack, start, end, match_type),
+        }
+    }
+}
+
+impl std::fmt::Display for HalfValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Simple(_) => write!(f, "Simple"),
+            Self::Dfa(_) => write!(f, "Dfa"),
         }
     }
 }

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -37,10 +37,16 @@ impl SimpleValidator {
         if analysis.has_start_or_end_line
             || analysis.has_repetitions
             || analysis.has_word_boundaries
+            // Classes are not handled because the naive solution would be to use the class bitmap
+            // as a new SimpleNode, which would make its size grow to more than 32 bytes, compared
+            // to the min 16 bytes currently. This makes performances much worse for use-cases
+            // very reliant on simple validators.
+            // Some classes could be handled if there is a way to encode how to check them in as
+            // few bytes as possible. But for the moment, this isn't really needed.
             || analysis.has_classes
             || analysis.has_alternations
         {
-            // TODO: handle fixed size repetitions and handle classes.
+            // TODO: handle fixed size repetitions.
             return None;
         }
 

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -13,12 +13,10 @@ use boreal_parser::regex::{
 };
 
 mod hir;
-pub use hir::Hir;
+pub use hir::{Class, Hir};
 
 mod visitor;
 pub(crate) use visitor::{visit, VisitAction, Visitor};
-
-use self::hir::Class;
 
 /// Regex following the YARA format.
 #[derive(Clone, Debug)]

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -18,6 +18,8 @@ pub use hir::Hir;
 mod visitor;
 pub(crate) use visitor::{visit, VisitAction, Visitor};
 
+use self::hir::Class;
+
 /// Regex following the YARA format.
 #[derive(Clone, Debug)]
 pub struct Regex {
@@ -147,8 +149,14 @@ impl Visitor for AstPrinter {
                     self.res.push(']');
                 }
             }
-            Hir::Class(ClassKind::Perl(p)) => self.push_perl_class(p),
-            Hir::Class(ClassKind::Bracketed(c)) => self.push_bracketed_class(c),
+            Hir::Class(Class {
+                definition: ClassKind::Perl(p),
+                bitmap: _bitmap,
+            }) => self.push_perl_class(p),
+            Hir::Class(Class {
+                definition: ClassKind::Bracketed(c),
+                bitmap: _bitmap,
+            }) => self.push_bracketed_class(c),
             Hir::Dot => self.res.push('.'),
             Hir::Literal(b) => self.push_literal(*b),
             Hir::Group(_) => self.res.push('('),

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Unicode-DFS-2016",
+    "MPL-2.0",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explicitly disallowed licenses


### PR DESCRIPTION
Compute a bitmap of which bytes are covered by a class, and store it in the HIR.
This is then used in two different contexts:

- When finding out whether a regex can be covered by only literals
- In the simple validator when confirming AC matches

This will make it easier to use in literals extraction as well. This is left for a future PR however, as the literals extraction algorithm needs some rework.