### PR TITLE
fix invalid errors when rule with wildcard rules uses has errors

### DIFF
--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -203,12 +203,12 @@ impl<'a> RuleCompiler<'a> {
 
 pub(super) fn compile_rule(
     rule: parser::Rule,
-    namespace: &mut Namespace,
+    namespace: &Namespace,
     external_symbols: &Vec<ExternalSymbol>,
     params: &CompilerParams,
     parsed_contents: &str,
 ) -> Result<CompiledRule, CompilationError> {
-    let (condition, wildcards, vars, warnings) = {
+    let (condition, rule_wildcard_uses, vars, warnings) = {
         let mut compiler = RuleCompiler::new(&rule, namespace, external_symbols, params)?;
         let condition = compile_bool_expression(&mut compiler, rule.condition)?;
 
@@ -219,9 +219,6 @@ pub(super) fn compile_rule(
             compiler.warnings,
         )
     };
-    if !wildcards.is_empty() {
-        namespace.forbidden_rule_prefixes.extend(wildcards);
-    }
 
     // Check duplication of tags
     let mut tags_spans = HashMap::with_capacity(rule.tags.len());
@@ -270,6 +267,7 @@ pub(super) fn compile_rule(
         variables,
         variables_statistics,
         warnings,
+        rule_wildcard_uses,
     })
 }
 
@@ -279,6 +277,7 @@ pub(super) struct CompiledRule {
     pub variables: Vec<variable::Variable>,
     pub variables_statistics: Vec<statistics::CompiledString>,
     pub warnings: Vec<CompilationError>,
+    pub rule_wildcard_uses: Vec<String>,
 }
 
 #[cfg(test)]
@@ -314,6 +313,7 @@ mod tests {
             variables: Vec::new(),
             variables_statistics: Vec::new(),
             warnings: Vec::new(),
+            rule_wildcard_uses: Vec::new(),
         });
         test_type_traits_non_clonable(RuleCompilerVariable {
             name: "a".to_owned(),

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -113,12 +113,7 @@ impl Compiler {
 
     #[track_caller]
     pub fn check_add_rules_err(mut self, rules: &str, expected_prefix: &str) {
-        let err = self.compiler.add_rules_str(rules).unwrap_err();
-        let desc = add_rule_error_get_desc(&err, rules);
-        assert!(
-            desc.starts_with(expected_prefix),
-            "error: {desc}\nexpected prefix: {expected_prefix}"
-        );
+        self.check_add_rules_err_boreal(rules, expected_prefix);
 
         // Check libyara also rejects it
         if let Some(compiler) = self.yara_compiler.take() {
@@ -127,6 +122,16 @@ impl Compiler {
                 "conformity test failed for libyara"
             );
         }
+    }
+
+    #[track_caller]
+    pub fn check_add_rules_err_boreal(&mut self, rules: &str, expected_prefix: &str) {
+        let err = self.compiler.add_rules_str(rules).unwrap_err();
+        let desc = add_rule_error_get_desc(&err, rules);
+        assert!(
+            desc.starts_with(expected_prefix),
+            "error: {desc}\nexpected prefix: {expected_prefix}"
+        );
     }
 
     pub fn check_add_rules_warnings(mut self, rules: &str, expected_warnings_prefix: &[&str]) {


### PR DESCRIPTION
When we add a rule that contains a wildcard use of rule names, it is forbidden to add any more rules that matches this wildcard. However, if the adding rule fails to compile, then we should not add this restriction. This was buggy and is now fixed.