### PR TITLE
Rework raw variables matching

### DIFF
--- a/boreal-parser/src/expression/for_expression.rs
+++ b/boreal-parser/src/expression/for_expression.rs
@@ -150,7 +150,7 @@ fn for_expression_kind(input: Input) -> ParseResult<ForExprKind> {
             preceded(rtrim(ttag("at")), cut(primary_expression)),
             |expr| ForExprKind::At(Box::new(expr)),
         ),
-        map(success(()), |_| ForExprKind::None),
+        map(success(()), |()| ForExprKind::None),
     ))(input)
 }
 

--- a/boreal-parser/src/file.rs
+++ b/boreal-parser/src/file.rs
@@ -64,7 +64,7 @@ pub struct Include {
 /// If the input cannot be parsed properly and entirely as a list
 /// of yara rules, an error is returned.
 pub(crate) fn parse_yara_file(input: Input) -> ParseResult<YaraFile> {
-    let (mut input, _) = ltrim(input)?;
+    let (mut input, ()) = ltrim(input)?;
 
     let mut file = YaraFile {
         components: Vec::new(),

--- a/boreal-parser/src/nom_recipes.rs
+++ b/boreal-parser/src/nom_recipes.rs
@@ -41,7 +41,7 @@ pub(crate) fn ltrim(mut input: Input) -> ParseResult<()> {
             value((), multispace1),
         ))(input)
         {
-            Ok((i, _)) => input = i,
+            Ok((i, ())) => input = i,
             Err(nom::Err::Error(_)) => return Ok((input, ())),
             err @ Err(_) => return err,
         }

--- a/boreal/README.md
+++ b/boreal/README.md
@@ -137,13 +137,6 @@ Modules not yet supported:
 A few key features are still missing. If you are looking into using boreal in place of YARA,
 some of those might be blockers for you:
 
-#### Optimizations
-
-A few optimizations were done, mostly to have acceptable performances. However, there is still a
-lot that is planned and yet to be done. As can be seen in the [benchmarks](/boreal/benches/README.md),
-huge number of rules, big files and bad hex or regex strings deteriorates performances quite a lot.
-This is mainly because of missing optimizations that is planned in the next releases.
-
 #### Process scanning
 
 Only scanning files or bytes is available for the moment.
@@ -159,12 +152,6 @@ need is not implemented, please create an issue.
 I am not quite sure what are the use-cases for this YARA feature, as the compilation of YARA rules
 is not that time consuming. Please create an issue with a use-case if this is a feature you would
 need.
-
-#### Using mmap/MapViewOfFile to avoid duplicating the scanned file in memory.
-
-This is unfortunately not done because of the trickiness of doing this properly in Rust, as reading
-of a file mapping can trigger signals (SIGBUS) or exceptions. I hope to have a solution for
-this in the future.
 
 ## Pay for what you use
 

--- a/boreal/src/evaluator/ac_scan.rs
+++ b/boreal/src/evaluator/ac_scan.rs
@@ -211,7 +211,6 @@ impl AcScan {
                     AcResult::Matches(v) => v.push(m),
                     _ => matches[variable_index] = AcResult::Matches(vec![m]),
                 },
-                AcMatchStatus::Unknown => matches[variable_index] = AcResult::Unknown,
                 AcMatchStatus::None => (),
             };
 

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -205,13 +205,13 @@ pub(crate) fn evaluate_rule<'scan, 'rule>(
     }
 }
 
-struct Evaluator<'a, 'b, 'c> {
-    var_matches: Option<VarMatches<'b>>,
+struct Evaluator<'scan, 'rule> {
+    var_matches: Option<VarMatches<'rule>>,
 
     // Array of previous rules results.
     //
     // This only stores results of rules that are depended upon, not all rules.
-    previous_rules_results: &'b [bool],
+    previous_rules_results: &'rule [bool],
 
     // Index of the currently selected variable.
     //
@@ -222,7 +222,7 @@ struct Evaluator<'a, 'b, 'c> {
     bounded_identifiers_stack: Vec<Arc<ModuleValue>>,
 
     // Data related only to the scan, independent of the rule.
-    scan_data: &'c mut ScanData<'a>,
+    scan_data: &'rule mut ScanData<'scan>,
 }
 
 #[derive(Debug)]
@@ -301,7 +301,7 @@ macro_rules! apply_cmp_op {
     }
 }
 
