### PR TITLE
Compute match details on match, clean up code

### DIFF
--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -178,6 +178,9 @@ impl<'a> ScanData<'a> {
 pub struct Params {
     /// Max number of matches for a given string.
     pub string_max_nb_matches: u32,
+
+    /// Max length of the matches returned in matching rules.
+    pub match_max_length: usize,
 }
 
 /// Evaluates an expression on a given byte slice.
@@ -370,7 +373,7 @@ impl Evaluator<'_, '_> {
                             var_matches.find_match_occurence(var_index, v - 1)
                         })?;
 
-                        mat.and_then(|mat| i64::try_from(mat.start).ok())
+                        mat.and_then(|mat| i64::try_from(mat.offset).ok())
                             .map(Value::Integer)
                             .ok_or(PoisonKind::Undefined)
                     }
@@ -390,7 +393,7 @@ impl Evaluator<'_, '_> {
                             var_matches.find_match_occurence(var_index, v - 1)
                         })?;
 
-                        mat.and_then(|mat| i64::try_from(mat.len()).ok())
+                        mat.and_then(|mat| i64::try_from(mat.length).ok())
                             .map(Value::Integer)
                             .ok_or(PoisonKind::Undefined)
                     }
@@ -1054,6 +1057,7 @@ mod tests {
         test_type_traits(Value::Integer(0));
         test_type_traits(Params {
             string_max_nb_matches: 0,
+            match_max_length: 0,
         });
         test_type_traits_non_clonable(ScanData {
             mem: b"",

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -328,6 +328,8 @@ impl Evaluator<'_, '_> {
 
             #[cfg(feature = "object")]
             Expression::Entrypoint => entrypoint::get_pe_or_elf_entry_point(self.scan_data.mem)
+                .and_then(|v| i64::try_from(v).ok())
+                .map(Value::Integer)
                 .ok_or(PoisonKind::Undefined),
             #[cfg(not(feature = "object"))]
             Expression::Entrypoint => Err(PoisonKind::Undefined),


### PR DESCRIPTION
Prepare handling process memory scanning by cleaning up code that rely on access to the scanned bytes:

- Stop computing the match details lazily just before returning the results. The match details are now computed when the match happens, as the scanned bytes may no longer be available later on.

- Refacto some other functions to make some future changes smoother.