### PR TITLE
Improve simple validator jump

### DIFF
--- a/boreal/tests/it/elf.rs
+++ b/boreal/tests/it/elf.rs
@@ -115,7 +115,7 @@ fn test_import_md5() {
 #[test]
 #[cfg(feature = "hash")]
 fn test_telfhash() {
-    use crate::utils::check_boreal;
+    use crate::utils::check;
 
     test(ELF32_FILE, "not defined elf.telfhash()");
     test(ELF32_SHAREDOBJ, "not defined elf.telfhash()");
@@ -125,8 +125,7 @@ fn test_telfhash() {
     test(ELF_X64_FILE, "not defined elf.telfhash()");
 
     let contents = std::fs::read("tests/assets/elf/elf_with_imports").unwrap();
-    // TODO: fixed on yara >4.3.0-rc1
-    check_boreal(
+    check(
         r#"
 import "elf"
 rule test {

--- a/boreal/tests/it/libyara_compat/rules.rs
+++ b/boreal/tests/it/libyara_compat/rules.rs
@@ -3182,8 +3182,7 @@ fn test_re() {
     check_regex_match("abc$", b"aabc", b"abc");
     check(&build_regex_rule("$abc"), b"abc", false);
     check_regex_match("(a|a$)bcd", b"abcd", b"abcd");
-    // TODO: re-enable when https://github.com/rust-lang/regex/issues/921 is fixed.
-    // check(&build_regex_rule("(a$|a$)bcd"), b"abcd", false);
+    check(&build_regex_rule("(a$|a$)bcd"), b"abcd", false);
     check(&build_regex_rule("(abc$|ab$)"), b"abcd", false);
     check_regex_match("^a(bc+|b[eh])g|.h$", b"abhg", b"abhg");
     check_regex_match("(bc+d$|ef*g.|h?i(j|k))", b"effgz", b"effgz");

--- a/boreal/tests/it/limits.rs
+++ b/boreal/tests/it/limits.rs
@@ -279,13 +279,10 @@ rule second {{
 
 #[test]
 fn test_max_split_match_length_hex_string() {
-    // Turns out yara works fine for the commented string.
-    // TODO: investigate why
     let checker = Checker::new(
         r#"
 rule a {
     strings:
-        // $a = { AA [1-] BB CC DD EE [1-] FF }
         $a = { AA ?? [1-] BB CC DD EE [1-] ?? FF }
     condition:
         any of them
@@ -301,7 +298,7 @@ rule a {
     mem.extend(b"\xAA \xBB\xCC\xDD\xEE");
     mem.resize(5_000, 0);
     mem.push(b'\xFF');
-    // checker.check(&mem, false);
+    checker.check(&mem, false);
 
     // If the \xFF is too far, it won't match.
     let mut mem = Vec::new();

--- a/boreal/tests/it/macho.rs
+++ b/boreal/tests/it/macho.rs
@@ -71,11 +71,10 @@ fn test_entry_point_for_arch() {
         file2,
         "macho.entry_point_for_arch(macho.CPU_TYPE_X86, macho.CPU_SUBTYPE_PENTIUM_M) == 2008",
     );
-    // TODO: Bug in LIBYARA
-    // test_cond(
-    //     file2,
-    //     "not defined macho.entry_point_for_arch(macho.CPU_TYPE_X86, macho.CPU_SUBTYPE_XEON)",
-    // );
+    test_cond(
+        file2,
+        "not defined macho.entry_point_for_arch(macho.CPU_TYPE_X86, macho.CPU_SUBTYPE_XEON)",
+    );
     {
         use std::io::Read;
 


### PR DESCRIPTION
Aggregate dot-all expressions into a fixed size jump. This improves validation of hex strings that contains chains of '?? ?? ...', and will allow handling fixed size jumps in the future.