### PR TITLE
Add fragmented memory handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,8 +888,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 [[package]]
 name = "yara"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac0de3e344eb6a5b3db94ec51c0f1467d6a64e49f7ab6c862a64e0c4a5ee904"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#0aa1a2909e5c0af1e845511e768ef09a70c3452b"
 dependencies = [
  "bitflags 2.4.0",
  "lazy_static",
@@ -900,8 +899,7 @@ dependencies = [
 [[package]]
 name = "yara-sys"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9b8f09f4221f2d5271b26a5811edf7e62c794f1a5ea546ce9238232521d933"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#0aa1a2909e5c0af1e845511e768ef09a70c3452b"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 [[package]]
 name = "yara"
 version = "0.21.0"
-source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#0aa1a2909e5c0af1e845511e768ef09a70c3452b"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#40fec76618edfcd1220ec5b848aa19d124031281"
 dependencies = [
  "bitflags 2.4.0",
  "lazy_static",
@@ -899,7 +899,7 @@ dependencies = [
 [[package]]
 name = "yara-sys"
 version = "0.21.0"
-source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#0aa1a2909e5c0af1e845511e768ef09a70c3452b"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.21.0#40fec76618edfcd1220ec5b848aa19d124031281"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ members = [
 # - Handle VirtualSize=0 when searching through sections
 #   - f7e5d82c5f6fa4ca9d6ef5a39e83b6109fe2c18c
 object = { git = 'https://github.com/vthib/boreal-object', branch = "version-0.32" }
+
+# Add ScanFlags::PROCESS_MEMORY: https://github.com/Hugal31/yara-rust/pull/130
+yara = { git = 'https://github.com/vthib/yara-rust', branch = 'version-0.21.0' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,10 @@ members = [
 #   - f7e5d82c5f6fa4ca9d6ef5a39e83b6109fe2c18c
 object = { git = 'https://github.com/vthib/boreal-object', branch = "version-0.32" }
 
-# Add ScanFlags::PROCESS_MEMORY: https://github.com/Hugal31/yara-rust/pull/130
+# yara-rust:
+# - Add ScanFlags::PROCESS_MEMORY: https://github.com/Hugal31/yara-rust/pull/130
+# yara:
+# - Add base address to elf entrypoint: https://github.com/VirusTotal/yara/pull/1989
+# - Fixes for macho module and process memory: https://github.com/VirusTotal/yara/pull/1995
+# - Fix for elf module and process memory: https://github.com/VirusTotal/yara/pull/1996
 yara = { git = 'https://github.com/vthib/yara-rust', branch = 'version-0.21.0' }

--- a/boreal/src/evaluator/entrypoint.rs
+++ b/boreal/src/evaluator/entrypoint.rs
@@ -3,9 +3,9 @@
 //! This depends on the `object` feature.
 
 use object::coff::SectionTable;
-use object::elf::{FileHeader32, FileHeader64};
+use object::elf::{FileHeader32, FileHeader64, ET_EXEC};
 use object::pe::{
-    ImageDosHeader, ImageNtHeaders32, ImageNtHeaders64, IMAGE_FILE_MACHINE_AMD64,
+    ImageDosHeader, ImageNtHeaders32, ImageNtHeaders64, IMAGE_FILE_DLL, IMAGE_FILE_MACHINE_AMD64,
     IMAGE_FILE_MACHINE_I386,
 };
 use object::read::elf::FileHeader;
@@ -14,17 +14,17 @@ use object::{Endianness, FileKind, LittleEndian as LE};
 
 use crate::module::elf;
 
-pub(super) fn get_pe_or_elf_entry_point(mem: &[u8]) -> Option<u64> {
+pub fn get_pe_or_elf_entry_point(mem: &[u8], memory: bool) -> Option<u64> {
     match FileKind::parse(mem).ok()? {
-        FileKind::Pe32 => parse_pe::<ImageNtHeaders32>(mem),
-        FileKind::Pe64 => parse_pe::<ImageNtHeaders64>(mem),
-        FileKind::Elf32 => parse_elf(FileHeader32::parse(mem).ok()?, mem),
-        FileKind::Elf64 => parse_elf(FileHeader64::parse(mem).ok()?, mem),
+        FileKind::Pe32 => parse_pe::<ImageNtHeaders32>(mem, memory),
+        FileKind::Pe64 => parse_pe::<ImageNtHeaders64>(mem, memory),
+        FileKind::Elf32 => parse_elf(FileHeader32::parse(mem).ok()?, mem, memory),
+        FileKind::Elf64 => parse_elf(FileHeader64::parse(mem).ok()?, mem, memory),
         _ => None,
     }
 }
 
-fn parse_pe<Pe: ImageNtHeaders>(mem: &[u8]) -> Option<u64> {
+fn parse_pe<Pe: ImageNtHeaders>(mem: &[u8], memory: bool) -> Option<u64> {
     let dos_header = ImageDosHeader::parse(mem).ok()?;
     let mut offset = dos_header.nt_headers_offset().into();
     let (nt_headers, _) = Pe::parse(mem, &mut offset).ok()?;
@@ -32,14 +32,24 @@ fn parse_pe<Pe: ImageNtHeaders>(mem: &[u8]) -> Option<u64> {
     let sections = nt_headers.sections(mem, offset).ok()?;
 
     // For some reasons, those tests exists here, but not in pe module...
-    let machine = nt_headers.file_header().machine.get(LE);
+    let hdr = nt_headers.file_header();
+    let machine = hdr.machine.get(LE);
     if machine != IMAGE_FILE_MACHINE_I386 && machine != IMAGE_FILE_MACHINE_AMD64 {
         return None;
     }
 
     let ep = opt_hdr.address_of_entry_point();
 
-    Some(pe_rva_to_file_offset(&sections, ep).unwrap_or(0))
+    if memory {
+        let characteristics = hdr.characteristics.get(LE);
+        if (characteristics & IMAGE_FILE_DLL) == 0 {
+            Some(u64::from(ep))
+        } else {
+            None
+        }
+    } else {
+        Some(pe_rva_to_file_offset(&sections, ep).unwrap_or(0))
+    }
 }
 
 // This reimplements the `yr_pe_rva_to_offset` function from libyara.
@@ -60,8 +70,20 @@ fn pe_rva_to_file_offset(sections: &SectionTable, va: u32) -> Option<u64> {
     u64::from(nearest_section_offset).checked_add(u64::from(va - nearest_section_va))
 }
 
-fn parse_elf<Elf: FileHeader<Endian = Endianness>>(header: &Elf, mem: &[u8]) -> Option<u64> {
+fn parse_elf<Elf: FileHeader<Endian = Endianness>>(
+    header: &Elf,
+    mem: &[u8],
+    memory: bool,
+) -> Option<u64> {
     let e = header.endian().ok()?;
 
-    elf::entry_point(header, e, mem)
+    if memory {
+        if header.e_type(e) == ET_EXEC {
+            Some(header.e_entry(e).into())
+        } else {
+            None
+        }
+    } else {
+        elf::entry_point(header, e, mem)
+    }
 }

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -267,7 +267,10 @@ impl Evaluator<'_, '_, '_> {
             #[cfg(feature = "object")]
             Expression::Entrypoint => {
                 let res = match self.scan_data.mem {
-                    Memory::Direct(mem) => entrypoint::get_pe_or_elf_entry_point(mem, false),
+                    Memory::Direct(mem) => entrypoint::get_pe_or_elf_entry_point(
+                        mem,
+                        self.scan_data.params.process_memory,
+                    ),
                     Memory::Fragmented { .. } => self.scan_data.entrypoint,
                 };
                 res.and_then(|ep| i64::try_from(ep).ok())

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -6,6 +6,7 @@ use std::slice::Iter;
 use crate::compiler::module::{
     BoundedValueIndex, ModuleExpression, ModuleExpressionKind, ModuleOperations, ValueOperation,
 };
+use crate::memory::Memory;
 use crate::module::{EvalContext, Module, ModuleDataMap, ScanContext, Value as ModuleValue};
 
 use super::{Evaluator, PoisonKind, Value};
@@ -96,7 +97,13 @@ pub(super) fn evaluate_expr(
                 .map(expr_value_to_module_value)
                 .collect();
             let eval_ctx = EvalContext {
-                mem: evaluator.scan_data.mem,
+                mem: match evaluator.scan_data.mem {
+                    Memory::Direct(mem) => mem,
+                    Memory::Fragmented { .. } => {
+                        // FIXME
+                        b""
+                    }
+                },
                 module_data: &evaluator.scan_data.module_values.data_map,
             };
             let value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;
@@ -146,7 +153,13 @@ fn evaluate_ops(
                         .map(expr_value_to_module_value)
                         .collect();
                     let eval_ctx = EvalContext {
-                        mem: evaluator.scan_data.mem,
+                        mem: match evaluator.scan_data.mem {
+                            Memory::Direct(mem) => mem,
+                            Memory::Fragmented { .. } => {
+                                // FIXME
+                                b""
+                            }
+                        },
                         module_data: &evaluator.scan_data.module_values.data_map,
                     };
                     let new_value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -33,10 +33,16 @@ impl EvalData {
         Self { values, data_map }
     }
 
-    pub fn scan_region(&mut self, region: &MemoryRegion, modules: &[Box<dyn Module>]) {
+    pub fn scan_region(
+        &mut self,
+        region: &MemoryRegion,
+        modules: &[Box<dyn Module>],
+        process_memory: bool,
+    ) {
         let mut scan_ctx = ScanContext {
             region,
             module_data: &mut self.data_map,
+            process_memory,
         };
 
         for (module, values) in modules.iter().zip(self.values.iter_mut()) {
@@ -99,6 +105,7 @@ pub(super) fn evaluate_expr(
             let eval_ctx = EvalContext {
                 mem: &evaluator.scan_data.mem,
                 module_data: &evaluator.scan_data.module_values.data_map,
+                process_memory: evaluator.scan_data.params.process_memory,
             };
             let value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;
             evaluate_ops(evaluator, &value, ops, expressions)
@@ -149,6 +156,7 @@ fn evaluate_ops(
                     let eval_ctx = EvalContext {
                         mem: &evaluator.scan_data.mem,
                         module_data: &evaluator.scan_data.module_values.data_map,
+                        process_memory: evaluator.scan_data.params.process_memory,
                     };
                     let new_value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;
                     // Avoid cloning the value if possible

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -6,7 +6,6 @@ use std::slice::Iter;
 use crate::compiler::module::{
     BoundedValueIndex, ModuleExpression, ModuleExpressionKind, ModuleOperations, ValueOperation,
 };
-use crate::memory::Memory;
 use crate::module::{EvalContext, Module, ModuleDataMap, ScanContext, Value as ModuleValue};
 
 use super::{Evaluator, PoisonKind, Value};
@@ -97,13 +96,7 @@ pub(super) fn evaluate_expr(
                 .map(expr_value_to_module_value)
                 .collect();
             let eval_ctx = EvalContext {
-                mem: match evaluator.scan_data.mem {
-                    Memory::Direct(mem) => mem,
-                    Memory::Fragmented { .. } => {
-                        // FIXME
-                        b""
-                    }
-                },
+                mem: &evaluator.scan_data.mem,
                 module_data: &evaluator.scan_data.module_values.data_map,
             };
             let value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;
@@ -153,13 +146,7 @@ fn evaluate_ops(
                         .map(expr_value_to_module_value)
                         .collect();
                     let eval_ctx = EvalContext {
-                        mem: match evaluator.scan_data.mem {
-                            Memory::Direct(mem) => mem,
-                            Memory::Fragmented { .. } => {
-                                // FIXME
-                                b""
-                            }
-                        },
+                        mem: &evaluator.scan_data.mem,
                         module_data: &evaluator.scan_data.module_values.data_map,
                     };
                     let new_value = fun(&eval_ctx, arguments).ok_or(PoisonKind::Undefined)?;

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -6,6 +6,7 @@ use std::slice::Iter;
 use crate::compiler::module::{
     BoundedValueIndex, ModuleExpression, ModuleExpressionKind, ModuleOperations, ValueOperation,
 };
+use crate::memory::MemoryRegion;
 use crate::module::{EvalContext, Module, ModuleDataMap, ScanContext, Value as ModuleValue};
 
 use super::{Evaluator, PoisonKind, Value};
@@ -32,9 +33,9 @@ impl EvalData {
         Self { values, data_map }
     }
 
-    pub fn scan_mem(&mut self, mem: &[u8], modules: &[Box<dyn Module>]) {
+    pub fn scan_region(&mut self, region: &MemoryRegion, modules: &[Box<dyn Module>]) {
         let mut scan_ctx = ScanContext {
-            mem,
+            region,
             module_data: &mut self.data_map,
         };
 

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -24,10 +24,9 @@ pub(super) fn evaluate_read_integer(
         | ReadIntegerType::Uint32BE => 4,
     };
 
-    let mem = evaluator
-        .scan_data
-        .mem
-        .get(addr, length)
+    let mem = addr
+        .checked_add(length)
+        .and_then(|end| evaluator.scan_data.mem.get(addr, end))
         .ok_or(PoisonKind::Undefined)?;
 
     match ty {

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -1,5 +1,5 @@
 //! Provides methods to evaluate the read integer expressions
-use crate::compiler::expression::Expression;
+use crate::{compiler::expression::Expression, memory::Memory};
 use boreal_parser::expression::ReadIntegerType;
 
 use super::{Evaluator, PoisonKind, Value};
@@ -24,9 +24,11 @@ pub(super) fn evaluate_read_integer(
         | ReadIntegerType::Uint32BE => 4,
     };
 
-    let mem = evaluator
-        .scan_data
-        .mem
+    let mem = match evaluator.scan_data.mem {
+        Memory::Direct(v) => v,
+        Memory::Fragmented { .. } => todo!(),
+    };
+    let mem = mem
         .get(addr..(addr + length))
         .ok_or(PoisonKind::Undefined)?;
 

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -1,5 +1,5 @@
 //! Provides methods to evaluate the read integer expressions
-use crate::{compiler::expression::Expression, memory::Memory};
+use crate::compiler::expression::Expression;
 use boreal_parser::expression::ReadIntegerType;
 
 use super::{Evaluator, PoisonKind, Value};
@@ -24,12 +24,10 @@ pub(super) fn evaluate_read_integer(
         | ReadIntegerType::Uint32BE => 4,
     };
 
-    let mem = match evaluator.scan_data.mem {
-        Memory::Direct(v) => v,
-        Memory::Fragmented { .. } => todo!(),
-    };
-    let mem = mem
-        .get(addr..(addr + length))
+    let mem = evaluator
+        .scan_data
+        .mem
+        .get(addr, length)
         .ok_or(PoisonKind::Undefined)?;
 
     match ty {

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -1,6 +1,8 @@
 //! Implement scanning for variables
 use std::cmp::Ordering;
 
+use crate::memory::MemoryRegion;
+
 /// Variable evaluation context.
 ///
 /// This is used to cache scan results for a single variable,
@@ -107,17 +109,21 @@ pub struct StringMatch {
 }
 
 impl StringMatch {
-    pub(crate) fn new(mem: &[u8], mat: std::ops::Range<usize>, match_max_length: usize) -> Self {
+    pub(crate) fn new(
+        region: &MemoryRegion,
+        mat: std::ops::Range<usize>,
+        match_max_length: usize,
+    ) -> Self {
         let length = mat.end - mat.start;
         let capped_length = std::cmp::min(length, match_max_length);
 
         Self {
-            data: mem[mat.start..]
+            data: region.mem[mat.start..]
                 .iter()
                 .take(capped_length)
                 .copied()
                 .collect(),
-            offset: mat.start,
+            offset: mat.start.saturating_add(region.start),
             length,
         }
     }

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -90,6 +90,7 @@ pub mod compiler;
 pub use compiler::Compiler;
 mod evaluator;
 mod matcher;
+pub mod memory;
 pub mod module;
 pub mod regex;
 pub mod scanner;

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -26,6 +26,31 @@ impl Memory<'_> {
             Self::Fragmented { .. } => None,
         }
     }
+
+    /// TODO
+    #[must_use]
+    pub fn get(&self, start: usize, length: usize) -> Option<&[u8]> {
+        match self {
+            Self::Direct(mem) => {
+                let end = start.checked_add(length)?;
+                mem.get(start..end)
+            }
+            Self::Fragmented { regions } => {
+                for region in *regions {
+                    let Some(relative_start) = start.checked_sub(region.start) else {
+                        break;
+                    };
+                    if relative_start > region.mem.len() {
+                        continue;
+                    }
+                    let end = relative_start.checked_add(length)?;
+                    return region.mem.get(relative_start..end);
+                }
+
+                None
+            }
+        }
+    }
 }
 
 /// A region of memory to scan.

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -1,0 +1,52 @@
+//! Describe the different types of objects that can be scanned.
+
+/// Memory to scan
+#[derive(Debug)]
+pub enum Memory<'a> {
+    /// Direct access to all of the bytes to scan.
+    ///
+    /// For example, scanning a file using mmap.
+    Direct(&'a [u8]),
+
+    /// Fragmented access to the bytes to scan.
+    ///
+    /// This is as if the bytes to scan had holes, which is useful when scanning
+    /// the memory of a process, which consists of non contiguous regions of
+    /// bytes.
+    Fragmented {
+        /// Non overlapping regions mapping the fragmented memory.
+        regions: &'a [MemoryRegion<'a>],
+    },
+}
+
+impl Memory<'_> {
+    pub(crate) fn filesize(&self) -> Option<usize> {
+        match self {
+            Self::Direct(mem) => Some(mem.len()),
+            Self::Fragmented { .. } => None,
+        }
+    }
+}
+
+/// A region of memory to scan.
+#[derive(Debug)]
+pub struct MemoryRegion<'a> {
+    /// Index of the start of the region.
+    pub start: usize,
+
+    /// Bytes of the whole region.
+    pub mem: &'a [u8],
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    use super::*;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(Memory::Direct(b""));
+        test_type_traits_non_clonable(MemoryRegion { start: 0, mem: b"" });
+    }
+}

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -45,7 +45,15 @@ impl<'a> Memory<'a> {
         }
     }
 
-    /// TODO
+    /// Retrieve the data that matches the given range, potentially truncated.
+    ///
+    /// This will fetch the memory region containing this range and return the data slice
+    /// matching the exact range, possibly truncated.
+    ///
+    /// If the start does not belong to any memory region, None is returned.
+    ///
+    /// If the end is after the end of the region, the slice is truncated.
+    // TODO: return an iterator if the range overlaps multiple regions that are contiguous?
     #[must_use]
     pub fn get(&self, start: usize, end: usize) -> Option<&'a [u8]> {
         match self {

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -27,6 +27,15 @@ impl Memory<'_> {
         }
     }
 
+    /// True if all the memory is readily available.
+    #[must_use]
+    pub fn is_direct(&self) -> bool {
+        match self {
+            Self::Direct(_) => true,
+            Self::Fragmented { .. } => false,
+        }
+    }
+
     /// TODO
     #[must_use]
     pub fn get(&self, start: usize, length: usize) -> Option<&[u8]> {

--- a/boreal/src/module/elf.rs
+++ b/boreal/src/module/elf.rs
@@ -246,6 +246,11 @@ impl Module for Elf {
     }
 
     fn get_dynamic_values(&self, ctx: &mut ScanContext, out: &mut HashMap<&'static str, Value>) {
+        if !out.is_empty() {
+            // We already found an elf in a scanned region, so ignore the others.
+            return;
+        }
+
         if let Some(values) = ctx
             .module_data
             .get_mut::<Self>()

--- a/boreal/src/module/elf.rs
+++ b/boreal/src/module/elf.rs
@@ -249,7 +249,7 @@ impl Module for Elf {
         if let Some(values) = ctx
             .module_data
             .get_mut::<Self>()
-            .and_then(|data| parse_file(ctx.mem, data))
+            .and_then(|data| parse_file(ctx.region.mem, data))
         {
             *out = values;
         }

--- a/boreal/src/module/macho.rs
+++ b/boreal/src/module/macho.rs
@@ -690,7 +690,7 @@ impl Module for MachO {
         if let Some(values) = ctx
             .module_data
             .get_mut::<Self>()
-            .and_then(|data| parse_file(ctx.mem, data, false, 0))
+            .and_then(|data| parse_file(ctx.region.mem, data, false, 0))
         {
             *out = values;
         }

--- a/boreal/src/module/macho.rs
+++ b/boreal/src/module/macho.rs
@@ -687,6 +687,11 @@ impl Module for MachO {
     }
 
     fn get_dynamic_values(&self, ctx: &mut ScanContext, out: &mut HashMap<&'static str, Value>) {
+        if !out.is_empty() {
+            // We already found a macho in a scanned region, so ignore the others.
+            return;
+        }
+
         if let Some(values) = ctx
             .module_data
             .get_mut::<Self>()

--- a/boreal/src/module/math.rs
+++ b/boreal/src/module/math.rs
@@ -134,10 +134,10 @@ impl Module for Math {
 
 fn get_mem_slice<'a>(ctx: &EvalContext<'a, '_>, offset: i64, length: i64) -> Option<&'a [u8]> {
     let start: usize = offset.try_into().ok()?;
-    let end = start.checked_add(length.try_into().ok()?)?;
-    let end = std::cmp::min(end, ctx.mem.len());
+    let length: usize = length.try_into().ok()?;
+    let end = start.checked_add(length)?;
 
-    ctx.mem.get(start..end)
+    ctx.mem.get(start, end)
 }
 
 impl Math {
@@ -296,7 +296,10 @@ impl Math {
             (Some(Value::Integer(offset)), Some(Value::Integer(length))) => {
                 distribution(get_mem_slice(ctx, offset, length)?)
             }
-            (None, None) => distribution(ctx.mem),
+            (None, None) => match ctx.mem.get_direct() {
+                Some(mem) => distribution(mem),
+                None => return None,
+            },
             _ => return None,
         };
 
@@ -314,7 +317,10 @@ impl Math {
             (Some(Value::Integer(offset)), Some(Value::Integer(length))) => {
                 distribution(get_mem_slice(ctx, offset, length)?)
             }
-            (None, None) => distribution(ctx.mem),
+            (None, None) => match ctx.mem.get_direct() {
+                Some(mem) => distribution(mem),
+                None => return None,
+            },
             _ => return None,
         };
 
@@ -331,7 +337,10 @@ impl Math {
             (Some(Value::Integer(offset)), Some(Value::Integer(length))) => {
                 distribution(get_mem_slice(ctx, offset, length)?)
             }
-            (None, None) => distribution(ctx.mem),
+            (None, None) => match ctx.mem.get_direct() {
+                Some(mem) => distribution(mem),
+                None => return None,
+            },
             _ => return None,
         };
 
@@ -489,6 +498,7 @@ fn distribution(bytes: &[u8]) -> [u64; 256] {
 
 #[cfg(test)]
 mod tests {
+    use crate::memory::Memory;
     use crate::module::ModuleDataMap;
 
     use super::*;
@@ -496,7 +506,7 @@ mod tests {
     #[test]
     fn test_in_range_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -511,7 +521,7 @@ mod tests {
     #[test]
     fn test_deviation_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -528,7 +538,7 @@ mod tests {
     #[test]
     fn test_mean_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -541,7 +551,7 @@ mod tests {
     #[test]
     fn test_serial_correlation_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -554,7 +564,7 @@ mod tests {
     #[test]
     fn test_monte_carlo_pi_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -567,7 +577,7 @@ mod tests {
     #[test]
     fn test_entropy_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -580,7 +590,7 @@ mod tests {
     #[test]
     fn test_min_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -593,7 +603,7 @@ mod tests {
     #[test]
     fn test_max_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -606,7 +616,7 @@ mod tests {
     #[test]
     fn test_to_number_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -617,7 +627,7 @@ mod tests {
     #[test]
     fn test_abs_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -628,7 +638,7 @@ mod tests {
     #[test]
     fn test_count_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -640,7 +650,7 @@ mod tests {
     #[test]
     fn test_percentage_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 
@@ -652,7 +662,7 @@ mod tests {
     #[test]
     fn test_mode_invalid_args() {
         let ctx = EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap::default(),
         };
 

--- a/boreal/src/module/math.rs
+++ b/boreal/src/module/math.rs
@@ -503,12 +503,19 @@ mod tests {
 
     use super::*;
 
+    macro_rules! ctx {
+        () => {
+            EvalContext {
+                mem: &Memory::Direct(b""),
+                module_data: &ModuleDataMap::default(),
+                process_memory: false,
+            }
+        };
+    }
+
     #[test]
     fn test_in_range_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::in_range(&ctx, vec![]).is_none());
         assert!(Math::in_range(&ctx, vec![0.5.into()]).is_none());
@@ -520,10 +527,7 @@ mod tests {
 
     #[test]
     fn test_deviation_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::deviation(&ctx, vec![]).is_none());
         assert!(Math::deviation(&ctx, vec![0.5.into()]).is_none());
@@ -537,10 +541,7 @@ mod tests {
 
     #[test]
     fn test_mean_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::mean(&ctx, vec![]).is_none());
         assert!(Math::mean(&ctx, vec![0.5.into()]).is_none());
@@ -550,10 +551,7 @@ mod tests {
 
     #[test]
     fn test_serial_correlation_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::serial_correlation(&ctx, vec![]).is_none());
         assert!(Math::serial_correlation(&ctx, vec![0.5.into()]).is_none());
@@ -563,10 +561,7 @@ mod tests {
 
     #[test]
     fn test_monte_carlo_pi_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::monte_carlo_pi(&ctx, vec![]).is_none());
         assert!(Math::monte_carlo_pi(&ctx, vec![0.5.into()]).is_none());
@@ -576,10 +571,7 @@ mod tests {
 
     #[test]
     fn test_entropy_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::entropy(&ctx, vec![]).is_none());
         assert!(Math::entropy(&ctx, vec![0.5.into()]).is_none());
@@ -589,10 +581,7 @@ mod tests {
 
     #[test]
     fn test_min_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::min(&ctx, vec![]).is_none());
         assert!(Math::min(&ctx, vec![0.5.into()]).is_none());
@@ -602,10 +591,7 @@ mod tests {
 
     #[test]
     fn test_max_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::max(&ctx, vec![]).is_none());
         assert!(Math::max(&ctx, vec![0.5.into()]).is_none());
@@ -615,10 +601,7 @@ mod tests {
 
     #[test]
     fn test_to_number_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::to_number(&ctx, vec![]).is_none());
         assert!(Math::to_number(&ctx, vec![0.into()]).is_none());
@@ -626,10 +609,7 @@ mod tests {
 
     #[test]
     fn test_abs_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::abs(&ctx, vec![]).is_none());
         assert!(Math::abs(&ctx, vec![0.5.into()]).is_none());
@@ -637,10 +617,7 @@ mod tests {
 
     #[test]
     fn test_count_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::count(&ctx, vec![]).is_none());
         assert!(Math::count(&ctx, vec![0.5.into()]).is_none());
@@ -649,10 +626,7 @@ mod tests {
 
     #[test]
     fn test_percentage_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::percentage(&ctx, vec![]).is_none());
         assert!(Math::percentage(&ctx, vec![0.5.into()]).is_none());
@@ -661,10 +635,7 @@ mod tests {
 
     #[test]
     fn test_mode_invalid_args() {
-        let ctx = EvalContext {
-            mem: &Memory::Direct(b""),
-            module_data: &ModuleDataMap::default(),
-        };
+        let ctx = ctx!();
 
         assert!(Math::mode(&ctx, vec![0.5.into()]).is_none());
     }

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -186,6 +186,11 @@ pub struct ScanContext<'a, 'b> {
     ///
     /// See [`ModuleData`] for an example on how this can be used.
     pub module_data: &'a mut ModuleDataMap,
+
+    /// True if the region should be considered part of a process memory.
+    ///
+    /// See [`crate::scanner::ScanParams::process_memory`] for more details.
+    pub process_memory: bool,
 }
 
 impl std::fmt::Debug for ScanContext<'_, '_> {
@@ -203,6 +208,11 @@ pub struct EvalContext<'a, 'b> {
     ///
     /// See [`ModuleData`] for an example on how this can be used.
     pub module_data: &'b ModuleDataMap,
+
+    /// True if the scan is done on a process memory.
+    ///
+    /// See [`crate::scanner::ScanParams::process_memory`] for more details.
+    pub process_memory: bool,
 }
 
 impl std::fmt::Debug for EvalContext<'_, '_> {
@@ -356,7 +366,8 @@ pub enum Value {
         /// # fn fun(_: &EvalContext, _: Vec<Value>) -> Option<Value> { None }
         /// # let ctx = EvalContext {
         /// #     mem: &Memory::Direct(b""),
-        /// #     module_data: &Default::default()
+        /// #     module_data: &Default::default(),
+        /// #     process_memory: false,
         /// # };
         /// let result = fun(&ctx, vec![
         ///     Value::bytes("a"),
@@ -727,10 +738,12 @@ mod tests {
         test_type_traits_non_clonable(ScanContext {
             region: &MemoryRegion { start: 0, mem: b"" },
             module_data: &mut ModuleDataMap(HashMap::new()),
+            process_memory: false,
         });
         test_type_traits_non_clonable(EvalContext {
             mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap(HashMap::new()),
+            process_memory: false,
         });
 
         test_type_traits(Value::Integer(0));

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -41,6 +41,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::memory::Memory;
 use crate::regex::Regex;
 
 mod time;
@@ -196,7 +197,7 @@ impl std::fmt::Debug for ScanContext<'_> {
 /// Context provided to module functions during evaluation.
 pub struct EvalContext<'a, 'b> {
     /// Input being scanned.
-    pub mem: &'a [u8],
+    pub mem: &'b Memory<'a>,
 
     /// Private data (per-scan) of each module.
     ///
@@ -349,10 +350,14 @@ pub enum Value {
         /// `fun("a", 1 + 2, #foo)` would call the function `fun` with:
         ///
         /// ```
+        /// # use boreal::memory::Memory;
         /// # use boreal::module::{EvalContext, Value};
         /// # let x = 3;
         /// # fn fun(_: &EvalContext, _: Vec<Value>) -> Option<Value> { None }
-        /// # let ctx = EvalContext { mem: b"", module_data: &Default::default() };
+        /// # let ctx = EvalContext {
+        /// #     mem: &Memory::Direct(b""),
+        /// #     module_data: &Default::default()
+        /// # };
         /// let result = fun(&ctx, vec![
         ///     Value::bytes("a"),
         ///     Value::Integer(3),
@@ -724,7 +729,7 @@ mod tests {
             module_data: &mut ModuleDataMap(HashMap::new()),
         });
         test_type_traits_non_clonable(EvalContext {
-            mem: b"",
+            mem: &Memory::Direct(b""),
             module_data: &ModuleDataMap(HashMap::new()),
         });
 

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -41,7 +41,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::memory::Memory;
+use crate::memory::{Memory, MemoryRegion};
 use crate::regex::Regex;
 
 mod time;
@@ -178,9 +178,9 @@ impl std::fmt::Debug for Box<dyn Module> {
 }
 
 /// Context provided to module methods during scanning.
-pub struct ScanContext<'a> {
-    /// Input being scanned.
-    pub mem: &'a [u8],
+pub struct ScanContext<'a, 'b> {
+    /// Memory region being scanned.
+    pub region: &'a MemoryRegion<'b>,
 
     /// Private data (per-scan) of each module.
     ///
@@ -188,7 +188,7 @@ pub struct ScanContext<'a> {
     pub module_data: &'a mut ModuleDataMap,
 }
 
-impl std::fmt::Debug for ScanContext<'_> {
+impl std::fmt::Debug for ScanContext<'_, '_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ScanContext").finish()
     }
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(ScanContext {
-            mem: b"",
+            region: &MemoryRegion { start: 0, mem: b"" },
             module_data: &mut ModuleDataMap(HashMap::new()),
         });
         test_type_traits_non_clonable(EvalContext {

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1109,14 +1109,14 @@ impl Module for Pe {
             return;
         };
 
-        let res = match FileKind::parse(ctx.mem) {
+        let res = match FileKind::parse(ctx.region.mem) {
             Ok(FileKind::Pe32) => {
                 data.is_32bit = true;
-                self.parse_file::<ImageNtHeaders32>(ctx.mem, data)
+                self.parse_file::<ImageNtHeaders32>(ctx.region.mem, data)
             }
             Ok(FileKind::Pe64) => {
                 data.is_32bit = false;
-                self.parse_file::<ImageNtHeaders64>(ctx.mem, data)
+                self.parse_file::<ImageNtHeaders64>(ctx.region.mem, data)
             }
             _ => None,
         };

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1109,6 +1109,11 @@ impl Module for Pe {
             return;
         };
 
+        if data.found_pe {
+            // We already found a PE in a region, so ignore the others
+            return;
+        }
+
         let res = match FileKind::parse(ctx.region.mem) {
             Ok(FileKind::Pe32) => {
                 data.is_32bit = true;
@@ -1121,9 +1126,13 @@ impl Module for Pe {
             _ => None,
         };
 
-        if let Some(values) = res {
-            *out = values;
-        }
+        match res {
+            Some(values) => {
+                *out = values;
+                data.found_pe = true;
+            }
+            None => *out = [("is_pe", 0.into())].into(),
+        };
     }
 }
 
@@ -2343,6 +2352,7 @@ pub struct Data {
     resource_languages: Vec<u32>,
     is_32bit: bool,
     is_dll: u16,
+    found_pe: bool,
 }
 
 struct DataImport {

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -472,7 +472,8 @@ impl Inner {
                     #[cfg(feature = "object")]
                     if scan_data.entrypoint.is_none() {
                         scan_data.entrypoint = entrypoint::get_pe_or_elf_entry_point(
-                            region.mem, true,
+                            region.mem,
+                            scan_data.params.process_memory,
                         )
                         .and_then(|ep| {
                             let start = u64::try_from(region.start).ok()?;

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -175,6 +175,17 @@ impl Scanner {
         Ok(self.scan_mem(&mmap))
     }
 
+    // FIXME: clean up proto and doc before release
+    #[doc(hidden)]
+    #[must_use]
+    pub fn scan_fragmented(&self, regions: &[MemoryRegion]) -> ScanResult {
+        self.inner.scan(
+            Memory::Fragmented { regions },
+            &self.scan_params,
+            &self.external_symbols_values,
+        )
+    }
+
     /// Define a value for a symbol defined and used in compiled rules.
     ///
     /// This symbol must have been defined when compiling rules using

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -315,9 +315,11 @@ impl Inner {
         match scan_data.mem {
             Memory::Direct(mem) => {
                 // We can evaluate module values and then try to evaluate rules without matches.
-                scan_data
-                    .module_values
-                    .scan_region(&MemoryRegion { start: 0, mem }, &self.modules);
+                scan_data.module_values.scan_region(
+                    &MemoryRegion { start: 0, mem },
+                    &self.modules,
+                    scan_data.params.process_memory,
+                );
 
                 if !scan_data.params.compute_full_matches && scan_data.mem.is_direct() {
                     #[cfg(feature = "profiling")]
@@ -489,7 +491,11 @@ impl Inner {
                     }
 
                     // And finally, evaluate the module values on each region.
-                    scan_data.module_values.scan_region(region, &self.modules);
+                    scan_data.module_values.scan_region(
+                        region,
+                        &self.modules,
+                        scan_data.params.process_memory,
+                    );
                 }
             }
         }
@@ -746,7 +752,11 @@ mod tests {
         let scanner = compiler.into_scanner();
 
         let mut module_values = evaluator::module::EvalData::new(&scanner.inner.modules);
-        module_values.scan_region(&MemoryRegion { start: 0, mem }, &scanner.inner.modules);
+        module_values.scan_region(
+            &MemoryRegion { start: 0, mem },
+            &scanner.inner.modules,
+            false,
+        );
 
         let mut scan_data = ScanData {
             mem: Memory::Direct(mem),

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -112,4 +112,27 @@ mod tests {
     fn test_types_traits() {
         test_type_traits(ScanParams::default());
     }
+
+    #[test]
+    fn test_getters() {
+        let params = ScanParams::default();
+
+        let params = params.compute_full_matches(true);
+        assert!(params.get_compute_full_matches());
+
+        let params = params.match_max_length(3);
+        assert_eq!(params.get_match_max_length(), 3);
+
+        let params = params.string_max_nb_matches(3);
+        assert_eq!(params.get_string_max_nb_matches(), 3);
+
+        let params = params.timeout_duration(Some(Duration::from_secs(4)));
+        assert_eq!(params.get_timeout_duration(), Some(&Duration::from_secs(4)));
+
+        let params = params.compute_statistics(true);
+        assert!(params.get_compute_statistics());
+
+        let params = params.process_memory(true);
+        assert!(params.get_process_memory());
+    }
 }

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -21,6 +21,9 @@ pub struct ScanParams {
     ///
     /// This requires the `profiling` feature.
     pub(crate) compute_statistics: bool,
+
+    /// Scanned bytes are part of a process memory.
+    pub(crate) process_memory: bool,
 }
 
 impl Default for ScanParams {
@@ -31,6 +34,7 @@ impl Default for ScanParams {
             string_max_nb_matches: 1_000,
             timeout_duration: None,
             compute_statistics: false,
+            process_memory: false,
         }
     }
 }
@@ -100,6 +104,62 @@ impl ScanParams {
     pub fn compute_statistics(mut self, compute_statistics: bool) -> Self {
         self.compute_statistics = compute_statistics;
         self
+    }
+
+    /// Scanned bytes are part of the memory of a process.
+    ///
+    /// This has an impact of the behavior of some modules. For example, some file analysis
+    /// modules such as `pe` or `elf` will depend on this flag to decide whether to use the
+    /// virtual address values (if this flag is true), or the file offset values (if it is
+    /// false).
+    ///
+    /// This is always true when using the APIs to scan a process, regardless of this
+    /// parameter. It is false in other APIs, unless this parameter is set.
+    ///
+    /// One reason to use this parameter is for example to modify how a process regions
+    /// are fetched or filtered, but still rely on the same scanning behavior. The
+    /// [`crate::Scanner::scan_mem`] or [`crate::Scanner::scan_fragmented`] can then be used,
+    /// and the scan will evaluate as if [`crate::Scanner::scan_process`] was called.
+    #[must_use]
+    pub fn process_memory(mut self, process_memory: bool) -> Self {
+        self.process_memory = process_memory;
+        self
+    }
+
+    /// Returns whether full matches are computed on matching rules.
+    #[must_use]
+    pub fn get_compute_full_matches(&self) -> bool {
+        self.compute_full_matches
+    }
+
+    /// Returns the maxiumum length of the matches returned in matching rules.
+    #[must_use]
+    pub fn get_match_max_length(&self) -> usize {
+        self.match_max_length
+    }
+
+    /// Returns the maximum number of matches for a given string.
+    #[must_use]
+    pub fn get_string_max_nb_matches(&self) -> u32 {
+        self.string_max_nb_matches
+    }
+
+    /// Returns the maximum duration of a scan before it is stopped.
+    #[must_use]
+    pub fn get_timeout_duration(&self) -> Option<&Duration> {
+        self.timeout_duration.as_ref()
+    }
+
+    /// Returns whether statistics are computed during scanning.
+    #[must_use]
+    pub fn get_compute_statistics(&self) -> bool {
+        self.compute_statistics
+    }
+
+    /// Returns whether scanned bytes are considered part of the memory of a process.
+    #[must_use]
+    pub fn get_process_memory(&self) -> bool {
+        self.process_memory
     }
 }
 

--- a/boreal/tests/it/elf.rs
+++ b/boreal/tests/it/elf.rs
@@ -43,52 +43,62 @@ condition:
 
 #[test]
 fn test_coverage_elf32() {
-    compare_module_values_on_mem(Elf, "ELF32_FILE", ELF32_FILE, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_FILE", ELF32_FILE, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_FILE", ELF32_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_elf64() {
-    compare_module_values_on_mem(Elf, "ELF64_FILE", ELF64_FILE, &[]);
+    compare_module_values_on_mem(Elf, "ELF64_FILE", ELF64_FILE, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF64_FILE", ELF64_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_elf32_nosections() {
-    compare_module_values_on_mem(Elf, "ELF32_NOSECTIONS", ELF32_NOSECTIONS, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_NOSECTIONS", ELF32_NOSECTIONS, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_NOSECTIONS", ELF32_NOSECTIONS, true, &[]);
 }
 
 #[test]
 fn test_coverage_elf32_sharedobj() {
-    compare_module_values_on_mem(Elf, "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, true, &[]);
 }
 
 #[test]
 fn test_coverage_elf32_mips() {
-    compare_module_values_on_mem(Elf, "ELF32_MIPS_FILE", ELF32_MIPS_FILE, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_MIPS_FILE", ELF32_MIPS_FILE, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF32_MIPS_FILE", ELF32_MIPS_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_elf_x64_file() {
-    compare_module_values_on_mem(Elf, "ELF_X64_FILE", ELF_X64_FILE, &[]);
+    compare_module_values_on_mem(Elf, "ELF_X64_FILE", ELF_X64_FILE, false, &[]);
+    compare_module_values_on_mem(Elf, "ELF_X64_FILE", ELF_X64_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_smallest() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/smallest", &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/smallest", false, &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/smallest", true, &[]);
 }
 
 #[test]
 fn test_coverage_invalid_sections() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_sections", &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_sections", false, &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_sections", true, &[]);
 }
 
 #[test]
 fn test_coverage_invalid_program_header() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_program_header", &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_program_header", false, &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_program_header", true, &[]);
 }
 
 #[test]
 fn test_coverage_invalid_symbols() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_symbols", &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_symbols", false, &[]);
+    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_symbols", true, &[]);
 }
 
 #[test]

--- a/boreal/tests/it/fragmented.rs
+++ b/boreal/tests/it/fragmented.rs
@@ -203,8 +203,6 @@ rule dll {
 "#;
     let mut checker = Checker::new(rule);
     checker.set_process_memory_flag();
-    let mut checker_without_yara = Checker::new_without_yara(rule);
-    checker_without_yara.set_process_memory_flag();
 
     let pe32 = std::fs::read("tests/assets/libyara/data/tiny").unwrap();
     let pe64 = std::fs::read("tests/assets/libyara/data/pe_mingw").unwrap();
@@ -215,20 +213,10 @@ rule dll {
         &[(0, b"a"), (1000, &pe64), (2000, &pe32)],
         vec![("default:pe64".to_owned(), vec![])],
     );
-    // TODO: dll should not be handled when doing a process memory scan
-    checker_without_yara.check_fragmented_full_matches(
-        &[(0, &dll), (1000, b"b")],
-        vec![
-            ("default:pe64".to_owned(), vec![]),
-            ("default:dll".to_owned(), vec![]),
-        ],
-    );
-    checker_without_yara.check_fragmented_full_matches(
+    checker.check_fragmented_full_matches(&[(0, &dll), (1000, b"b")], vec![]);
+    checker.check_fragmented_full_matches(
         &[(0, &dll), (1000, b"b"), (2000, &pe32)],
-        vec![
-            ("default:pe64".to_owned(), vec![]),
-            ("default:dll".to_owned(), vec![]),
-        ],
+        vec![("default:pe32".to_owned(), vec![])],
     );
 }
 
@@ -268,22 +256,11 @@ rule so {
     );
 
     // Should ignore a SO file
-    // TODO: so should not be handled when doing a process memory scan
-    checker_without_yara.check_fragmented_full_matches(
-        &[(0, ELF32_SHAREDOBJ), (1000, b"b")],
-        vec![
-            ("default:elf32".to_owned(), vec![]),
-            ("default:so".to_owned(), vec![]),
-        ],
-    );
+    checker.check_fragmented_full_matches(&[(0, ELF32_SHAREDOBJ), (1000, b"b")], vec![]);
 
-    // TODO: so should not be handled when doing a process memory scan
     checker_without_yara.check_fragmented_full_matches(
         &[(0, ELF32_SHAREDOBJ), (1000, b"b"), (2000, ELF32_FILE)],
-        vec![
-            ("default:elf32".to_owned(), vec![]),
-            ("default:so".to_owned(), vec![]),
-        ],
+        vec![("default:elf32".to_owned(), vec![])],
     );
 }
 

--- a/boreal/tests/it/fragmented.rs
+++ b/boreal/tests/it/fragmented.rs
@@ -1,0 +1,85 @@
+use crate::utils::Checker;
+
+#[test]
+fn test_fragmented_string_scan() {
+    let checker = Checker::new(
+        r"
+rule a {
+    strings:
+        $a = /a\w+/
+        $b = /^cde/
+    condition:
+        #a == 4 and #b == 2
+}",
+    );
+
+    let regions = &[
+        (0, b"cde abc ab".as_slice()),
+        (0x1000, b"abcde cde"),
+        (0x2000, b"cde"),
+        (0x3000, b" abcd "),
+    ];
+    checker.check_fragmented(regions, true);
+    checker.check_fragmented_full_matches(
+        regions,
+        vec![(
+            "default:a".to_owned(),
+            vec![
+                (
+                    "a",
+                    vec![
+                        (b"abc", 4, 3),
+                        (b"ab", 8, 2),
+                        (b"abcde", 0x1000, 5),
+                        (b"abcd", 0x3001, 4),
+                    ],
+                ),
+                ("b", vec![(b"cde", 0, 3), (b"cde", 0x2000, 3)]),
+            ],
+        )],
+    );
+}
+
+// Check strings matches do not handle spans across regions
+#[test]
+fn test_fragmented_cut() {
+    let checker = Checker::new(
+        r#"
+rule a {
+    strings:
+        $a = "abcd"
+    condition:
+        $a
+}"#,
+    );
+
+    // Disjoint region, should not match
+    checker.check_fragmented(&[(0, b"ab"), (1000, b"cd")], false);
+    // Adjacent region. It does not work, but we could imagine a match mode
+    // where it does.
+    checker.check_fragmented(&[(0, b"ab"), (2, b"cd")], false);
+}
+
+#[test]
+fn test_fragmented_filesize() {
+    let checker = Checker::new(
+        r#"
+rule a {
+    condition:
+        filesize == 10
+}"#,
+    );
+    checker.check(b"0123456789", true);
+    checker.check_fragmented(&[(0, b"0123456789")], false);
+    checker.check_fragmented(&[(0, b"01234"), (5, b"56789")], false);
+
+    let checker = Checker::new(
+        r#"
+rule a {
+    condition:
+        not defined filesize
+}"#,
+    );
+    checker.check(b"0", false);
+    checker.check_fragmented(&[(0, b"0")], true);
+}

--- a/boreal/tests/it/fragmented.rs
+++ b/boreal/tests/it/fragmented.rs
@@ -83,3 +83,35 @@ rule a {
     checker.check(b"0", false);
     checker.check_fragmented(&[(0, b"0")], true);
 }
+
+#[test]
+fn test_fragmented_read_integer() {
+    let checker = Checker::new(
+        r#"
+rule a {
+    condition:
+        uint32(1000) == 0x12345678
+}"#,
+    );
+
+    let data = std::iter::repeat(0).take(2000).collect::<Vec<_>>();
+    checker.check_fragmented(&[(0, &data)], false);
+
+    let data = std::iter::repeat(0)
+        .take(1000)
+        .chain([0x78, 0x56, 0x34, 0x12])
+        .collect::<Vec<_>>();
+    checker.check_fragmented(&[(0, &data)], true);
+    checker.check_fragmented(&[(0, &data[1..])], false);
+    checker.check_fragmented(&[(200, &data[200..])], true);
+    checker.check_fragmented(&[(200, &data[201..])], false);
+    checker.check_fragmented(&[(200, &data[199..])], false);
+    checker.check_fragmented(&[(500, b"aaa"), (800, &data[800..])], true);
+
+    // Check when at the limit
+    checker.check_fragmented(&[(1000, &[0x78, 0x56, 0x34, 0x12])], true);
+    checker.check_fragmented(&[(1000, &[0x78, 0x56, 0x34, 0x12, 0])], true);
+    checker.check_fragmented(&[(999, &[0, 0x78, 0x56, 0x34, 0x12])], true);
+    checker.check_fragmented(&[(1000, &[0x78, 0x56]), (1002, &[0x34, 0x12])], false);
+    checker.check_fragmented(&[(1050, b"")], false);
+}

--- a/boreal/tests/it/fragmented.rs
+++ b/boreal/tests/it/fragmented.rs
@@ -121,13 +121,20 @@ rule a {
 fn test_fragmented_entrypoint() {
     use crate::libyara_compat::util::{ELF32_FILE, ELF32_SHAREDOBJ, ELF64_FILE};
 
-    let undefined_checker = Checker::new("rule a { condition: not defined entrypoint }");
     fn checker(value: u64) -> Checker {
-        Checker::new(&format!("rule a {{ condition: entrypoint == {value} }}"))
+        let mut checker = Checker::new(&format!("rule a {{ condition: entrypoint == {value} }}"));
+        checker.set_process_memory_flag();
+        checker
     }
     fn checker_without_yara(value: u64) -> Checker {
-        Checker::new_without_yara(&format!("rule a {{ condition: entrypoint == {value} }}"))
+        let mut checker =
+            Checker::new_without_yara(&format!("rule a {{ condition: entrypoint == {value} }}"));
+        checker.set_process_memory_flag();
+        checker
     }
+
+    let mut undefined_checker = Checker::new("rule a { condition: not defined entrypoint }");
+    undefined_checker.set_process_memory_flag();
 
     undefined_checker.check_fragmented(&[(0, b"")], true);
 

--- a/boreal/tests/it/hash.rs
+++ b/boreal/tests/it/hash.rs
@@ -40,6 +40,11 @@ fn test_md5() {
         r#"hash.md5(0, filesize) == "c3fcd3d76192e4007dfb496cca67e13b""#,
         b"abcdefghijklmnopqrstuvwxyz",
     );
+    // Instrument the cache
+    test(
+        "hash.md5(0, filesize) == hash.md5(0, filesize)",
+        b"abcdefghijklmnopqrstuvwxyz",
+    );
     test(
         "hash.md5(0, filesize * 2) == hash.md5(0, filesize)",
         b"abcdefghijklmnopqrstuvwxyz",
@@ -72,6 +77,11 @@ fn test_sha1() {
     );
     test(
         r#"hash.sha1(0, filesize) == "32d10c7b8cf96570ca04ce37f2a19d84240d3a89""#,
+        b"abcdefghijklmnopqrstuvwxyz",
+    );
+    // Instrument the cache
+    test(
+        "hash.sha1(0, filesize) == hash.sha1(0, filesize)",
         b"abcdefghijklmnopqrstuvwxyz",
     );
     test(
@@ -111,6 +121,11 @@ fn test_sha256() {
     test(
         "hash.sha256(0, filesize) == \
             \"71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73\"",
+        b"abcdefghijklmnopqrstuvwxyz",
+    );
+    // Instrument the cache
+    test(
+        "hash.sha256(0, filesize) == hash.sha256(0, filesize)",
         b"abcdefghijklmnopqrstuvwxyz",
     );
     test(

--- a/boreal/tests/it/macho.rs
+++ b/boreal/tests/it/macho.rs
@@ -108,22 +108,38 @@ fn test_entry_point_for_arch() {
 
 #[test]
 fn test_coverage_non_macho() {
-    compare_module_values_on_mem(MachO, "ELF32_FILE", ELF32_FILE, &[]);
+    compare_module_values_on_mem(MachO, "ELF32_FILE", ELF32_FILE, false, &[]);
+    compare_module_values_on_mem(MachO, "ELF32_FILE", ELF32_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_x86() {
-    compare_module_values_on_mem(MachO, "MACHO_X86_FILE", MACHO_X86_FILE, &[]);
+    compare_module_values_on_mem(MachO, "MACHO_X86_FILE", MACHO_X86_FILE, false, &[]);
+    compare_module_values_on_mem(MachO, "MACHO_X86_FILE", MACHO_X86_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_ppc() {
-    compare_module_values_on_mem(MachO, "MACHO_PPC_FILE", MACHO_PPC_FILE, &[]);
+    compare_module_values_on_mem(MachO, "MACHO_PPC_FILE", MACHO_PPC_FILE, false, &[]);
+    compare_module_values_on_mem(MachO, "MACHO_PPC_FILE", MACHO_PPC_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_x86_object() {
-    compare_module_values_on_mem(MachO, "MACHO_X86_OBJECT_FILE", MACHO_X86_OBJECT_FILE, &[]);
+    compare_module_values_on_mem(
+        MachO,
+        "MACHO_X86_OBJECT_FILE",
+        MACHO_X86_OBJECT_FILE,
+        false,
+        &[],
+    );
+    compare_module_values_on_mem(
+        MachO,
+        "MACHO_X86_OBJECT_FILE",
+        MACHO_X86_OBJECT_FILE,
+        true,
+        &[],
+    );
 }
 
 #[test]
@@ -132,26 +148,43 @@ fn test_coverage_macho_x64_dylib() {
         MachO,
         "MACHO_X86_64_DYLIB_FILE",
         MACHO_X86_64_DYLIB_FILE,
+        false,
+        &[],
+    );
+    compare_module_values_on_mem(
+        MachO,
+        "MACHO_X86_64_DYLIB_FILE",
+        MACHO_X86_64_DYLIB_FILE,
+        true,
         &[],
     );
 }
 
 #[test]
 fn test_coverage_macho_tiny_macho() {
-    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-macho", &[]);
+    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-macho", false, &[]);
+    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-macho", true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_tiny_universal() {
-    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-universal", &[]);
+    compare_module_values_on_file(
+        MachO,
+        "tests/assets/libyara/data/tiny-universal",
+        false,
+        &[],
+    );
+    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-universal", true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_entry_points() {
-    compare_module_values_on_file(MachO, "tests/assets/macho/entry_points", &[]);
+    compare_module_values_on_file(MachO, "tests/assets/macho/entry_points", false, &[]);
+    compare_module_values_on_file(MachO, "tests/assets/macho/entry_points", true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_fat64() {
-    compare_module_values_on_file(MachO, "tests/assets/macho/fat64", &[]);
+    compare_module_values_on_file(MachO, "tests/assets/macho/fat64", false, &[]);
+    compare_module_values_on_file(MachO, "tests/assets/macho/fat64", true, &[]);
 }

--- a/boreal/tests/it/main.rs
+++ b/boreal/tests/it/main.rs
@@ -24,6 +24,9 @@ mod namespaces;
 mod undefined;
 mod variables;
 
+// Tests related to scanning of fragmented memory
+mod fragmented;
+
 // Tests related to different limits set.
 mod limits;
 

--- a/boreal/tests/it/pe.rs
+++ b/boreal/tests/it/pe.rs
@@ -493,7 +493,6 @@ fn test_coverage_pe_libyara_0ca09bde() {
         "tests/assets/libyara/data/\
         0ca09bde7602769120fadc4f7a4147347a7a97271370583586c9e587fd396171",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -507,7 +506,6 @@ fn test_coverage_pe_libyara_33fc70f9() {
         "tests/assets/libyara/data/\
         33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -521,7 +519,6 @@ fn test_coverage_pe_libyara_3b8b9015() {
         "tests/assets/libyara/data/\
         3b8b90159fa9b6048cc5410c5d53f116943564e4d05b04a843f9b3d0540d0c1c",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
             #[cfg(not(feature = "authenticode"))]
@@ -587,7 +584,6 @@ fn test_coverage_pe_libyara_pe_mingw() {
         Pe::default(),
         "tests/assets/libyara/data/pe_mingw",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -600,7 +596,6 @@ fn test_coverage_pe_libyara_tiny() {
         Pe::default(),
         "tests/assets/libyara/data/tiny",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -613,7 +608,6 @@ fn test_coverage_pe_libyara_tiny_51ff() {
         Pe::default(),
         "tests/assets/libyara/data/tiny-idata-51ff",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -628,7 +622,6 @@ fn test_coverage_pe_libyara_tiny_5200() {
         Pe::default(),
         "tests/assets/libyara/data/tiny-idata-5200",
         &[
-            "pe.rich_signature",
             "pe.import_details[1].functions",
             "pe.import_details[1].number_of_functions",
             "pe.import_details[2].functions",
@@ -669,7 +662,6 @@ fn test_coverage_pe_libyara_tiny_overlay() {
         Pe::default(),
         "tests/assets/libyara/data/tiny-overlay",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -718,7 +710,6 @@ fn test_coverage_pe_1561_32_section1() {
         Pe::default(),
         "tests/assets/yara_1561/Win32/FileTest_Section1_Starts_at_header.exe",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],
@@ -732,7 +723,6 @@ fn test_coverage_pe_c6f9709f() {
         "tests/assets/libyara/data/\
          c6f9709feccf42f2d9e22057182fe185f177fb9daaa2649b4669a24f2ee7e3ba_0h_410h",
         &[
-            "pe.rich_signature",
             #[cfg(not(feature = "authenticode"))]
             "pe.number_of_signatures",
         ],

--- a/boreal/tests/it/pe.rs
+++ b/boreal/tests/it/pe.rs
@@ -434,299 +434,279 @@ rule test {
 
 #[test]
 fn test_coverage_pe_ord_and_delay() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/pe/ord_and_delay.exe",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/pe/ord_and_delay.exe";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_resources_only() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/pe/resources_only.dll",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/pe/resources_only.dll";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_079a472d() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-            #[cfg(not(feature = "authenticode"))]
-            "pe.signatures",
-            #[cfg(not(feature = "authenticode"))]
-            "pe.is_signed",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+        #[cfg(not(feature = "authenticode"))]
+        "pe.signatures",
+        #[cfg(not(feature = "authenticode"))]
+        "pe.is_signed",
+    ];
+    let path = "tests/assets/libyara/data/\
+        079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885";
+
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_079a472d_upx() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885.upx",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/\
+        079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885.upx";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_0ca09bde() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        0ca09bde7602769120fadc4f7a4147347a7a97271370583586c9e587fd396171",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/\
+        0ca09bde7602769120fadc4f7a4147347a7a97271370583586c9e587fd396171";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_33fc70f9() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/\
+        33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_3b8b9015() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        3b8b90159fa9b6048cc5410c5d53f116943564e4d05b04a843f9b3d0540d0c1c",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-            #[cfg(not(feature = "authenticode"))]
-            "pe.signatures",
-            #[cfg(not(feature = "authenticode"))]
-            "pe.is_signed",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+        #[cfg(not(feature = "authenticode"))]
+        "pe.signatures",
+        #[cfg(not(feature = "authenticode"))]
+        "pe.is_signed",
+    ];
+    let path = "tests/assets/libyara/data/\
+        3b8b90159fa9b6048cc5410c5d53f116943564e4d05b04a843f9b3d0540d0c1c";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_ca21e1c32() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-        ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/\
+        ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_mtxex() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/mtxex.dll",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/mtxex.dll";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_mtxex_modified() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/mtxex_modified_rsrc_rva.dll",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/mtxex_modified_rsrc_rva.dll";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &[]);
 }
 
 #[test]
 fn test_coverage_pe_libyara_pe_imports() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/pe_imports",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/pe_imports";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_pe_mingw() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/pe_mingw",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/pe_mingw";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_tiny() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/tiny",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/tiny";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_tiny_51ff() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/tiny-idata-51ff",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/tiny-idata-51ff";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 // FIXME
 #[ignore]
 fn test_coverage_pe_libyara_tiny_5200() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/tiny-idata-5200",
-        &[
-            "pe.import_details[1].functions",
-            "pe.import_details[1].number_of_functions",
-            "pe.import_details[2].functions",
-            "pe.import_details[2].number_of_functions",
-            "pe.import_details[3].functions",
-            "pe.import_details[3].number_of_functions",
-            "pe.import_details[4].functions",
-            "pe.import_details[4].number_of_functions",
-            "pe.import_details[5].functions",
-            "pe.import_details[5].number_of_functions",
-            "pe.import_details[6].functions",
-            "pe.import_details[6].number_of_functions",
-            "pe.import_details[7].functions",
-            "pe.import_details[7].number_of_functions",
-            "pe.import_details[8].functions",
-            "pe.import_details[8].number_of_functions",
-            "pe.import_details[9].functions",
-            "pe.import_details[9].number_of_functions",
-            "pe.import_details[10].functions",
-            "pe.import_details[10].number_of_functions",
-            // libyara allows getting the hint name from outside the .idata section, which
-            // returns garbage. boreal do not do it, hence the differences
-            "pe.import_details[0].functions[1].name",
-            "pe.import_details[0].functions[2].name",
-            "pe.import_details[0].functions[3].name",
-            // TODO: invalid imports are still counted by libyara. Is that desirable? I don't think
-            // so
-            "pe.number_of_imports",
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        "pe.import_details[1].functions",
+        "pe.import_details[1].number_of_functions",
+        "pe.import_details[2].functions",
+        "pe.import_details[2].number_of_functions",
+        "pe.import_details[3].functions",
+        "pe.import_details[3].number_of_functions",
+        "pe.import_details[4].functions",
+        "pe.import_details[4].number_of_functions",
+        "pe.import_details[5].functions",
+        "pe.import_details[5].number_of_functions",
+        "pe.import_details[6].functions",
+        "pe.import_details[6].number_of_functions",
+        "pe.import_details[7].functions",
+        "pe.import_details[7].number_of_functions",
+        "pe.import_details[8].functions",
+        "pe.import_details[8].number_of_functions",
+        "pe.import_details[9].functions",
+        "pe.import_details[9].number_of_functions",
+        "pe.import_details[10].functions",
+        "pe.import_details[10].number_of_functions",
+        // libyara allows getting the hint name from outside the .idata section, which
+        // returns garbage. boreal do not do it, hence the differences
+        "pe.import_details[0].functions[1].name",
+        "pe.import_details[0].functions[2].name",
+        "pe.import_details[0].functions[3].name",
+        // TODO: invalid imports are still counted by libyara. Is that desirable? I don't think
+        // so
+        "pe.number_of_imports",
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/tiny-idata-5200";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_libyara_tiny_overlay() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/tiny-overlay",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/tiny-overlay";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_1561_std() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/yara_1561/x64/FileTest.exe",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/yara_1561/x64/FileTest.exe";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_1561_align_40() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/yara_1561/x64/FileTest_alignment_40.exe",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/yara_1561/x64/FileTest_alignment_40.exe";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_1561_32_align_40() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/yara_1561/Win32/FileTest_Alignment_40.exe",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/yara_1561/Win32/FileTest_Alignment_40.exe";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_1561_32_section1() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/yara_1561/Win32/FileTest_Section1_Starts_at_header.exe",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/yara_1561/Win32/FileTest_Section1_Starts_at_header.exe";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_pe_c6f9709f() {
-    compare_module_values_on_file(
-        Pe::default(),
-        "tests/assets/libyara/data/\
-         c6f9709feccf42f2d9e22057182fe185f177fb9daaa2649b4669a24f2ee7e3ba_0h_410h",
-        &[
-            #[cfg(not(feature = "authenticode"))]
-            "pe.number_of_signatures",
-        ],
-    );
+    let diffs = [
+        #[cfg(not(feature = "authenticode"))]
+        "pe.number_of_signatures",
+    ];
+    let path = "tests/assets/libyara/data/\
+         c6f9709feccf42f2d9e22057182fe185f177fb9daaa2649b4669a24f2ee7e3ba_0h_410h";
+    compare_module_values_on_file(Pe::default(), path, false, &diffs);
+    compare_module_values_on_file(Pe::default(), path, true, &diffs);
 }
 
 #[test]

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -340,6 +340,11 @@ impl Checker {
         }
     }
 
+    pub fn set_process_memory_flag(&mut self) {
+        let params = self.scanner.scan_params().clone();
+        self.scanner.set_scan_params(params.process_memory(true));
+    }
+
     #[track_caller]
     pub fn check_fragmented(&self, regions: &[(usize, &[u8])], expected_res: bool) {
         let regions = convert_regions(regions);
@@ -349,8 +354,9 @@ impl Checker {
 
         if let Some(rules) = &self.yara_rules {
             let mut scanner = rules.scanner().unwrap();
-            // FIXME: expose flags in boreal API
-            scanner.set_flags(yara::ScanFlags::PROCESS_MEMORY);
+            if self.scanner.scan_params().get_process_memory() {
+                scanner.set_flags(yara::ScanFlags::PROCESS_MEMORY);
+            }
             let res = scanner
                 .scan_mem_blocks(YaraBlocks {
                     current: 0,

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -341,7 +341,7 @@ impl Checker {
     }
 
     #[track_caller]
-    pub fn check_fragmented(&self, regions: &[(usize, &'static [u8])], expected_res: bool) {
+    pub fn check_fragmented(&self, regions: &[(usize, &[u8])], expected_res: bool) {
         let regions = convert_regions(regions);
         let res = self.scanner.scan_fragmented(&regions);
         let res = !res.matched_rules.is_empty();
@@ -397,7 +397,7 @@ impl Checker {
     }
 }
 
-fn convert_regions(regions: &[(usize, &'static [u8])]) -> Vec<MemoryRegion<'static>> {
+fn convert_regions<'a>(regions: &[(usize, &'a [u8])]) -> Vec<MemoryRegion<'a>> {
     regions
         .iter()
         .map(|(start, mem)| MemoryRegion { start: *start, mem })

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -369,11 +369,7 @@ impl Checker {
     }
 
     #[track_caller]
-    pub fn check_fragmented_full_matches(
-        &self,
-        regions: &[(usize, &'static [u8])],
-        expected: FullMatches,
-    ) {
+    pub fn check_fragmented_full_matches(&self, regions: &[(usize, &[u8])], expected: FullMatches) {
         let regions = convert_regions(regions);
 
         // We need to compute the full matches for this test
@@ -386,7 +382,10 @@ impl Checker {
         }
 
         if let Some(rules) = &self.yara_rules {
-            let scanner = rules.scanner().unwrap();
+            let mut scanner = rules.scanner().unwrap();
+            if self.scanner.scan_params().get_process_memory() {
+                scanner.set_flags(yara::ScanFlags::PROCESS_MEMORY);
+            }
             let res = scanner
                 .scan_mem_blocks(YaraBlocks {
                     current: 0,

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -348,7 +348,9 @@ impl Checker {
         assert_eq!(res, expected_res, "test failed for boreal");
 
         if let Some(rules) = &self.yara_rules {
-            let scanner = rules.scanner().unwrap();
+            let mut scanner = rules.scanner().unwrap();
+            // FIXME: expose flags in boreal API
+            scanner.set_flags(yara::ScanFlags::PROCESS_MEMORY);
             let res = scanner
                 .scan_mem_blocks(YaraBlocks {
                     current: 0,


### PR DESCRIPTION
This is the first part of the introduction of process memory scanning.

This PR introduces a distinction on the type of memory being scanned, which can be either "direct" (ie, direct access to all the scanned bytes) or "fragmented" (ie, lazy access to a set of disjointed slices).
The API to scan fragmented memory is not yet exposed, as it will be reworked as a trait to accomodate the different ways of fetching memory of a process on different OSes.

It also introduces the new "process_memory" scan parameter, which mirrors the "PROCESS_MEMORY" yara flag. It is used to modify how some modules handle the scanned bytes.