### PR TITLE
Update boreal parser documentation

### DIFF
--- a/boreal-parser/src/error.rs
+++ b/boreal-parser/src/error.rs
@@ -1,3 +1,4 @@
+//! Parsing error types.
 use std::num::ParseIntError;
 use std::ops::Range;
 
@@ -163,7 +164,7 @@ impl ParseError<Input<'_>> for Error {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ErrorKind {
+pub(crate) enum ErrorKind {
     /// A base64 modifier alphabet has an invalid length.
     ///
     /// The length must be 64.

--- a/boreal-parser/src/expression/boolean_expression.rs
+++ b/boreal-parser/src/expression/boolean_expression.rs
@@ -8,7 +8,8 @@ use nom::{
     sequence::preceded,
 };
 
-use crate::{error::ErrorKind, Error, Regex};
+use crate::error::{Error, ErrorKind};
+use crate::regex::Regex;
 
 use super::{
     super::{
@@ -24,7 +25,7 @@ use super::{
 };
 
 /// parse or operator
-pub fn boolean_expression(mut input: Input) -> ParseResult<Expression> {
+pub(crate) fn boolean_expression(mut input: Input) -> ParseResult<Expression> {
     // Expression parsing involves multiple recursives paths, making it quite complex.
     // There are however a few observations we can make:
     // - only two combinators receive recursive calls: this one and `primary_expression`.

--- a/boreal-parser/src/expression/for_expression.rs
+++ b/boreal-parser/src/expression/for_expression.rs
@@ -351,11 +351,10 @@ fn rule_enum_element(input: Input) -> ParseResult<SetElement> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        expression::{ExpressionKind, Identifier, IdentifierOperation},
-        test_helpers::{parse, parse_err, test_public_type},
-        IdentifierOperationType,
+    use crate::expression::{
+        ExpressionKind, Identifier, IdentifierOperation, IdentifierOperationType,
     };
+    use crate::test_helpers::{parse, parse_err, test_public_type};
 
     #[test]
     fn test_for_selection() {

--- a/boreal-parser/src/expression/identifier.rs
+++ b/boreal-parser/src/expression/identifier.rs
@@ -9,10 +9,10 @@ use nom::{
 };
 
 use super::{Expression, Identifier, IdentifierOperation};
+use crate::expression::IdentifierOperationType;
 use crate::nom_recipes::{not_followed, rtrim};
 use crate::string::identifier as raw_identifier;
 use crate::types::{Input, ParseResult};
-use crate::IdentifierOperationType;
 
 use super::boolean_expression::boolean_expression;
 use super::primary_expression::primary_expression;

--- a/boreal-parser/src/expression/mod.rs
+++ b/boreal-parser/src/expression/mod.rs
@@ -1,3 +1,4 @@
+//! Types related to the condition part of YARA rules.
 use std::ops::Range;
 
 mod boolean_expression;
@@ -10,7 +11,7 @@ mod string_expression;
 
 use crate::regex::Regex;
 
-pub(super) use boolean_expression::boolean_expression as expression;
+pub(crate) use boolean_expression::boolean_expression as expression;
 
 const MAX_EXPR_RECURSION: usize = 20;
 
@@ -423,6 +424,7 @@ pub struct VariableSet {
     pub elements: Vec<SetElement>,
 }
 
+/// Element of a set.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SetElement {
     /// Name of the element.

--- a/boreal-parser/src/expression/primary_expression.rs
+++ b/boreal-parser/src/expression/primary_expression.rs
@@ -12,15 +12,14 @@ use nom::{
 
 use super::{expression, identifier, read_integer, string_expression, Expression, ExpressionKind};
 use crate::{
-    error::ErrorKind,
+    error::{Error, ErrorKind},
     nom_recipes::{rtrim, textual_tag as ttag},
     number, regex, string,
     types::{Input, ParseResult},
-    Error,
 };
 
 /// parse | operator
-pub fn primary_expression(mut input: Input) -> ParseResult<Expression> {
+pub(crate) fn primary_expression(mut input: Input) -> ParseResult<Expression> {
     let start = input.pos();
 
     if input.expr_recursion_counter >= super::MAX_EXPR_RECURSION {
@@ -257,17 +256,13 @@ where
 mod tests {
     use super::super::Identifier;
     use super::{primary_expression as pe, Expression, ExpressionKind as Expr};
-    use crate::error::ErrorKind;
+    use crate::error::{Error, ErrorKind};
+    use crate::expression::ReadIntegerType;
     use crate::expression::MAX_EXPR_RECURSION;
-    use crate::regex::{AssertionKind, Node, RepetitionKind};
+    use crate::regex::{AssertionKind, Node, Regex, RepetitionKind};
     use crate::test_helpers::parse_err_type;
+    use crate::test_helpers::{parse, parse_check, parse_err};
     use crate::types::Input;
-    use crate::Error;
-    use crate::{
-        expression::ReadIntegerType,
-        regex::Regex,
-        test_helpers::{parse, parse_check, parse_err},
-    };
     use std::ops::Range;
 
     #[test]

--- a/boreal-parser/src/file.rs
+++ b/boreal-parser/src/file.rs
@@ -1,4 +1,4 @@
-//! Parse yara rules.
+//! Types related to YARA files.
 use std::ops::Range;
 
 use nom::branch::alt;
@@ -8,7 +8,7 @@ use nom::combinator::map;
 use nom::sequence::delimited;
 use nom::{combinator::cut, sequence::preceded};
 
-use crate::Rule;
+use crate::rule::Rule;
 
 use super::rule::rule;
 use super::{
@@ -63,7 +63,7 @@ pub struct Include {
 ///
 /// If the input cannot be parsed properly and entirely as a list
 /// of yara rules, an error is returned.
-pub fn parse_yara_file(input: Input) -> ParseResult<YaraFile> {
+pub(crate) fn parse_yara_file(input: Input) -> ParseResult<YaraFile> {
     let (mut input, _) = ltrim(input)?;
 
     let mut file = YaraFile {
@@ -129,10 +129,8 @@ fn import(input: Input) -> ParseResult<Import> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        test_helpers::{parse, parse_err, test_public_type},
-        Expression, ExpressionKind,
-    };
+    use crate::expression::{Expression, ExpressionKind};
+    use crate::test_helpers::{parse, parse_err, test_public_type};
 
     #[test]
     fn test_parse_yara_file() {

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -42,25 +42,14 @@
 // - The returned input is right-trimmed
 // The [`nom_recipes::rtrim`] function is provided to make this easier.
 
-mod error;
-pub use error::Error;
-mod expression;
-pub use expression::{
-    Expression, ExpressionKind, ForIterator, ForSelection, Identifier, IdentifierOperation,
-    IdentifierOperationType, ReadIntegerType, RuleSet, VariableSet,
-};
-mod file;
-pub use file::{YaraFile, YaraFileComponent};
+pub mod error;
+pub mod expression;
+pub mod file;
 pub mod hex_string;
 mod nom_recipes;
 mod number;
 pub mod regex;
-pub use regex::Regex;
-mod rule;
-pub use rule::{
-    Metadata, Rule, VariableDeclaration, VariableDeclarationValue, VariableModifierBase64,
-    VariableModifiers,
-};
+pub mod rule;
 mod string;
 mod types;
 
@@ -70,7 +59,7 @@ mod types;
 ///
 /// Returns an error if the parsing fails, or if there are
 /// trailing data in the file that has not been parsed.
-pub fn parse(input: &str) -> Result<YaraFile, Error> {
+pub fn parse(input: &str) -> Result<file::YaraFile, error::Error> {
     use nom::Finish;
 
     let input = types::Input::new(input);

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -2,7 +2,96 @@
 //!
 //! This crate is designed to be used by the [`boreal` crate](https://docs.rs/boreal/%2A/boreal/).
 //!
-//! It exposes a single function, [`parse`], which parses the contents of a YARA file.
+//! It exposes a main entrypoint function, [`parse`], which parses the contents of a YARA file.
+//!
+//! ```rust
+//! use boreal_parser::*;
+//! use boreal_parser::expression::*;
+//! use boreal_parser::file::*;
+//! use boreal_parser::rule::*;
+//!
+//! let file = parse(r#"
+//! import "pe"
+//!
+//! private rule b : tag1 {
+//!     meta:
+//!         a = true
+//!     strings:
+//!         $b = "\\mspaint.exe" wide
+//!     condition:
+//!         pe.is_dll() and all of them
+//! }"#)?;
+//!
+//! assert_eq!(
+//!     file.components[0],
+//!     YaraFileComponent::Import(Import {
+//!         name: "pe".to_owned(),
+//!         span: 1..12,
+//!     })
+//! );
+//! assert_eq!(
+//!     file.components[1],
+//!     YaraFileComponent::Rule(Box::new(Rule {
+//!         name: "b".to_owned(),
+//!         name_span: 27..28,
+//!         tags: vec![RuleTag {
+//!             tag: "tag1".to_owned(),
+//!             span: 31..35
+//!         }],
+//!         metadatas: vec![Metadata {
+//!             name: "a".to_owned(),
+//!             value: MetadataValue::Boolean(true)
+//!         }],
+//!         variables: vec![VariableDeclaration {
+//!             name: "b".to_owned(),
+//!             value: VariableDeclarationValue::Bytes(b"\\mspaint.exe".to_vec()),
+//!             modifiers: VariableModifiers {
+//!                 wide: true,
+//!                 ..Default::default()
+//!             },
+//!             span: 86..111,
+//!         }],
+//!
+//!         condition: Expression {
+//!             expr: ExpressionKind::And(vec![
+//!                 Expression {
+//!                     expr: ExpressionKind::Identifier(Identifier {
+//!                         name: "pe".to_owned(),
+//!                         name_span: 135..137,
+//!                         operations: vec![
+//!                             IdentifierOperation {
+//!                                 op: IdentifierOperationType::Subfield(
+//!                                     "is_dll".to_owned()
+//!                                 ),
+//!                                 span: 137..144,
+//!                             },
+//!                             IdentifierOperation {
+//!                                 op: IdentifierOperationType::FunctionCall(vec![]),
+//!                                 span: 144..146,
+//!                             }
+//!                         ],
+//!                     }),
+//!                     span: 135..146,
+//!                 },
+//!                 Expression {
+//!                     expr: ExpressionKind::For {
+//!                         selection: ForSelection::All,
+//!                         set: VariableSet { elements: vec![] },
+//!
+//!                         body: None,
+//!                     },
+//!                     span: 151..162,
+//!                 }
+//!             ]),
+//!             span: 135..162
+//!         },
+//!         is_private: true,
+//!         is_global: false,
+//!     }))
+//! );
+//!
+//! # Ok::<(), boreal_parser::error::Error>(())
+//! ```
 
 // Deny most of allowed by default lints from rustc.
 #![deny(explicit_outlives_requirements)]
@@ -30,9 +119,7 @@
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::single_match_else)]
-
-// TODO: To activate before release
-// #![deny(clippy::cargo)]
+#![deny(clippy::cargo)]
 
 // Parsing uses the [`nom`] crate, adapted for textual parsing.
 //

--- a/boreal-parser/src/nom_recipes.rs
+++ b/boreal-parser/src/nom_recipes.rs
@@ -15,7 +15,7 @@ use super::error::{Error, ErrorKind};
 use super::types::{Input, ParseResult};
 
 /// Right trim after the given parser.
-pub fn rtrim<'a, F, O>(mut inner: F) -> impl FnMut(Input<'a>) -> ParseResult<'a, O>
+pub(crate) fn rtrim<'a, F, O>(mut inner: F) -> impl FnMut(Input<'a>) -> ParseResult<'a, O>
 where
     F: Parser<Input<'a>, O, Error> + 'a,
 {
@@ -33,7 +33,7 @@ where
 }
 
 /// Left trim the input.
-pub fn ltrim(mut input: Input) -> ParseResult<()> {
+pub(crate) fn ltrim(mut input: Input) -> ParseResult<()> {
     loop {
         match alt((
             multiline_comment,
@@ -49,7 +49,7 @@ pub fn ltrim(mut input: Input) -> ParseResult<()> {
 }
 
 /// Accepts a first parser, only if the second one does not match afterwards
-pub fn not_followed<'a, F, G, OF, OG>(
+pub(crate) fn not_followed<'a, F, G, OF, OG>(
     mut f: F,
     mut g: G,
 ) -> impl FnMut(Input<'a>) -> ParseResult<'a, OF>
@@ -70,7 +70,7 @@ where
 }
 
 /// Accepts a single character if the passed function returns true on it.
-pub fn take_one<F>(f: F) -> impl for<'a> Fn(Input<'a>) -> ParseResult<'a, char>
+pub(crate) fn take_one<F>(f: F) -> impl for<'a> Fn(Input<'a>) -> ParseResult<'a, char>
 where
     F: Fn(char) -> bool,
 {
@@ -89,7 +89,7 @@ where
 /// following character is not alphanumeric.
 /// This avoids recognizing a tag inside a word, for example, recognizing
 /// `foo` in `foobar`.
-pub fn textual_tag(
+pub(crate) fn textual_tag(
     tag: &'static str,
 ) -> impl for<'a> Fn(Input<'a>) -> ParseResult<'a, &'static str> {
     move |input: Input| {
@@ -133,7 +133,7 @@ fn singleline_comment(input: Input) -> ParseResult<()> {
 ///
 /// This allows using the starting input to generate a proper span
 /// for the error.
-pub fn map_res<'a, O1, O2, F, G>(
+pub(crate) fn map_res<'a, O1, O2, F, G>(
     mut parser: F,
     mut f: G,
 ) -> impl FnMut(Input<'a>) -> ParseResult<O2>

--- a/boreal-parser/src/number.rs
+++ b/boreal-parser/src/number.rs
@@ -94,7 +94,7 @@ fn octal_number(input: Input) -> ParseResult<i64> {
 /// - hexadecimal with 0x prefix,
 /// - octal with 0o prefix,
 /// - decimal with optional KB/MB suffix.
-pub fn number(input: Input) -> ParseResult<i64> {
+pub(crate) fn number(input: Input) -> ParseResult<i64> {
     // XXX: decimal number must be last, otherwise, it would parse the '0'
     // in the '0x'/'0o' prefix.
     alt((hexadecimal_number, octal_number, decimal_number))(input)
@@ -104,7 +104,7 @@ pub fn number(input: Input) -> ParseResult<i64> {
 ///
 /// Equivalent to the _DOUBLE_ lexical pattern in libyara.
 /// This functions matches the pattern `/\d+\.\d+/`.
-pub fn double(input: Input) -> ParseResult<f64> {
+pub(crate) fn double(input: Input) -> ParseResult<f64> {
     let (input, payload) = rtrim(recognize(tuple((digit1, char('.'), digit1))))(input)?;
 
     // Safety: this cannot fail, we are parsing `[0-9]+ '.' [0-9]+` which is guaranteed to

--- a/boreal-parser/src/rule.rs
+++ b/boreal-parser/src/rule.rs
@@ -14,9 +14,10 @@ use super::{
     expression::{self, Expression},
     hex_string,
     nom_recipes::{map_res, rtrim, textual_tag as ttag},
-    number, regex, string,
+    number, regex,
+    regex::Regex,
+    string,
     types::{Input, ParseResult, Position},
-    Regex,
 };
 
 /// A Yara rule.
@@ -66,8 +67,11 @@ pub struct RuleTag {
 /// Value associated with a metadata key.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MetadataValue {
+    /// Bytestring variant.
     Bytes(Vec<u8>),
+    /// Integer variant.
     Integer(i64),
+    /// Boolean variant.
     Boolean(bool),
 }
 
@@ -114,10 +118,7 @@ pub struct VariableModifiers {
     /// Xor modifier, providing the range.
     pub xor: Option<(u8, u8)>,
 
-    /// Base64 modifier.alphabet.
-    ///
-    /// This is only applicable if `flags` contains [`VariableFlags::BASE64`]
-    /// or [`VariableFlags::BASE64WIDE`].
+    /// Base64 modifier.
     pub base64: Option<VariableModifierBase64>,
 }
 
@@ -150,7 +151,7 @@ pub struct VariableDeclaration {
 /// Parse a rule
 ///
 /// Related to the `rule` pattern in `grammar.y` in libyara.
-pub fn rule(mut input: Input) -> ParseResult<Rule> {
+pub(crate) fn rule(mut input: Input) -> ParseResult<Rule> {
     let mut is_private = false;
     let mut is_global = false;
 
@@ -565,7 +566,6 @@ mod tests {
     use crate::expression::{Expression, ExpressionKind, ForSelection, VariableSet};
     use crate::hex_string::{Mask, Token};
     use crate::test_helpers::test_public_type;
-    use crate::Regex;
 
     use super::super::test_helpers::{parse, parse_err};
     use super::*;

--- a/boreal-parser/src/string.rs
+++ b/boreal-parser/src/string.rs
@@ -41,7 +41,7 @@ fn string_identifier_no_rtrim(input: Input) -> ParseResult<String> {
 /// This is equivalent to the `_STRING_IDENTIFIER_` lexical patterns in
 /// libyara.
 /// Roughly equivalent to `$[a-ZA-Z0-9_]*`.
-pub fn string_identifier(input: Input) -> ParseResult<String> {
+pub(crate) fn string_identifier(input: Input) -> ParseResult<String> {
     rtrim(string_identifier_no_rtrim)(input)
 }
 
@@ -49,7 +49,7 @@ pub fn string_identifier(input: Input) -> ParseResult<String> {
 ///
 /// This is equivalent to
 /// `_STRING_IDENTIFIER_ | _STRING_IDENTIFIER_WITH_WILDCARD_` in libyara.
-pub fn string_identifier_with_wildcard(input: Input) -> ParseResult<(String, bool)> {
+pub(crate) fn string_identifier_with_wildcard(input: Input) -> ParseResult<(String, bool)> {
     rtrim(pair(
         string_identifier_no_rtrim,
         map(opt(char('*')), |v| v.is_some()),
@@ -57,24 +57,24 @@ pub fn string_identifier_with_wildcard(input: Input) -> ParseResult<(String, boo
 }
 
 /// Parse a string count, roughly equivalent to `#[a-zA-Z0-9_]*`.
-pub fn count(input: Input) -> ParseResult<String> {
+pub(crate) fn count(input: Input) -> ParseResult<String> {
     rtrim(preceded(char('#'), cut(identifier_contents)))(input)
 }
 
 /// Parse a string offset, roughly equivalent to `@[a-zA-Z0-9_]*`.
-pub fn offset(input: Input) -> ParseResult<String> {
+pub(crate) fn offset(input: Input) -> ParseResult<String> {
     rtrim(preceded(char('@'), cut(identifier_contents)))(input)
 }
 
 /// Parse a string length, roughly equivalent to `![a-zA-Z0-9_]*`.
-pub fn length(input: Input) -> ParseResult<String> {
+pub(crate) fn length(input: Input) -> ParseResult<String> {
     rtrim(preceded(char('!'), cut(identifier_contents)))(input)
 }
 
 /// Parse an identifier.
 ///
 /// This is roughly equivalent to `[a-ZA-Z_][a-zA-Z0-9_]*`.
-pub fn identifier(input: Input) -> ParseResult<String> {
+pub(crate) fn identifier(input: Input) -> ParseResult<String> {
     rtrim(map(
         recognize(tuple((
             take_one(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '_')),
@@ -91,7 +91,7 @@ pub fn identifier(input: Input) -> ParseResult<String> {
 /// patterns `\t`, `\r`, `\n`, `\"`, `\\`, and `\x[0-9a-fA-F]{2}`.
 ///
 /// This parser allows non ascii bytes, hence returning a byte string.
-pub fn quoted(input: Input) -> ParseResult<Vec<u8>> {
+pub(crate) fn quoted(input: Input) -> ParseResult<Vec<u8>> {
     rtrim(quoted_no_rtrim)(input)
 }
 

--- a/boreal-parser/src/test_helpers.rs
+++ b/boreal-parser/src/test_helpers.rs
@@ -1,11 +1,15 @@
-use crate::Error;
+use crate::error::Error;
 
 use crate::types::{Input, ParseResult};
 use nom::Finish;
 
 #[track_caller]
-pub fn parse<'a, F, O, O2>(f: F, input: &'a str, expected_rest_input: &str, expected_result: O2)
-where
+pub(crate) fn parse<'a, F, O, O2>(
+    f: F,
+    input: &'a str,
+    expected_rest_input: &str,
+    expected_result: O2,
+) where
     F: FnOnce(Input<'a>) -> ParseResult<'a, O> + 'a,
     O: PartialEq + std::fmt::Debug + From<O2>,
 {
@@ -16,7 +20,7 @@ where
 }
 
 #[track_caller]
-pub fn parse_err<'a, F, O>(f: F, input: &'a str)
+pub(crate) fn parse_err<'a, F, O>(f: F, input: &'a str)
 where
     F: FnOnce(Input<'a>) -> ParseResult<'a, O>,
     O: PartialEq + std::fmt::Debug,
@@ -27,7 +31,7 @@ where
 }
 
 #[track_caller]
-pub fn parse_err_type<'a, F, O>(f: F, input: &'a str, err: &Error)
+pub(crate) fn parse_err_type<'a, F, O>(f: F, input: &'a str, err: &Error)
 where
     F: FnOnce(Input<'a>) -> ParseResult<'a, O>,
     O: PartialEq + std::fmt::Debug,
@@ -38,7 +42,7 @@ where
 }
 
 #[track_caller]
-pub fn parse_check<'a, F, O, C>(f: F, input: &'a str, check: C)
+pub(crate) fn parse_check<'a, F, O, C>(f: F, input: &'a str, check: C)
 where
     F: FnOnce(Input<'a>) -> ParseResult<'a, O>,
     O: PartialEq + std::fmt::Debug,
@@ -54,7 +58,7 @@ where
 // - Instrument those impls to avoid having those derive be marked as missed in coverage...
 //
 // Each module that exposes public types is expected to use it on those types.
-pub fn test_public_type<T: Clone + std::fmt::Debug + Send + Sync>(t: T) {
+pub(crate) fn test_public_type<T: Clone + std::fmt::Debug + Send + Sync>(t: T) {
     #[allow(clippy::redundant_clone)]
     let _r = t.clone();
     let _r = format!("{:?}", &t);

--- a/boreal-parser/src/types.rs
+++ b/boreal-parser/src/types.rs
@@ -7,7 +7,7 @@ use nom::{
 };
 
 #[derive(Clone, Copy, Debug)]
-pub struct Input<'a> {
+pub(crate) struct Input<'a> {
     /// Whole input being parsed.
     ///
     /// This reference is never modified.
@@ -36,14 +36,14 @@ pub struct Input<'a> {
 
 /// Position inside the input.
 #[derive(Clone, Copy, Debug)]
-pub struct Position<'a> {
+pub(crate) struct Position<'a> {
     cursor: &'a str,
 }
 
-pub type ParseResult<'a, O> = IResult<Input<'a>, O, Error>;
+pub(crate) type ParseResult<'a, O> = IResult<Input<'a>, O, Error>;
 
 impl<'a> Input<'a> {
-    pub fn new(input: &'a str) -> Self {
+    pub(crate) fn new(input: &'a str) -> Self {
         Self {
             input,
             cursor: input,
@@ -53,17 +53,17 @@ impl<'a> Input<'a> {
         }
     }
 
-    pub fn pos(&self) -> Position<'a> {
+    pub(crate) fn pos(&self) -> Position<'a> {
         Position {
             cursor: self.cursor,
         }
     }
 
-    pub fn cursor(&self) -> &'a str {
+    pub(crate) fn cursor(&self) -> &'a str {
         self.cursor
     }
 
-    pub fn advance(&mut self, count: usize) {
+    pub(crate) fn advance(&mut self, count: usize) {
         if self.cursor.len() >= count {
             self.cursor = &self.cursor[count..];
         } else {
@@ -71,17 +71,17 @@ impl<'a> Input<'a> {
         }
     }
 
-    pub fn strip_prefix(&self, prefix: &str) -> Option<Self> {
+    pub(crate) fn strip_prefix(&self, prefix: &str) -> Option<Self> {
         self.cursor
             .strip_prefix(prefix)
             .map(|cursor| Self { cursor, ..*self })
     }
 
-    pub fn save_cursor_before_rtrim(&mut self) {
+    pub(crate) fn save_cursor_before_rtrim(&mut self) {
         self.cursor_before_last_rtrim = self.cursor;
     }
 
-    pub fn get_position_offset(&self) -> usize {
+    pub(crate) fn get_position_offset(&self) -> usize {
         (self.cursor.as_ptr() as usize) - (self.input.as_ptr() as usize)
     }
 
@@ -89,7 +89,7 @@ impl<'a> Input<'a> {
     ///
     /// The given input is the start of the span.
     /// The end of the span is the cursor saved before the last rtrim.
-    pub fn get_span_from(&self, start: Position) -> Range<usize> {
+    pub(crate) fn get_span_from(&self, start: Position) -> Range<usize> {
         let input = self.input.as_ptr() as usize;
 
         let start = start.cursor.as_ptr() as usize - input;
@@ -107,7 +107,7 @@ impl<'a> Input<'a> {
     ///
     /// The given input is the start of the span.
     /// The end of the span is the current position of the cursor.
-    pub fn get_span_from_no_rtrim(&self, start: Position) -> Range<usize> {
+    pub(crate) fn get_span_from_no_rtrim(&self, start: Position) -> Range<usize> {
         let input = self.input.as_ptr() as usize;
 
         Range {

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -3,7 +3,7 @@
 //! This module contains all types describing a rule condition, built from the parsed AST.
 use std::ops::Range;
 
-use boreal_parser as parser;
+use boreal_parser::expression as parser;
 
 use super::module::ModuleExpression;
 use super::rule::RuleCompiler;
@@ -1219,9 +1219,9 @@ fn compile_for_iterator(
 
 fn compile_regex(
     compiler: &mut RuleCompiler<'_>,
-    regex: parser::Regex,
+    regex: boreal_parser::regex::Regex,
 ) -> Result<Regex, CompilationError> {
-    let parser::Regex {
+    let boreal_parser::regex::Regex {
         ast,
         case_insensitive,
         dot_all,

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ops::Range;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
+
+use boreal_parser::rule::Metadata;
+use boreal_parser::rule::VariableDeclaration;
 
 use super::expression::{compile_bool_expression, Expression, VariableIndex};
 use super::external_symbol::ExternalSymbol;
@@ -23,7 +27,7 @@ pub struct Rule {
     pub tags: Vec<String>,
 
     /// Metadata associated with the rule.
-    pub metadatas: Vec<boreal_parser::Metadata>,
+    pub metadatas: Vec<Metadata>,
 
     /// Number of variables used by the rule.
     pub(crate) nb_variables: usize,
@@ -89,7 +93,7 @@ pub(super) struct RuleCompilerVariable {
 
 impl<'a> RuleCompiler<'a> {
     pub(super) fn new(
-        rule_variables: &[boreal_parser::VariableDeclaration],
+        rule_variables: &[VariableDeclaration],
         namespace: &'a Namespace,
         external_symbols: &'a Vec<ExternalSymbol>,
         params: &'a CompilerParams,
@@ -196,7 +200,7 @@ impl<'a> RuleCompiler<'a> {
 }
 
 pub(super) fn compile_rule(
-    rule: boreal_parser::Rule,
+    rule: boreal_parser::rule::Rule,
     namespace: &Namespace,
     external_symbols: &Vec<ExternalSymbol>,
     params: &CompilerParams,

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -20,7 +20,7 @@ fn compile_expr(expression_str: &str, expected_type: Type) {
         .into_iter()
         .next()
         .map(|v| match v {
-            boreal_parser::YaraFileComponent::Rule(v) => v,
+            boreal_parser::file::YaraFileComponent::Rule(v) => v,
             _ => panic!(),
         })
         .unwrap();

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -1,4 +1,4 @@
-use boreal_parser::{VariableDeclaration, VariableDeclarationValue};
+use boreal_parser::rule::{VariableDeclaration, VariableDeclarationValue};
 
 use crate::atoms::{atoms_rank, pick_atom_in_literal};
 use crate::matcher::{Matcher, Modifiers};
@@ -47,7 +47,7 @@ pub(super) fn compile_variable(
                 Ok(Matcher::new_bytes(s, &modifiers))
             }
         }
-        VariableDeclarationValue::Regex(boreal_parser::Regex {
+        VariableDeclarationValue::Regex(boreal_parser::regex::Regex {
             ast,
             case_insensitive,
             dot_all,
@@ -155,7 +155,7 @@ impl std::fmt::Display for VariableCompilationError {
 mod tests {
     use std::collections::HashMap;
 
-    use boreal_parser::VariableModifiers;
+    use boreal_parser::rule::VariableModifiers;
 
     use super::*;
     use crate::compiler::{CompilerParams, Namespace};

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -1,6 +1,6 @@
 //! Provides methods to evaluate the read integer expressions
 use crate::compiler::expression::Expression;
-use boreal_parser::ReadIntegerType;
+use boreal_parser::expression::ReadIntegerType;
 
 use super::{Evaluator, PoisonKind, Value};
 

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -227,7 +227,7 @@ impl<'a> VariableEvaluation<'a> {
 
 #[cfg(test)]
 mod tests {
-    use boreal_parser::VariableModifiers;
+    use boreal_parser::rule::VariableModifiers;
 
     use crate::matcher::Matcher;
     use crate::test_helpers::test_type_traits_non_clonable;

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, ops::Range};
 
-use boreal_parser::VariableModifiers;
+use boreal_parser::rule::VariableModifiers;
 
 use crate::regex::Hir;
 


### PR DESCRIPTION
Re-organize imports. Several objects were not properly exported, which should now be fixed.

Also, add a docstring to show a bit what the parsed AST looks like.