-impl Evaluator<'_, '_, '_> {
+impl Evaluator<'_, '_> {
     fn get_variable_index(&self, var_index: VariableIndex) -> Result<usize, PoisonKind> {
         var_index
             .0

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -39,10 +39,11 @@ pub(super) fn evaluate_read_integer(
     let addr = evaluator.evaluate_expr(addr)?.unwrap_number()?;
 
     let addr = usize::try_from(addr).map_err(|_| PoisonKind::Undefined)?;
-    if addr >= evaluator.mem.len() {
-        return Err(PoisonKind::Undefined);
-    }
-    let mem = &evaluator.mem[addr..];
+    let mem = &evaluator
+        .scan_data
+        .mem
+        .get(addr..)
+        .ok_or(PoisonKind::Undefined)?;
 
     let v = match ty {
         ReadIntegerType::Int8 => read_le!(i8, mem),

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -1,7 +1,6 @@
 //! Implement scanning for variables
 use std::cmp::Ordering;
 
-use super::ac_scan::AcResult;
 use super::{Params, ScanData};
 use crate::compiler::variable::Variable;
 
@@ -23,22 +22,15 @@ pub(crate) struct VariableEvaluation<'a> {
     pub(crate) matches: Vec<Match>,
 }
 
-pub type Match = std::ops::Range<usize>;
+type Match = std::ops::Range<usize>;
 
 impl<'a> VariableEvaluation<'a> {
     /// Build a new variable evaluation context, from a variable.
-    pub fn new(var: &'a Variable, params: Params, ac_result: AcResult) -> Self {
-        let mut this = Self {
+    pub fn new(var: &'a Variable, params: Params, matches: Vec<Match>) -> Self {
+        Self {
             var,
             params,
-            matches: Vec::new(),
-        };
-        match ac_result {
-            AcResult::NotFound => this,
-            AcResult::Matches(matches) => {
-                this.matches = matches;
-                this
-            }
+            matches,
         }
     }
 

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -10,12 +10,17 @@ pub(crate) struct VarMatches<'a> {
     /// Matches per variable.
     ///
     /// This uses the same order as the variables vec in the scanner object.
-    pub(crate) matches: &'a [Vec<Match>],
+    matches: &'a [Vec<Match>],
 }
 
 type Match = std::ops::Range<usize>;
 
-impl VarMatches<'_> {
+impl<'a> VarMatches<'a> {
+    /// Create a new `VarMatches` object from a list of variable matches.
+    pub fn new(matches: &'a [Vec<Match>]) -> Self {
+        Self { matches }
+    }
+
     /// Return true if the variable can be found in the scanned memory.
     pub fn find(&self, var_index: usize) -> bool {
         !self.matches[var_index].is_empty()

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -56,9 +56,6 @@ pub enum AcMatchStatus {
 
     /// The literal does not give any match.
     None,
-
-    /// Unknown status for the match, will need to be confirmed on its own.
-    Unknown,
 }
 
 /// Type of a match.
@@ -321,7 +318,11 @@ impl Matcher {
                     ),
                 }
             }
-            MatcherKind::Raw(_) => AcMatchStatus::Unknown,
+            MatcherKind::Raw(_) => {
+                // A raw matcher has no literals, so this is unreachable.
+                debug_assert!(false);
+                AcMatchStatus::None
+            }
         }
     }
 
@@ -450,6 +451,6 @@ mod tests {
         });
         test_type_traits(MatchType::Ascii);
         test_type_traits_non_clonable(Matches::None);
-        test_type_traits(AcMatchStatus::Unknown);
+        test_type_traits(AcMatchStatus::None);
     }
 }

--- a/boreal/src/module/pe/debug.rs
+++ b/boreal/src/module/pe/debug.rs
@@ -41,7 +41,7 @@ pub fn pdb_path(data_dirs: &DataDirectories, mem: &[u8], sections: &SectionTable
         let mut info = Bytes(info);
         let sig = match info.read_bytes(4) {
             Ok(v) => v.0,
-            Err(_) => continue,
+            Err(()) => continue,
         };
 
         let pdb_path_offset = match sig {

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -383,7 +383,6 @@ impl Inner {
                     rule,
                     var_evals,
                     &mut scan_data,
-                    params.compute_full_matches,
                     params.match_max_length,
                 ));
             }
@@ -427,7 +426,6 @@ impl Inner {
                             rule,
                             Vec::new(),
                             scan_data,
-                            false,
                             params.match_max_length,
                         ));
                     }
@@ -452,7 +450,6 @@ impl Inner {
                     rule,
                     Vec::new(),
                     scan_data,
-                    false,
                     params.match_max_length,
                 ));
             }
@@ -476,17 +473,10 @@ fn collect_nb_elems<I: Iterator<Item = T>, T>(iter: &mut I, nb: usize) -> Vec<T>
 
 fn build_matched_rule<'a>(
     rule: &'a Rule,
-    mut var_evals: Vec<VariableEvaluation<'a>>,
+    var_evals: Vec<VariableEvaluation<'a>>,
     scan_data: &mut ScanData,
-    compute_full_matches: bool,
     match_max_length: usize,
 ) -> MatchedRule<'a> {
-    if compute_full_matches {
-        for var_eval in &mut var_evals {
-            var_eval.compute_all_matches(scan_data);
-        }
-    }
-
     MatchedRule {
         namespace: rule.namespace.as_deref(),
         name: &rule.name,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -347,9 +347,7 @@ impl Inner {
             let var_matches = collect_nb_elems(&mut ac_matches_iter, rule.nb_variables);
             let res = match evaluate_rule(
                 rule,
-                Some(VarMatches {
-                    matches: &var_matches,
-                }),
+                Some(VarMatches::new(&var_matches)),
                 &mut scan_data,
                 &previous_results,
             ) {

--- a/boreal/tests/it/variables.rs
+++ b/boreal/tests/it/variables.rs
@@ -102,6 +102,23 @@ rule a {
     checker.check(b"aaqUu", true);
     checker.check(b"aAaQUu", false);
 
+    // Test fullword with raw matcher
+    let checker = Checker::new(
+        r#"
+rule a {
+    strings:
+        $a = /a$/ fullword
+    condition:
+        $a
+}"#,
+    );
+    checker.check(b"", false);
+    checker.check(b"a", true);
+    checker.check(b"ba", false);
+    checker.check(b"<a", true);
+    checker.check(b"ab", false);
+    checker.check(b"b", false);
+
     let checker = Checker::new(
         r#"
 rule a {


### PR DESCRIPTION
Stop evaluating raw variables lazily, and do it during (or rather, after) the ac pass. This allows simplifying quite a lot of code, and will make it much easier to add handling of more complex scan data (for example process memory).