### PR TITLE
Simplify module evaluation

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -249,7 +249,7 @@ fn scan_file(scanner: &Scanner, path: &Path, options: ScanOptions) -> std::io::R
         for (module_name, module_value) in res.module_values {
             // A module value must be an object. Filter out empty ones, it means the module has not
             // generated any values.
-            if let ModuleValue::Object(map) = &*module_value {
+            if let ModuleValue::Object(map) = &module_value {
                 if !map.is_empty() {
                     print!("{module_name}");
                     print_module_value(&module_value, 4);

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -1,7 +1,6 @@
 //! Provides methods to evaluate module values during scanning.
 use std::iter::Peekable;
 use std::slice::Iter;
-use std::sync::Arc;
 
 use crate::compiler::module::{
     BoundedValueIndex, ModuleExpression, ModuleExpressionKind, ModuleOperations, ValueOperation,
@@ -43,9 +42,8 @@ pub(super) fn evaluate_expr(
                     .get(*index)
                     .ok_or(PoisonKind::Undefined)?,
             };
-            let value = Arc::clone(value);
 
-            evaluate_ops(evaluator, &value, ops, expressions)
+            evaluate_ops(evaluator, value, ops, expressions)
         }
         ModuleExpressionKind::StaticFunction { fun } => {
             let Some(ValueOperation::FunctionCall(nb_arguments)) = ops.next() else {
@@ -64,7 +62,7 @@ pub(super) fn evaluate_expr(
 }
 
 fn evaluate_ops(
-    evaluator: &mut Evaluator,
+    evaluator: &Evaluator,
     mut value: &ModuleValue,
     mut operations: Peekable<Iter<ValueOperation>>,
     mut expressions: std::vec::IntoIter<Value>,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -485,7 +485,7 @@ pub struct ScanResult<'scanner> {
     /// On-scan values of all modules used in the scanner.
     ///
     /// First element is the module name, second one is the dynamic values produced by the module.
-    pub module_values: Vec<(&'static str, Arc<crate::module::Value>)>,
+    pub module_values: Vec<(&'static str, crate::module::Value)>,
 
     /// Indicates if evaluation timed out.
     ///

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -562,7 +562,7 @@ pub fn compare_module_values_on_mem<M: Module>(
     let scanner = compiler.into_scanner();
 
     let res = scanner.scan_mem(mem);
-    let boreal_value = res
+    let mut boreal_value = res
         .module_values
         .into_iter()
         .find_map(|(name, module_value)| {
@@ -575,7 +575,6 @@ pub fn compare_module_values_on_mem<M: Module>(
         .unwrap();
 
     // Enrich value using the static values, so that it can be compared with yara's
-    let mut boreal_value = Arc::try_unwrap(boreal_value).unwrap();
     enrich_with_static_values(&mut boreal_value, module.get_static_values());
 
     let c = yara::Compiler::new().unwrap();


### PR DESCRIPTION
Rework how module values are evaluated to simplify some code, and remove the use of Arc to wrap module values.