### PR TITLE
feat: add memmap feature to use mmap for scanned files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,7 @@ dependencies = [
  "hex",
  "md-5",
  "memchr",
+ "memmap2",
  "object",
  "once_cell",
  "regex-automata",
@@ -544,6 +545,15 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "minimal-lexical"

--- a/boreal-cli/Cargo.toml
+++ b/boreal-cli/Cargo.toml
@@ -14,10 +14,12 @@ name = "boreal"
 path = "src/main.rs"
 
 [features]
-default = ["authenticode", "profiling"]
+default = ["authenticode", "memmap", "profiling"]
 
 # Enable authenticode parsing in boreal, requires OpenSSL
 authenticode = ["boreal/authenticode"]
+# Enable use of memory maps to load files to scan.
+memmap = ["boreal/memmap"]
 # Enables scan statistics. Should not impact performances
 # significantly, and very useful in a CLI tool to debug rules.
 profiling = ["boreal/profiling"]

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> ExitCode {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 struct ScanOptions {
     print_module_data: bool,
     no_mmap: bool,
@@ -437,8 +437,24 @@ impl std::fmt::Debug for ByteString<'_> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn verify_cli() {
-        super::build_command().debug_assert();
+        build_command().debug_assert();
+    }
+
+    #[test]
+    fn test_types() {
+        fn test<T: Clone + std::fmt::Debug + Send + Sync>(t: T) {
+            #[allow(clippy::redundant_clone)]
+            let _r = t.clone();
+            let _r = format!("{:?}", &t);
+        }
+
+        test(ScanOptions {
+            print_module_data: false,
+            no_mmap: false,
+        });
     }
 }

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -644,3 +644,34 @@ fn test_module_names() {
         // Still successful, since some other files in the directory may have been scanned
         .success();
 }
+
+#[test]
+#[cfg(feature = "memmap")]
+fn test_no_mmap() {
+    let rule_file = test_file(
+        r#"
+rule first {
+    strings:
+        $a = "abc"
+    condition:
+        any of them
+}
+rule second {
+    strings:
+        $a = "xyz"
+    condition:
+        any of them
+}"#,
+    );
+
+    let input = test_file("xyabcz");
+    // Not matching
+    cmd()
+        .arg("--no-mmap")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(predicate::eq(format!("first {}\n", input.path().display())))
+        .stderr("")
+        .success();
+}

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.62"
 
 [features]
-default = ["hash", "object"]
+default = ["hash", "object", "memmap"]
 
 # Enables the "hash" module.
 hash = ["md-5", "sha1", "sha2", "hex", "crc32fast", "tlsh2"]
@@ -27,7 +27,10 @@ object = ["dep:object"]
 # The `object` feature must also be enabled to get access to the "pe" module.
 authenticode = ["dep:authenticode-parser"]
 
-# Enables computating of statistics during scanning.
+# Adds an API to scan files using memory maps.
+memmap = ["dep:memmap2"]
+
+# Enables computation of statistics during scanning.
 profiling = []
 
 [dependencies]
@@ -62,6 +65,9 @@ object = { version = "0.32", optional = true, default-features = false, features
 # "authenticode" feature
 authenticode-parser = { version = "0.3", optional = true }
 
+# "memmap" feature
+memmap2 = { version = "0.7", optional = true }
+
 [dev-dependencies]
 base64 = "0.21"
 glob = "0.3.1"
@@ -73,4 +79,4 @@ yara = { version = "0.19", features = ["vendored"] }
 once_cell = "1.18"
 
 [package.metadata.docs.rs]
-features = ["authenticode"]
+features = ["authenticode", "memmap"]

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -143,7 +143,10 @@ impl Compiler {
     pub unsafe fn new_with_pe_signatures() -> Self {
         let mut this = Self::new_without_pe_module();
 
-        let _r = this.add_module(crate::module::Pe::new_with_signatures());
+        let _r = this.add_module(
+            // Safety: guaranteed by the safety contract of this function
+            unsafe { crate::module::Pe::new_with_signatures() },
+        );
 
         this
     }

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -602,7 +602,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::test_type_traits_non_clonable;
 
-    #[cfg_attr(coverage_nightly, no_coverage)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_fun(_ctx: &ScanContext, args: Vec<Value>) -> Option<Value> {
         drop(args);
         None

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -51,6 +51,7 @@
 #![deny(unused_lifetimes)]
 #![deny(unused_qualifications)]
 #![deny(unused_results)]
+#![deny(unsafe_op_in_unsafe_fn)]
 // Do the same for clippy
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -69,7 +69,7 @@
 #![deny(clippy::cargo)]
 // Handled by cargo-deny
 #![allow(clippy::multiple_crate_versions)]
-#![cfg_attr(coverage_nightly, feature(no_coverage))]
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 // Used in integration tests, not in the library.
 // This is to remove the "unused_crate_dependencies" warning, maybe a better solution

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -659,7 +659,7 @@ mod tests {
     use super::*;
     use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
 
-    #[cfg_attr(coverage_nightly, no_coverage)]
+    #[cfg_attr(coverage_nightly, coverage(off))]
     fn test_fun(_ctx: &ScanContext, args: Vec<Value>) -> Option<Value> {
         drop(args);
         None

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1139,7 +1139,10 @@ impl Pe {
     #[cfg(feature = "authenticode")]
     pub unsafe fn new_with_signatures() -> Self {
         Self {
-            token: Some(authenticode_parser::InitializationToken::new()),
+            token: Some(
+                // Safety: guaranteed by the safety contract of this function
+                unsafe { authenticode_parser::InitializationToken::new() },
+            ),
         }
     }
 

--- a/boreal/src/module/pe/ord.rs
+++ b/boreal/src/module/pe/ord.rs
@@ -19,7 +19,7 @@ pub(super) fn ord_lookup(dll_name: &[u8], ord: u16) -> Vec<u8> {
     format!("ord{ord}").into_bytes()
 }
 
-#[cfg_attr(coverage_nightly, no_coverage)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn wsock32_ord_lookup(ord: u16) -> Option<&'static [u8]> {
     match ord {
         1 => Some(b"accept"),
@@ -143,7 +143,7 @@ fn wsock32_ord_lookup(ord: u16) -> Option<&'static [u8]> {
     }
 }
 
-#[cfg_attr(coverage_nightly, no_coverage)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 fn oleaut32_ord_lookup(ord: u16) -> Option<&'static [u8]> {
     match ord {
         2 => Some(b"SysAllocString"),


### PR DESCRIPTION
Add a new feature, `memmap`, enabled by default. This adds a new dependency and a new API to scan file using mmap to read from it.

This feature and API is used by default in boreal-cli. An option is added to avoid using mmap.