### PR TITLE
Add warning on unknown regex escape

### DIFF
--- a/boreal-parser/src/expression/boolean_expression.rs
+++ b/boreal-parser/src/expression/boolean_expression.rs
@@ -322,7 +322,7 @@ mod tests {
     use super::*;
     use crate::{
         expression::{Identifier, MAX_EXPR_RECURSION},
-        regex::{self, Regex},
+        regex::{self, Literal, Regex},
         test_helpers::{parse, parse_check, parse_err, parse_err_type, test_public_type},
     };
     use std::ops::Range;
@@ -676,7 +676,7 @@ mod tests {
                         span: 0..3,
                     }),
                     Regex {
-                        ast: regex::Node::Literal(b'b'),
+                        ast: regex::Node::Literal(Literal { byte: b'b' }),
                         case_insensitive: true,
                         dot_all: false,
                         span: 12..16,

--- a/boreal-parser/src/expression/boolean_expression.rs
+++ b/boreal-parser/src/expression/boolean_expression.rs
@@ -678,6 +678,7 @@ mod tests {
                     Regex {
                         ast: regex::Node::Literal(Literal {
                             byte: b'b',
+                            span: 13..14,
                             escaped: false,
                         }),
                         case_insensitive: true,

--- a/boreal-parser/src/expression/boolean_expression.rs
+++ b/boreal-parser/src/expression/boolean_expression.rs
@@ -676,7 +676,10 @@ mod tests {
                         span: 0..3,
                     }),
                     Regex {
-                        ast: regex::Node::Literal(Literal { byte: b'b' }),
+                        ast: regex::Node::Literal(Literal {
+                            byte: b'b',
+                            escaped: false,
+                        }),
                         case_insensitive: true,
                         dot_all: false,
                         span: 12..16,

--- a/boreal-parser/src/expression/primary_expression.rs
+++ b/boreal-parser/src/expression/primary_expression.rs
@@ -460,11 +460,17 @@ mod tests {
                 expr: Expr::Regex(Regex {
                     ast: Node::Concat(vec![
                         Node::Repetition {
-                            node: Box::new(Node::Literal(Literal { byte: b'a' })),
+                            node: Box::new(Node::Literal(Literal {
+                                byte: b'a',
+                                escaped: false,
+                            })),
                             kind: RepetitionKind::ZeroOrMore,
                             greedy: true,
                         },
-                        Node::Literal(Literal { byte: b'b' }),
+                        Node::Literal(Literal {
+                            byte: b'b',
+                            escaped: false,
+                        }),
                         Node::Assertion(AssertionKind::EndLine),
                     ]),
                     case_insensitive: true,

--- a/boreal-parser/src/expression/primary_expression.rs
+++ b/boreal-parser/src/expression/primary_expression.rs
@@ -259,7 +259,7 @@ mod tests {
     use crate::error::{Error, ErrorKind};
     use crate::expression::ReadIntegerType;
     use crate::expression::MAX_EXPR_RECURSION;
-    use crate::regex::{AssertionKind, Node, Regex, RepetitionKind};
+    use crate::regex::{AssertionKind, Literal, Node, Regex, RepetitionKind};
     use crate::test_helpers::parse_err_type;
     use crate::test_helpers::{parse, parse_check, parse_err};
     use crate::types::Input;
@@ -460,11 +460,11 @@ mod tests {
                 expr: Expr::Regex(Regex {
                     ast: Node::Concat(vec![
                         Node::Repetition {
-                            node: Box::new(Node::Literal(b'a')),
+                            node: Box::new(Node::Literal(Literal { byte: b'a' })),
                             kind: RepetitionKind::ZeroOrMore,
                             greedy: true,
                         },
-                        Node::Literal(b'b'),
+                        Node::Literal(Literal { byte: b'b' }),
                         Node::Assertion(AssertionKind::EndLine),
                     ]),
                     case_insensitive: true,

--- a/boreal-parser/src/expression/primary_expression.rs
+++ b/boreal-parser/src/expression/primary_expression.rs
@@ -462,6 +462,7 @@ mod tests {
                         Node::Repetition {
                             node: Box::new(Node::Literal(Literal {
                                 byte: b'a',
+                                span: 1..2,
                                 escaped: false,
                             })),
                             kind: RepetitionKind::ZeroOrMore,
@@ -469,6 +470,7 @@ mod tests {
                         },
                         Node::Literal(Literal {
                             byte: b'b',
+                            span: 3..4,
                             escaped: false,
                         }),
                         Node::Assertion(AssertionKind::EndLine),

--- a/boreal-parser/src/rule.rs
+++ b/boreal-parser/src/rule.rs
@@ -927,11 +927,17 @@ mod tests {
                     value: VariableDeclarationValue::Regex(Regex {
                         ast: regex::Node::Concat(vec![
                             regex::Node::Repetition {
-                                node: Box::new(regex::Node::Literal(Literal { byte: b'a' })),
+                                node: Box::new(regex::Node::Literal(Literal {
+                                    byte: b'a',
+                                    escaped: false,
+                                })),
                                 kind: regex::RepetitionKind::ZeroOrOne,
                                 greedy: true,
                             },
-                            regex::Node::Literal(Literal { byte: b'b' }),
+                            regex::Node::Literal(Literal {
+                                byte: b'b',
+                                escaped: false,
+                            }),
                         ]),
                         case_insensitive: false,
                         dot_all: false,

--- a/boreal-parser/src/rule.rs
+++ b/boreal-parser/src/rule.rs
@@ -929,6 +929,7 @@ mod tests {
                             regex::Node::Repetition {
                                 node: Box::new(regex::Node::Literal(Literal {
                                     byte: b'a',
+                                    span: 39..40,
                                     escaped: false,
                                 })),
                                 kind: regex::RepetitionKind::ZeroOrOne,
@@ -936,6 +937,7 @@ mod tests {
                             },
                             regex::Node::Literal(Literal {
                                 byte: b'b',
+                                span: 41..42,
                                 escaped: false,
                             }),
                         ]),

--- a/boreal-parser/src/rule.rs
+++ b/boreal-parser/src/rule.rs
@@ -565,6 +565,7 @@ fn condition(input: Input) -> ParseResult<Expression> {
 mod tests {
     use crate::expression::{Expression, ExpressionKind, ForSelection, VariableSet};
     use crate::hex_string::{Mask, Token};
+    use crate::regex::Literal;
     use crate::test_helpers::test_public_type;
 
     use super::super::test_helpers::{parse, parse_err};
@@ -926,11 +927,11 @@ mod tests {
                     value: VariableDeclarationValue::Regex(Regex {
                         ast: regex::Node::Concat(vec![
                             regex::Node::Repetition {
-                                node: Box::new(regex::Node::Literal(b'a')),
+                                node: Box::new(regex::Node::Literal(Literal { byte: b'a' })),
                                 kind: regex::RepetitionKind::ZeroOrOne,
                                 greedy: true,
                             },
-                            regex::Node::Literal(b'b'),
+                            regex::Node::Literal(Literal { byte: b'b' }),
                         ]),
                         case_insensitive: false,
                         dot_all: false,

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -9,7 +9,7 @@ use super::module::ModuleExpression;
 use super::rule::RuleCompiler;
 use super::{module, CompilationError};
 use crate::module::Type as ModuleType;
-use crate::regex::{regex_ast_to_hir, regex_hir_to_string, Regex, RegexAstError};
+use crate::regex::{regex_ast_to_hir, regex_hir_to_string, Regex};
 
 /// Type of a parsed expression
 ///
@@ -1231,11 +1231,7 @@ fn compile_regex(
     let mut warnings = Vec::new();
     let hir = regex_ast_to_hir(ast, &mut warnings);
     for warn in warnings {
-        compiler.add_warning(match warn {
-            RegexAstError::NonAsciiChar { span } => {
-                CompilationError::RegexContainsNonAsciiChar { span }
-            }
-        })?;
+        compiler.add_warning(warn.into())?;
     }
 
     Regex::from_string(regex_hir_to_string(&hir), case_insensitive, dot_all)

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -2,7 +2,7 @@ use boreal_parser::rule::{VariableDeclaration, VariableDeclarationValue};
 
 use crate::atoms::{atoms_rank, pick_atom_in_literal};
 use crate::matcher::{Matcher, Modifiers};
-use crate::regex::{regex_ast_to_hir, RegexAstError};
+use crate::regex::regex_ast_to_hir;
 use crate::statistics;
 
 use super::rule::RuleCompiler;
@@ -59,11 +59,7 @@ pub(super) fn compile_variable(
             let mut warnings = Vec::new();
             let hir = regex_ast_to_hir(ast, &mut warnings);
             for warn in warnings {
-                compiler.add_warning(match warn {
-                    RegexAstError::NonAsciiChar { span } => {
-                        CompilationError::RegexContainsNonAsciiChar { span }
-                    }
-                })?;
+                compiler.add_warning(warn.into())?;
             }
             Matcher::new_regex(
                 &hir,

--- a/boreal/src/regex/hir.rs
+++ b/boreal/src/regex/hir.rs
@@ -269,6 +269,7 @@ impl From<Token> for Hir {
                     definition: ClassKind::Bracketed(BracketedClass {
                         items: vec![BracketedClassItem::Literal(Literal {
                             byte: b,
+                            span: 0..1,
                             escaped: false,
                         })],
                         negated: true,

--- a/boreal/src/regex/hir.rs
+++ b/boreal/src/regex/hir.rs
@@ -3,8 +3,8 @@ use std::ops::Range;
 use bitmaps::Bitmap;
 use boreal_parser::hex_string::{Mask, Token};
 use boreal_parser::regex::{
-    AssertionKind, BracketedClass, BracketedClassItem, ClassKind, Literal, Node, PerlClass,
-    PerlClassKind, RepetitionKind, RepetitionRange,
+    AssertionKind, BracketedClass, BracketedClassItem, ClassKind, Literal, LiteralChar, Node,
+    PerlClass, PerlClassKind, RepetitionKind, RepetitionRange,
 };
 
 /// HIR of a regular expression.
@@ -151,7 +151,7 @@ pub(crate) fn regex_ast_to_hir(node: Node, warnings: &mut Vec<RegexAstError>) ->
                 // a bit hacky, where we handle the special
                 // "repetition over a char" case, to put the repetition
                 // only over the last byte.
-                Node::Char { c, span } => {
+                Node::Char(LiteralChar { c, span }) => {
                     warnings.push(RegexAstError::NonAsciiChar { span });
 
                     let mut enc = vec![0; 4];
@@ -177,7 +177,7 @@ pub(crate) fn regex_ast_to_hir(node: Node, warnings: &mut Vec<RegexAstError>) ->
                 },
             }
         }
-        Node::Char { c, span } => {
+        Node::Char(LiteralChar { c, span }) => {
             warnings.push(RegexAstError::NonAsciiChar { span });
             let mut enc = vec![0; 4];
             let res = c.encode_utf8(&mut enc);

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -8,8 +8,8 @@ use std::ops::Range;
 use regex_automata::{meta, util::syntax, Input};
 
 use boreal_parser::regex::{
-    AssertionKind, BracketedClass, BracketedClassItem, ClassKind, PerlClass, PerlClassKind,
-    RepetitionKind, RepetitionRange,
+    AssertionKind, BracketedClass, BracketedClassItem, ClassKind, Literal, PerlClass,
+    PerlClassKind, RepetitionKind, RepetitionRange,
 };
 
 mod hir;
@@ -250,8 +250,8 @@ impl AstPrinter {
         for item in &cls.items {
             match item {
                 BracketedClassItem::Perl(p) => self.push_perl_class(p),
-                BracketedClassItem::Literal(b) => self.push_literal(*b),
-                BracketedClassItem::Range(a, b) => {
+                BracketedClassItem::Literal(Literal { byte }) => self.push_literal(*byte),
+                BracketedClassItem::Range(Literal { byte: a }, Literal { byte: b }) => {
                     self.push_literal(*a);
                     self.res.push('-');
                     self.push_literal(*b);

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -250,8 +250,8 @@ impl AstPrinter {
         for item in &cls.items {
             match item {
                 BracketedClassItem::Perl(p) => self.push_perl_class(p),
-                BracketedClassItem::Literal(Literal { byte }) => self.push_literal(*byte),
-                BracketedClassItem::Range(Literal { byte: a }, Literal { byte: b }) => {
+                BracketedClassItem::Literal(Literal { byte, .. }) => self.push_literal(*byte),
+                BracketedClassItem::Range(Literal { byte: a, .. }, Literal { byte: b, .. }) => {
                     self.push_literal(*a);
                     self.res.push('-');
                     self.push_literal(*b);

--- a/boreal/tests/assets/warning_files/regex_contains_non_ascii_char2.yar
+++ b/boreal/tests/assets/warning_files/regex_contains_non_ascii_char2.yar
@@ -3,4 +3,4 @@ rule a {
 }
 
 // [expected warning]: mem:2:29: warning: a non ascii character is present in a regex
-// [expected warning]: mem:2:32: warning: a non ascii character is present in a regex
+// [expected warning]: mem:2:31: warning: a non ascii character is present in a regex

--- a/boreal/tests/assets/warning_files/regex_contains_non_ascii_char2.yar
+++ b/boreal/tests/assets/warning_files/regex_contains_non_ascii_char2.yar
@@ -1,5 +1,5 @@
 rule a {
-    condition: "a" matches /𩸽_\⏫*_/
+    condition: "a" matches /𩸽_⏫*_/
 }
 
 // [expected warning]: mem:2:29: warning: a non ascii character is present in a regex

--- a/boreal/tests/assets/warning_files/regex_unknown_escape.yar
+++ b/boreal/tests/assets/warning_files/regex_unknown_escape.yar
@@ -1,0 +1,6 @@
+rule a {
+    condition:
+        /C:\Users/
+}
+
+// [expected warning]: mem:3:12: warning: unknown escape sequence

--- a/boreal/tests/assets/warning_files/regex_unknown_escape_2.yar
+++ b/boreal/tests/assets/warning_files/regex_unknown_escape_2.yar
@@ -1,0 +1,10 @@
+rule a {
+    strings:
+        $a = /a\é\^[1\23]/
+    condition:
+        $a
+}
+
+// [expected warning]: mem:3:16: warning: unknown escape sequence
+// [expected warning]: mem:3:16: warning: a non ascii character is present in a regex
+// [expected warning]: mem:3:22: warning: unknown escape sequence

--- a/boreal/tests/assets/warning_files/regex_unknown_escape_3.yar
+++ b/boreal/tests/assets/warning_files/regex_unknown_escape_3.yar
@@ -1,0 +1,9 @@
+rule a {
+    strings:
+        $a = /[\2-\i]/
+    condition:
+        $a
+}
+
+// [expected warning]: mem:3:16: warning: unknown escape sequence
+// [expected warning]: mem:3:19: warning: unknown escape sequence

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -148,7 +148,7 @@ impl Compiler {
             );
         }
 
-        // Check libyara also rejects it
+        // Check libyara accepts it.
         // TODO: add a way to get the warnings in yara-rust
         // For the moment, check the rule is not rejected at least.
         if let Some(compiler) = self.yara_compiler.take() {

--- a/boreal/tests/it/warning.rs
+++ b/boreal/tests/it/warning.rs
@@ -80,6 +80,30 @@ rule a {
 }
 
 #[test]
+fn test_warning_regex_unknown_escape() {
+    check_warnings(
+        r"
+rule a {
+    strings:
+        $a = /a\/a\i+\é_[1\2]-[a\0-\9z]2\+\🙄+/
+    condition:
+        $a and /\V/
+}",
+        &[
+            "mem:6:17: warning: unknown escape sequence",
+            "mem:4:19: warning: unknown escape sequence",
+            "mem:4:22: warning: unknown escape sequence",
+            "mem:4:22: warning: a non ascii character is present in a regex",
+            "mem:4:27: warning: unknown escape sequence",
+            "mem:4:33: warning: unknown escape sequence",
+            "mem:4:36: warning: unknown escape sequence",
+            "mem:4:43: warning: unknown escape sequence",
+            "mem:4:43: warning: a non ascii character is present in a regex",
+        ],
+    );
+}
+
+#[test]
 fn test_fail_on_warning_param() {
     let mut compiler = Compiler::new();
 


### PR DESCRIPTION
This is the equivalent of https://github.com/VirusTotal/yara/pull/1880 from YARA.

It detects when escaping done in a regex serves no purpose, and emits a warning in that case.
This detection is more strict than the one in YARA, i see no real reason to ignore escaping to '<', '>', '@', '"', etc. Detecting those are more useful than ignoring them.