### PR TITLE
Add ScanError and return Result type on all scan methods

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -3,6 +3,7 @@ use std::process::ExitCode;
 use std::thread::JoinHandle;
 
 use boreal::module::Value as ModuleValue;
+use boreal::scanner::ScanError;
 use boreal::{statistics, Compiler, Scanner};
 
 use clap::{command, value_parser, Arg, ArgAction, ArgMatches, Command};
@@ -236,13 +237,13 @@ impl ScanOptions {
     }
 }
 
-fn scan_file(scanner: &Scanner, path: &Path, options: ScanOptions) -> std::io::Result<()> {
+fn scan_file(scanner: &Scanner, path: &Path, options: ScanOptions) -> Result<(), ScanError> {
     let res = if cfg!(feature = "memmap") && !options.no_mmap {
         // Safety: By default, we accept that this CLI tool can abort if the underlying
         // file is truncated while the scan is ongoing.
-        unsafe { scanner.scan_file_memmap(path)? }
+        unsafe { scanner.scan_file_memmap(path).map_err(|(err, _)| err)? }
     } else {
-        scanner.scan_file(path)?
+        scanner.scan_file(path).map_err(|(err, _)| err)?
     };
 
     if options.print_module_data {

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -28,7 +28,7 @@
 //! let scanner = compiler.into_scanner();
 //!
 //! // Use this object to scan strings or files.
-//! let res = scanner.scan_mem(b"<\0t\0m\0p\0.\0d\0a\0t\0>\0");
+//! let res = scanner.scan_mem(b"<\0t\0m\0p\0.\0d\0a\0t\0>\0").unwrap();
 //! assert!(res.matched_rules.iter().any(|rule| rule.name == "example"));
 //!
 //! # Ok::<(), boreal::compiler::AddRuleError>(())

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -4,13 +4,11 @@ use std::collections::HashMap;
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind};
 
-use super::{EvalError, StringMatch};
+use super::{ScanData, ScanError, StringMatch};
 use crate::atoms::pick_atom_in_literal;
 use crate::compiler::variable::Variable;
 use crate::matcher::{AcMatchStatus, Matcher};
 use crate::memory::MemoryRegion;
-
-use super::ScanData;
 
 /// Factorize atoms from all variables, to scan for them in a single pass.
 ///
@@ -121,11 +119,11 @@ impl AcScan {
         variables: &[Variable],
         scan_data: &mut ScanData,
         matches: &mut [Vec<StringMatch>],
-    ) -> Result<(), EvalError> {
+    ) -> Result<(), ScanError> {
         // Iterate over aho-corasick matches, validating those matches
         for mat in self.aho.find_overlapping_iter(region.mem) {
             if scan_data.check_timeout() {
-                return Err(EvalError::Timeout);
+                return Err(ScanError::Timeout);
             }
             self.handle_possible_match(region, &mat, variables, scan_data, matches);
         }

--- a/boreal/src/scanner/error.rs
+++ b/boreal/src/scanner/error.rs
@@ -5,12 +5,16 @@ pub enum ScanError {
     ///
     /// See [`crate::scanner::ScanParams::timeout_duration`] for more details.
     Timeout,
+
+    /// Error when reading a file to scan.
+    ScannedFileRead(std::io::Error),
 }
 
 impl std::fmt::Display for ScanError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Timeout => write!(f, "timeout"),
+            Self::ScannedFileRead(err) => write!(f, "error reading the file to scan: {err}"),
         }
     }
 }

--- a/boreal/src/scanner/error.rs
+++ b/boreal/src/scanner/error.rs
@@ -1,0 +1,29 @@
+/// Scanning error
+#[derive(Debug)]
+pub enum ScanError {
+    /// Scanning took too long and timed out.
+    ///
+    /// See [`crate::scanner::ScanParams::timeout_duration`] for more details.
+    Timeout,
+}
+
+impl std::fmt::Display for ScanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "timeout"),
+        }
+    }
+}
+
+impl std::error::Error for ScanError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(ScanError::Timeout);
+    }
+}

--- a/boreal/tests/it/elf.rs
+++ b/boreal/tests/it/elf.rs
@@ -7,7 +7,7 @@ use crate::utils::{compare_module_values_on_file, compare_module_values_on_mem, 
 
 #[test]
 fn test_non_elf() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
     import "elf"
 

--- a/boreal/tests/it/evaluation.rs
+++ b/boreal/tests/it/evaluation.rs
@@ -159,7 +159,7 @@ fn test_eval_shr() {
 
 #[test]
 fn test_eval_var_count_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -186,7 +186,7 @@ rule a {
     );
 
     // Matches can overlap
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -202,7 +202,7 @@ rule a {
 
 #[test]
 fn test_eval_var_length_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -214,7 +214,7 @@ rule a {
     checker.check(b"", false);
     checker.check(b"abc", true);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -227,7 +227,7 @@ rule a {
     checker.check(b"abc", false);
     checker.check(b"abc abcc", true);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -249,7 +249,7 @@ rule a {
 
 #[test]
 fn test_eval_var_offset_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -265,7 +265,7 @@ rule a {
     checker.check(b"   ab", false);
     checker.check(b"abab", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -294,7 +294,7 @@ rule a {
 
 #[test]
 fn test_eval_var_count_regex() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -326,7 +326,7 @@ rule a {
 
 #[test]
 fn test_eval_var_length_regex() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -341,7 +341,7 @@ rule a {
     // Regexes are greedy
     checker.check(b"aabb", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -354,7 +354,7 @@ rule a {
     checker.check(b"aaabb", false);
     checker.check(b"aa.*b+", true);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -373,7 +373,7 @@ rule a {
 
 #[test]
 fn test_eval_var_offset_regex() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -391,7 +391,7 @@ rule a {
     checker.check(b"abab", false);
 
     // Force the use of a raw matcher
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -408,7 +408,7 @@ rule a {
     checker.check(b"   ab", false);
     checker.check(b"abab", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -431,7 +431,7 @@ rule a {
 
 #[test]
 fn test_eval_var_count_hex_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -461,7 +461,7 @@ rule a {
 
 #[test]
 fn test_eval_var_length_hex_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -476,7 +476,7 @@ rule a {
     checker.check(b"\xab_\xcd\xcd\xcd", true);
     checker.check(b"\xabpad\xcd", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -521,7 +521,7 @@ rule a {
 
 #[test]
 fn test_eval_var_offset_hex_string() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -688,7 +688,7 @@ fn test_eval_matches() {
 
 #[test]
 fn test_eval_var_count_in_range() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -705,7 +705,7 @@ rule a {
     checker.check(b"  abcabcabc", true);
     checker.check(b"   abcabcabc", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -725,7 +725,7 @@ rule a {
     checker.check(b"    aaabb", false);
 
     // Same but with a variable that uses a raw matcher.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -744,7 +744,7 @@ rule a {
     checker.check(b"   aaabb", true);
     checker.check(b"    aaabb", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -763,7 +763,7 @@ rule a {
     checker.check(b"<<<|||\xab\xab\xab_\xcd", false);
 
     // Range reaching negative is fine
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1084,7 +1084,7 @@ rule b {
 
 #[test]
 fn test_private_rule() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 private rule a { strings: $a0 = "a0" condition: $a0 }
 rule b { condition: a }
@@ -1107,7 +1107,7 @@ private rule f { condition: false }
 
 #[test]
 fn test_private_strings() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 // rule with only private strings
 rule a {
@@ -1175,7 +1175,7 @@ rule c {
 
 #[test]
 fn test_global_rules() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 global rule g1 {
     strings:
@@ -1218,7 +1218,7 @@ rule bar {
 
 #[test]
 fn test_global_rules_in_rulesets() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 global private rule g1 {
     strings:
@@ -1318,7 +1318,7 @@ rule f {
 // properly handled.
 #[test]
 fn test_compute_full_matches_without_ac_scan() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 global rule a {
     strings:

--- a/boreal/tests/it/for_expression.rs
+++ b/boreal/tests/it/for_expression.rs
@@ -160,14 +160,14 @@ fn test_for_identifiers() {
         )
     };
 
-    let checker = Checker::new(&build("for any a in (1..(#a)): (!a[a] == 4)"));
+    let mut checker = Checker::new(&build("for any a in (1..(#a)): (!a[a] == 4)"));
     checker.check(b"", false);
     checker.check(b"ba baa baaaa baa", false);
     checker.check(b"ba baa baaa baa", true);
     checker.check(b"baaa baa", true);
     checker.check(b"ba ba baaa", true);
 
-    let checker = Checker::new(&build("for all a in (1..(#a-1)): (!a[a] == 4)"));
+    let mut checker = Checker::new(&build("for all a in (1..(#a-1)): (!a[a] == 4)"));
     checker.check(b"", false);
     checker.check(b"ba baa baaaa baa", false);
     checker.check(b"baaa baaa baaa", true);
@@ -176,14 +176,14 @@ fn test_for_identifiers() {
     checker.check(b"baaa baaa", true);
     checker.check(b"baaa", false);
 
-    let checker = Checker::new(&build("for any a in (1, #a): (!a[a] == 4)"));
+    let mut checker = Checker::new(&build("for any a in (1, #a): (!a[a] == 4)"));
     checker.check(b"", false);
     checker.check(b"ba baa baaaa baa", false);
     checker.check(b"baaa ba ba", true);
     checker.check(b"ba baaa ba", false);
     checker.check(b"ba ba baaa", true);
 
-    let checker = Checker::new(&build("for all a in (1, #a-1): (!a[a] == 4)"));
+    let mut checker = Checker::new(&build("for all a in (1, #a-1): (!a[a] == 4)"));
     checker.check(b"", false);
     checker.check(b"ba baa baaaa baa", false);
     checker.check(b"baaa ba ba", false);
@@ -213,7 +213,7 @@ fn test_for_identifiers() {
         true,
     );
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     condition:
@@ -285,7 +285,7 @@ fn test_for_modules() {
 #[test]
 fn test_for_identifiers_shadowing() {
     // Bounded identifier shadows a rule name.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a { condition: true }
 rule b { condition: for any a in (2): (a == 2) }
@@ -307,7 +307,7 @@ rule a { condition: for any tests in (2): (tests == 2) }
 
 #[test]
 fn test_for_expression_all() {
-    let checker = Checker::new(&build_rule("all of them"));
+    let mut checker = Checker::new(&build_rule("all of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -319,7 +319,7 @@ fn test_for_expression_all() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("all of ($*)"));
+    let mut checker = Checker::new(&build_rule("all of ($*)"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -331,7 +331,7 @@ fn test_for_expression_all() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("all of ($a0, $b1, $c0)"));
+    let mut checker = Checker::new(&build_rule("all of ($a0, $b1, $c0)"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -343,7 +343,7 @@ fn test_for_expression_all() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("all of ($a*)"));
+    let mut checker = Checker::new(&build_rule("all of ($a*)"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -360,7 +360,7 @@ fn test_for_expression_all() {
 
 #[test]
 fn test_for_expression_any() {
-    let checker = Checker::new(&build_rule("any of them"));
+    let mut checker = Checker::new(&build_rule("any of them"));
     checker.check(b"", false);
     checker.check(b"a0", true);
     checker.check(b"a1", true);
@@ -375,7 +375,7 @@ fn test_for_expression_any() {
 
 #[test]
 fn test_for_expression_none() {
-    let checker = Checker::new(&build_rule("none of them"));
+    let mut checker = Checker::new(&build_rule("none of them"));
     checker.check(b"", true);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -387,7 +387,7 @@ fn test_for_expression_none() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", false);
 
-    let checker = Checker::new(&build_rule("none of ($b*)"));
+    let mut checker = Checker::new(&build_rule("none of ($b*)"));
     checker.check(b"", true);
     checker.check(b"a0", true);
     checker.check(b"a1", true);
@@ -402,7 +402,7 @@ fn test_for_expression_none() {
 
 #[test]
 fn test_for_expression_number() {
-    let checker = Checker::new(&build_rule("(#a0-10) of them"));
+    let mut checker = Checker::new(&build_rule("(#a0-10) of them"));
     checker.check(b"", true);
     checker.check(b"a0", true);
     checker.check(b"a1", true);
@@ -415,7 +415,7 @@ fn test_for_expression_number() {
     checker.check(b"a0a1a2b0b1", true);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("0 of them"));
+    let mut checker = Checker::new(&build_rule("0 of them"));
     checker.check(b"", true);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -428,7 +428,7 @@ fn test_for_expression_number() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", false);
 
-    let checker = Checker::new(&build_rule("3 of them"));
+    let mut checker = Checker::new(&build_rule("3 of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -441,7 +441,7 @@ fn test_for_expression_number() {
     checker.check(b"a0a1a2b0b1", true);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("6 of them"));
+    let mut checker = Checker::new(&build_rule("6 of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -454,7 +454,7 @@ fn test_for_expression_number() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("7 of them"));
+    let mut checker = Checker::new(&build_rule("7 of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -470,7 +470,7 @@ fn test_for_expression_number() {
 
 #[test]
 fn test_for_expression_percent() {
-    let checker = Checker::new(&build_rule("(#c0 - 2)% of them"));
+    let mut checker = Checker::new(&build_rule("(#c0 - 2)% of them"));
     checker.check(b"", true);
     checker.check(b"a0", true);
     checker.check(b"a1", true);
@@ -483,7 +483,7 @@ fn test_for_expression_percent() {
     checker.check(b"a0a1a2b0b1", true);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("(#c0)% of them"));
+    let mut checker = Checker::new(&build_rule("(#c0)% of them"));
     checker.check(b"", true);
     checker.check(b"a0", true);
     checker.check(b"a1", true);
@@ -493,7 +493,7 @@ fn test_for_expression_percent() {
     checker.check(b"a0b1", true);
     checker.check(b"a0a1a2b0b1", true);
 
-    let checker = Checker::new(&build_rule("50% of them"));
+    let mut checker = Checker::new(&build_rule("50% of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -506,7 +506,7 @@ fn test_for_expression_percent() {
     checker.check(b"a0a1a2b0b1", true);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("50% of ($a*)"));
+    let mut checker = Checker::new(&build_rule("50% of ($a*)"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -524,7 +524,7 @@ fn test_for_expression_percent() {
     checker.check(b"a1a2", true);
 
     // Gets rounded up to 4 of them
-    let checker = Checker::new(&build_rule("51% of them"));
+    let mut checker = Checker::new(&build_rule("51% of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -538,7 +538,7 @@ fn test_for_expression_percent() {
     checker.check(b"a0a1a2b0b1", true);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("51% of ($a0, $a1, $a2, $c0)"));
+    let mut checker = Checker::new(&build_rule("51% of ($a0, $a1, $a2, $c0)"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -555,7 +555,7 @@ fn test_for_expression_percent() {
     checker.check(b"a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("100% of them"));
+    let mut checker = Checker::new(&build_rule("100% of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -568,7 +568,7 @@ fn test_for_expression_percent() {
     checker.check(b"a0a1a2b0b1", false);
     checker.check(b"a0a1a2b0b1c0", true);
 
-    let checker = Checker::new(&build_rule("(101 + #c0)% of them"));
+    let mut checker = Checker::new(&build_rule("(101 + #c0)% of them"));
     checker.check(b"", false);
     checker.check(b"a0", false);
     checker.check(b"a1", false);
@@ -587,7 +587,7 @@ fn test_for_expression_percent() {
 fn test_for_expression_overlap() {
     // Even if the selection number is bigger than the number of variables, this does not
     // mean the for expression is false: a variable can be reused.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
     rule a {
         strings:
@@ -603,7 +603,7 @@ fn test_for_expression_overlap() {
     checker.check(b"abcdef", true);
 
     // Same for wildcards
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
     rule a {
         strings:
@@ -699,20 +699,20 @@ fn test_for_identifiers_abbrev() {
         )
     };
 
-    let checker = Checker::new(&build("any of ($a, $b) in (0..5)"));
+    let mut checker = Checker::new(&build("any of ($a, $b) in (0..5)"));
     checker.check(b"", false);
     checker.check(b"aaa a a a", true);
     checker.check(b"a a a aaa", false);
     checker.check(b"a bbb aaa", true);
 
-    let checker = Checker::new(&build("all of ($a, $b*) in (2..5)"));
+    let mut checker = Checker::new(&build("all of ($a, $b*) in (2..5)"));
     checker.check(b"", false);
     checker.check(b"aaabbb", false);
     checker.check(b" aaabbb", false);
     checker.check(b"  aaabbb", true);
     checker.check(b"   aaabbb", false);
 
-    let checker = Checker::new(&build("any of them at 2"));
+    let mut checker = Checker::new(&build("any of them at 2"));
     checker.check(b"", false);
     checker.check(b"aaabbb", false);
     checker.check(b" aaabbb", false);

--- a/boreal/tests/it/fragmented.rs
+++ b/boreal/tests/it/fragmented.rs
@@ -2,7 +2,7 @@ use crate::utils::Checker;
 
 #[test]
 fn test_fragmented_string_scan() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r"
 rule a {
     strings:
@@ -43,7 +43,7 @@ rule a {
 // Check strings matches do not handle spans across regions
 #[test]
 fn test_fragmented_cut() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -62,7 +62,7 @@ rule a {
 
 #[test]
 fn test_fragmented_filesize() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     condition:
@@ -73,7 +73,7 @@ rule a {
     checker.check_fragmented(&[(0, b"0123456789")], false);
     checker.check_fragmented(&[(0, b"01234"), (5, b"56789")], false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     condition:
@@ -86,7 +86,7 @@ rule a {
 
 #[test]
 fn test_fragmented_read_integer() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     condition:

--- a/boreal/tests/it/full.rs
+++ b/boreal/tests/it/full.rs
@@ -64,7 +64,7 @@ rule d {
         "2nd namespace",
     );
 
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
 
     checker.check_full_matches(
         b"word, got many words, some full fullwords, some non-fullword \

--- a/boreal/tests/it/libyara_compat/rules.rs
+++ b/boreal/tests/it/libyara_compat/rules.rs
@@ -2707,7 +2707,7 @@ fn test_re() {
 
     #[track_caller]
     fn check_regex_match(regex: &str, mem: &[u8], expected_match: &[u8]) {
-        let checker = Checker::new(&build_regex_rule(regex));
+        let mut checker = Checker::new(&build_regex_rule(regex));
         checker.check_str_has_match(mem, expected_match);
     }
 

--- a/boreal/tests/it/namespaces.rs
+++ b/boreal/tests/it/namespaces.rs
@@ -13,7 +13,7 @@ rule bar { condition: tests.constants.one == 1 }"#,
         r#"
 rule foo { condition: tests.constants.two == 2 }"#,
     );
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_count(b"", 2);
 
     let mut compiler = Compiler::new();
@@ -28,7 +28,7 @@ rule bar { condition: tests.constants.one == 1 }"#,
 rule foo { condition: tests.constants.two == 2 }"#,
         "ns1",
     );
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_count(b"", 2);
 
     // But importing in one namespace does not bring it in others
@@ -61,7 +61,7 @@ fn test_namespaces_errors() {
     compiler.add_rules("rule a { condition: true }");
     compiler.add_rules_in_namespace("rule a { condition: true }", "ns1");
     compiler.add_rules_in_namespace("rule a { condition: true }", "ns2");
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_count(b"", 3);
 
     // Cannot depend on itself
@@ -84,7 +84,7 @@ fn test_rule_dependencies() {
     compiler.add_rules_in_namespace("rule a { strings: $c = /c/ condition: $c }", "ns1");
     compiler.add_rules_in_namespace("rule b { strings: $d = /d/ condition: a or $d }", "ns1");
 
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_rule_matches(b"", &[]);
 
     checker.check_rule_matches(b"a", &["default:a"]);
@@ -161,7 +161,7 @@ fn test_for_expression_rules() {
     compiler.add_rules("rule b2 { condition: 4 of (a0, a*) }");
     compiler.add_rules("rule b3 { condition: 50% of (a1, a2, a3) }");
 
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_rule_matches(b"", &[]);
 
     checker.check_rule_matches(b"a0", &["default:a0"]);
@@ -218,7 +218,7 @@ rule b2 { condition: tests.constants.two == 2 }
         "nsa",
     );
 
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
     checker.check_rule_matches(b"", &["default:a2", "default:a3", "nsa:tests", "nsa:b2"]);
     checker.check_rule_matches(
         b"<tests>",
@@ -347,7 +347,7 @@ rule f {
     compiler.add_file(&path.join("root.yar"));
     compiler.add_file_in_namespace(&path.join("root2.yar"), "ns2");
 
-    let checker = compiler.into_checker();
+    let mut checker = compiler.into_checker();
 
     checker.check_rule_matches(
         b"root2 aaaa bbbb cccc dddd eeee ffff",

--- a/boreal/tests/it/regex.rs
+++ b/boreal/tests/it/regex.rs
@@ -16,7 +16,7 @@ rule a {{
 fn test_regex_unicode_handling() {
     // The '+' will apply on the last byte of the 'é' utf-8 char, not on the char itself,
     // so this is: `<\xC3\xA9+>`.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -43,13 +43,13 @@ rule a {
     );
 
     // escaped unicode char is accepted.
-    let checker = Checker::new(r"rule a { strings: $a = /\µ/ condition: $a }");
+    let mut checker = Checker::new(r"rule a { strings: $a = /\µ/ condition: $a }");
     checker.check("µ".as_bytes(), true);
 }
 
 #[test]
 fn test_regex_flags() {
-    let checker = Checker::new(&build_rule(r"/a.b/"));
+    let mut checker = Checker::new(&build_rule(r"/a.b/"));
     checker.check(b"ab", false);
     checker.check(b"aab", true);
     checker.check(b"AaB", false);
@@ -59,7 +59,7 @@ fn test_regex_flags() {
     checker.check(b"a\nb", false);
     checker.check(b"A\nB", false);
 
-    let checker = Checker::new(&build_rule(r"/a.b/s"));
+    let mut checker = Checker::new(&build_rule(r"/a.b/s"));
     checker.check(b"ab", false);
     checker.check(b"aab", true);
     checker.check(b"AaB", false);
@@ -69,7 +69,7 @@ fn test_regex_flags() {
     checker.check(b"a\nb", true);
     checker.check(b"A\nB", false);
 
-    let checker = Checker::new(&build_rule(r"/a.b/i"));
+    let mut checker = Checker::new(&build_rule(r"/a.b/i"));
     checker.check(b"ab", false);
     checker.check(b"aab", true);
     checker.check(b"AaB", true);
@@ -79,7 +79,7 @@ fn test_regex_flags() {
     checker.check(b"a\nb", false);
     checker.check(b"A\nB", false);
 
-    let checker = Checker::new(&build_rule(r"/a.b/is"));
+    let mut checker = Checker::new(&build_rule(r"/a.b/is"));
     checker.check(b"ab", false);
     checker.check(b"aab", true);
     checker.check(b"AaB", true);
@@ -92,13 +92,13 @@ fn test_regex_flags() {
 
 #[test]
 fn test_regex_anchors() {
-    let checker = Checker::new(&build_rule(r"/^a/"));
+    let mut checker = Checker::new(&build_rule(r"/^a/"));
     checker.check(b"a", true);
     checker.check(b"ab", true);
     checker.check(b"ba", false);
     checker.check(b"b\ta", false);
     checker.check(b"b\na", false);
-    let checker = Checker::new(&build_rule(r"/a$/"));
+    let mut checker = Checker::new(&build_rule(r"/a$/"));
     checker.check(b"a", true);
     checker.check(b"ab", false);
     checker.check(b"ba", true);
@@ -106,13 +106,13 @@ fn test_regex_anchors() {
     checker.check(b"a\nb", false);
 
     // s flag does not modify this behavior
-    let checker = Checker::new(&build_rule(r"/^a/s"));
+    let mut checker = Checker::new(&build_rule(r"/^a/s"));
     checker.check(b"a", true);
     checker.check(b"ab", true);
     checker.check(b"ba", false);
     checker.check(b"b\ta", false);
     checker.check(b"b\na", false);
-    let checker = Checker::new(&build_rule(r"/a$/s"));
+    let mut checker = Checker::new(&build_rule(r"/a$/s"));
     checker.check(b"a", true);
     checker.check(b"ab", false);
     checker.check(b"ba", true);
@@ -130,23 +130,23 @@ fn test_regex_unneeded_escapes() {
     );
 
     // Escaping for specific regex behavior
-    let checker = Checker::new(&build_rule(r"/<\w\W>/"));
+    let mut checker = Checker::new(&build_rule(r"/<\w\W>/"));
     checker.check(b"<ab>", false);
     checker.check(b"<a/>", true);
     checker.check(b"<_]>", true);
     checker.check(b"<8]>", true);
     checker.check(b"<88>", false);
     checker.check(b"<[]>", false);
-    let checker = Checker::new(&build_rule(r"/<\d\D>/"));
+    let mut checker = Checker::new(&build_rule(r"/<\d\D>/"));
     checker.check(b"<ab>", false);
     checker.check(b"<7b>", true);
     checker.check(b"<77>", false);
-    let checker = Checker::new(&build_rule(r"/<\s\S>/"));
+    let mut checker = Checker::new(&build_rule(r"/<\s\S>/"));
     checker.check(b"<ab>", false);
     checker.check(b"< b>", true);
     checker.check(b"<\tb>", true);
     checker.check(b"<\t >", false);
-    let checker = Checker::new(&build_rule(r"/\bab\B/"));
+    let mut checker = Checker::new(&build_rule(r"/\bab\B/"));
     checker.check(b"ab", false);
     checker.check(b"<ab>", false);
     checker.check(b"abc", true);
@@ -167,7 +167,7 @@ fn test_regex_unneeded_escapes() {
     // Test from libyara: makes no sense, but works because of useless escapes being removed
     // This accepts 0, x, 5, then A-Z [ \\ and ]
     // This is *not* \x5A to \x5D
-    let checker = Checker::new(&build_rule(r"/[\0x5A-\x5D]/"));
+    let mut checker = Checker::new(&build_rule(r"/[\0x5A-\x5D]/"));
     checker.check(b"0", true);
     checker.check(b"1", false);
     checker.check(b"x", true);
@@ -182,46 +182,46 @@ fn test_regex_unneeded_escapes() {
 
 #[test]
 fn test_regex_at_most_repetitions() {
-    let checker = Checker::new(&build_rule(r"/<a{,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<a{,2}>/"));
     checker.check(b"<>", true);
     checker.check(b"<a>", true);
     checker.check(b"<aa>", true);
     checker.check(b"<aaa>", false);
 
     // Empty means {0,}, so same as *
-    let checker = Checker::new(&build_rule(r"/<a{,}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<a{,}>/"));
     checker.check(b"<>", true);
     checker.check(b"<a>", true);
     checker.check(b"<aaaaaaaaaaaaaaaaaa>", true);
     checker.check(b"<", false);
     checker.check(b">", false);
 
-    let checker = Checker::new(&build_rule(r"/<a\{,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<a\{,2}>/"));
     checker.check(b"<>", false);
     checker.check(b"<a>", false);
     checker.check(b"<a{,2}>", true);
 
-    let checker = Checker::new(&build_rule(r"/<\\{,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<\\{,2}>/"));
     checker.check(br"<>", true);
     checker.check(br"<\>", true);
     checker.check(br"<\\>", true);
     checker.check(br"<\\\>", false);
 
-    let checker = Checker::new(&build_rule(r"/<a{\,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<a{\,2}>/"));
     checker.check(br"<>", false);
     checker.check(br"<a>", false);
     checker.check(br"<aa>", false);
     checker.check(br"<aaa>", false);
     checker.check(br"<a{,2}>", true);
 
-    let checker = Checker::new(&build_rule(r"/<a{{,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<a{{,2}>/"));
     checker.check(br"<a>", true);
     checker.check(br"<a{>", true);
     checker.check(br"<a{{>", true);
     checker.check(br"<a{{{>", false);
     checker.check(br"<a{{,2}>", false);
 
-    let checker = Checker::new(&build_rule(r"/<\{{,2}>/"));
+    let mut checker = Checker::new(&build_rule(r"/<\{{,2}>/"));
     checker.check(br"<>", true);
     checker.check(br"<{>", true);
     checker.check(br"<{{>", true);

--- a/boreal/tests/it/variables.rs
+++ b/boreal/tests/it/variables.rs
@@ -2,7 +2,7 @@ use crate::utils::{build_rule, check, check_err, Checker};
 
 #[test]
 fn test_variable() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -52,7 +52,7 @@ fn test_variable_err() {
 #[test]
 fn test_variable_regex_modifiers() {
     // \x76 is 'v'
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r"
 rule a {
     strings:
@@ -103,7 +103,7 @@ rule a {
     checker.check(b"aAaQUu", false);
 
     // Test fullword with raw matcher
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -119,7 +119,7 @@ rule a {
     checker.check(b"ab", false);
     checker.check(b"b", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -138,7 +138,7 @@ rule a {
     // second match: ` yay |` => fullword, match
     checker.check(b"a| yay |", true);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -178,7 +178,7 @@ fn to_wide(e: &[u8]) -> Vec<u8> {
 #[test]
 fn test_variable_regex_wide() {
     // Without yara, it does not allow empty regex nodes
-    let checker = Checker::new_without_yara(
+    let mut checker = Checker::new_without_yara(
         r#"
         rule a {
             strings:
@@ -190,14 +190,14 @@ fn test_variable_regex_wide() {
     checker.check(b"", false);
     checker.check(b"\0", true);
 
-    let checker = build_checker(".", "wide");
+    let mut checker = build_checker(".", "wide");
     checker.check(b"", false);
     checker.check(b"\0", false);
     checker.check(b"a", false);
     checker.check(b"a\0", true);
     checker.check(b"ab", false);
 
-    let checker = build_checker("abc", "wide");
+    let mut checker = build_checker("abc", "wide");
     checker.check(b"abc", false);
     checker.check(b"a\0b\0c\0", true);
     checker.check(b"a\0b\0c", false);
@@ -205,7 +205,7 @@ fn test_variable_regex_wide() {
     checker.check(b"\0a\0b\0c\0", true);
     checker.check(b"\0a\0b\0c", false);
 
-    let checker = build_checker("a+b|cd{2,}", "wide");
+    let mut checker = build_checker("a+b|cd{2,}", "wide");
     checker.check(b"ab", false);
     checker.check(b"aaab", false);
     checker.check(b"abcd", false);
@@ -219,7 +219,7 @@ fn test_variable_regex_wide() {
     checker.check(b"c\0d\0d\0", true);
     checker.check(b"c\0d\0d\0d\0d\0", true);
 
-    let checker = build_checker("<[a-z][0-9]*>", "wide");
+    let mut checker = build_checker("<[a-z][0-9]*>", "wide");
     checker.check(b"<a>", false);
     checker.check(b"<\x00a\x00>\x00", true);
     checker.check(b"<\x00a>\x00", false);
@@ -232,7 +232,7 @@ fn test_variable_regex_wide() {
     checker.check(b"<\x00a\x009\x00d\x00>\x00", false);
     checker.check(b"a\x009\x00", false);
 
-    let checker = build_checker(r"\d[^abc]d$", "wide");
+    let mut checker = build_checker(r"\d[^abc]d$", "wide");
     checker.check(b"13d", false);
     checker.check(b"1\x003\x00d\x00", true);
     checker.check(b"1\x003\x00d", false);
@@ -242,7 +242,7 @@ fn test_variable_regex_wide() {
     checker.check(b"1\x00d\x00e\x00", false);
     checker.check(b"1\x00d\x00d\x00", true);
 
-    let checker = build_checker(r"a(b|c+)[def][^g]", "wide ascii");
+    let mut checker = build_checker(r"a(b|c+)[def][^g]", "wide ascii");
     checker.check(b"abdf", true);
     checker.check(b"a\0b\0d\0f\0", true);
     checker.check(b"a\0b\0d\0f", false);
@@ -252,7 +252,7 @@ fn test_variable_regex_wide() {
     checker.check(b"a\0c\0c\0c\0f\0\0\0", true);
     checker.check(b"a\0c\0c\0c\0f\0\0", false);
 
-    let checker = build_checker(r"d\b", "wide ascii");
+    let mut checker = build_checker(r"d\b", "wide ascii");
     checker.check(b"d", true);
     checker.check(b"d\0", true);
     checker.check(b"d.", true);
@@ -262,7 +262,7 @@ fn test_variable_regex_wide() {
     checker.check(b"da", false);
     checker.check(b"da\0", false);
 
-    let checker = build_checker(r"ad\b", "wide ascii");
+    let mut checker = build_checker(r"ad\b", "wide ascii");
     checker.check(b"ad", true);
     checker.check(b"ad\0", true);
     checker.check(b"ad.", true);
@@ -291,7 +291,7 @@ fn test_regex_wide_fullword(regex: &str, mem_ascii: &[u8]) {
     let mem_wide = &to_wide(mem_ascii);
 
     // Ascii fullword
-    let checker = build_checker(regex, "ascii fullword");
+    let mut checker = build_checker(regex, "ascii fullword");
     checker.check(&join(mem_ascii, b"", b""), true);
     checker.check(&join(mem_ascii, b"a", b""), false);
     checker.check(&join(mem_ascii, b"", b"a"), false);
@@ -300,7 +300,7 @@ fn test_regex_wide_fullword(regex: &str, mem_ascii: &[u8]) {
     checker.check(&join(mem_ascii, b"<", b">"), true);
 
     // Wide fullword
-    let checker = build_checker(regex, "wide fullword");
+    let mut checker = build_checker(regex, "wide fullword");
     checker.check(&join(mem_wide, b"", b""), true);
     checker.check(&join(mem_wide, b"a", b""), true);
     checker.check(&join(mem_wide, b"", b"a"), true);
@@ -315,7 +315,7 @@ fn test_regex_wide_fullword(regex: &str, mem_ascii: &[u8]) {
     checker.check(&join(mem_wide, b"a\0<\0", b">\0a\0"), true);
 
     // Ascii wide fullword
-    let checker = build_checker(regex, "ascii wide fullword");
+    let mut checker = build_checker(regex, "ascii wide fullword");
     checker.check(&join(mem_ascii, b"", b""), true);
     checker.check(&join(mem_ascii, b"a", b""), false);
     checker.check(&join(mem_ascii, b"", b"a"), false);
@@ -360,7 +360,7 @@ fn test_variable_regex_wide_fullword() {
 fn test_variable_regex_wide_fullword_raw() {
     // Test the wide fullword behavior with the "raw" matcher.
     // To ensure we get the raw matcher, we use a anchor.
-    let checker = build_checker("^ab", "ascii wide fullword");
+    let mut checker = build_checker("^ab", "ascii wide fullword");
     let mem_ascii = b"ab";
     let mem_wide = b"a\0b\0";
     checker.check(&join(mem_ascii, b"", b""), true);
@@ -375,7 +375,7 @@ fn test_variable_regex_wide_fullword_raw() {
     checker.check(&join(mem_wide, b"", b">\0"), true);
     checker.check(&join(mem_wide, b"", b"a\0"), false);
 
-    let checker = build_checker("ab$", "ascii wide fullword");
+    let mut checker = build_checker("ab$", "ascii wide fullword");
     checker.check(&join(mem_ascii, b"", b""), true);
     checker.check(&join(mem_ascii, b"a", b""), false);
     checker.check(&join(mem_ascii, b"<", b""), true);
@@ -389,7 +389,7 @@ fn test_variable_regex_wide_fullword_raw() {
     checker.check(&join(mem_wide, b"a\0", b""), false);
 
     // Do the same with word boundaries instead of fullword modifier
-    let checker = build_checker(r"\bab$", "ascii wide");
+    let mut checker = build_checker(r"\bab$", "ascii wide");
     checker.check(&join(mem_ascii, b"", b""), true);
     checker.check(&join(mem_ascii, b"a", b""), false);
     checker.check(&join(mem_ascii, b"<", b""), true);
@@ -402,7 +402,7 @@ fn test_variable_regex_wide_fullword_raw() {
     checker.check(&join(mem_wide, b"<\0", b""), true);
     checker.check(&join(mem_wide, b"a\0", b""), false);
 
-    let checker = build_checker(r"^a\x00b\x00", "ascii wide fullword");
+    let mut checker = build_checker(r"^a\x00b\x00", "ascii wide fullword");
     let mem_ascii = b"a\0b\0";
     let mem_wide = &to_wide(mem_ascii);
     checker.check(&join(mem_ascii, b"", b""), true);
@@ -423,7 +423,7 @@ fn test_variable_regex_wide_fullword_raw() {
 fn test_variable_regex_wide_word_boundaries() {
     // Test regex consisting of a single word boundary. No-one will ever use this regex, but
     // it helps comparing with libyara
-    let checker = build_checker(r"\b", "wide");
+    let mut checker = build_checker(r"\b", "wide");
     checker.check(b"", false);
     checker.check(b"\0", false);
     // This one has different behavior from libyara. Does it matter? no, no-one will every use
@@ -432,7 +432,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check_libyara(b"a\0", false);
     checker.check(b"\0a", false);
 
-    let checker = build_checker(r"\B", "wide");
+    let mut checker = build_checker(r"\B", "wide");
     checker.check(b"", false);
     // These ones have different behavior from libyara. Does it matter? no, no-one will every use
     // this regex.
@@ -444,7 +444,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check_libyara(b"\0a", false);
 
     // Check word boundary at start
-    let checker = build_checker(r"\ba+", "wide");
+    let mut checker = build_checker(r"\ba+", "wide");
     checker.check(b"", false);
     checker.check(b"a", false);
     checker.check(b"a\0", true);
@@ -456,7 +456,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(b"b\0a\0", false);
     checker.check(b"[\0a\0", true);
     checker.check(b"b\ra\0", true);
-    let checker = build_checker(r"\Ba", "wide");
+    let mut checker = build_checker(r"\Ba", "wide");
     checker.check(b"", false);
     checker.check(b"a", false);
     checker.check(b"a\0", false);
@@ -470,7 +470,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(b"b\ra\0", false);
 
     // Check word boundary at end
-    let checker = build_checker(r"a+\b", "wide");
+    let mut checker = build_checker(r"a+\b", "wide");
     checker.check(b"", false);
     checker.check(b"a", false);
     checker.check(b"a\0", true);
@@ -482,7 +482,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(b"b\0a\0", true);
     checker.check(b"[\0a\0", true);
     checker.check(b"b\ra\0", true);
-    let checker = build_checker(r"a\B", "wide");
+    let mut checker = build_checker(r"a\B", "wide");
     checker.check(b"", false);
     checker.check(b"a", false);
     checker.check(b"a\0", false);
@@ -496,7 +496,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(b"b\ra\0", false);
 
     // Check word boundary in the middle
-    let checker = build_checker(r"<.+\bA\b.+>", "wide");
+    let mut checker = build_checker(r"<.+\bA\b.+>", "wide");
     checker.check(&to_wide(b""), false);
     checker.check(&to_wide(b"<>"), false);
     checker.check(&to_wide(b"<A>"), false);
@@ -512,7 +512,7 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(&to_wide(b"<a[AA.AAA]>"), false);
     checker.check(&to_wide(b"<a[AA>A.>"), true);
     checker.check(&to_wide(b"<a[AA>AA.>"), false);
-    let checker = build_checker(r"<.+\BA\B.+>", "wide");
+    let mut checker = build_checker(r"<.+\BA\B.+>", "wide");
     checker.check(&to_wide(b""), false);
     checker.check(&to_wide(b"<>"), false);
     checker.check(&to_wide(b"<A>"), false);
@@ -530,14 +530,14 @@ fn test_variable_regex_wide_word_boundaries() {
     checker.check(&to_wide(b"<a[AA>AA.>"), false);
 
     // Test word boundaries do not use unicode syntax
-    let checker = build_checker(r"<\w+\b.a>", "wide");
+    let mut checker = build_checker(r"<\w+\b.a>", "wide");
     checker.check(&to_wide(b"<ave|a>"), true);
     checker.check(&to_wide(b"<aveva>"), false);
     checker.check(&to_wide("<avéva>".as_bytes()), false);
     checker.check(&to_wide("<avé|a>".as_bytes()), false);
 
     // Test word boundaries inside a repetition, regression test
-    let checker = build_checker(r"<(c\b.a){2}>", "wide");
+    let mut checker = build_checker(r"<(c\b.a){2}>", "wide");
     checker.check(&to_wide(b"<c|ac.a>"), true);
     checker.check(&to_wide(b"<cbac.a>"), false);
     checker.check(&to_wide(b"<c|acba>"), false);
@@ -564,7 +564,7 @@ rule a {{
 
     // This works, because we recheck after the initial match, and the repetition is greedy, hence
     // the post match will only reduce the match.
-    let checker = build_checker(r"a.{0,4}\b", "");
+    let mut checker = build_checker(r"a.{0,4}\b", "");
     checker.check(b"z a", true);
     checker.check(b"zz a1", true);
     checker.check(b"zzz a12", true);
@@ -573,7 +573,7 @@ rule a {{
     checker.check(b"zzzzz a1234>", true);
     checker.check(b"zzzz a12>34", true);
     checker.check(b"zzzz a>>>34", true);
-    let checker = build_checker(r"a.{0,4}\b", "wide");
+    let mut checker = build_checker(r"a.{0,4}\b", "wide");
     checker.check(&to_wide(b"zz a"), true);
     checker.check(&to_wide(b"zzzz a1"), true);
     checker.check(&to_wide(b"zzzzzz a12"), true);
@@ -585,7 +585,7 @@ rule a {{
 
     // This works, because we include mmore than the initial match, so the post check can improve
     // the non greedy repetition until it finds a boundary.
-    let checker = build_checker(r"a.{0,4}?\b", "");
+    let mut checker = build_checker(r"a.{0,4}?\b", "");
     checker.check(b"z a", true);
     checker.check(b"zz a1", true);
     checker.check(b"zzz a12", true);
@@ -594,7 +594,7 @@ rule a {{
     checker.check(b"zzzzz a1234>", true);
     checker.check(b"zzz a12>34", true);
     checker.check(b"z a>>>34", true);
-    let checker = build_checker(r"a.{0,4}?\b", "wide");
+    let mut checker = build_checker(r"a.{0,4}?\b", "wide");
     checker.check(&to_wide(b"zz a"), true);
     checker.check(&to_wide(b"zzzz a1"), true);
     checker.check(&to_wide(b"zzzzzz a12"), true);
@@ -608,7 +608,7 @@ rule a {{
 #[test]
 fn test_variable_boundary_ac_confirm() {
     // Make sure the boundary is taken into account when confirming an ac match.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r"
 rule a {
     strings:
@@ -627,7 +627,7 @@ rule a {
 #[test]
 fn test_variable_string_wide_ascii() {
     // \x76 is 'v'
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -666,7 +666,7 @@ rule a {
     checker.check(b"Zbar:", false);
     checker.check(b"0bAR:", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -742,9 +742,9 @@ rule a {
     condition:
         any of them
 }"#;
-    let checker = Checker::new(rule);
+    let mut checker = Checker::new(rule);
 
-    let check_xor = |mem: &[u8], xor_byte: u8, expected_res: bool| {
+    let mut check_xor = |mem: &[u8], xor_byte: u8, expected_res: bool| {
         let mut out = Vec::new();
         out.extend(b"abc");
         out.extend(mem.iter().map(|c| c ^ xor_byte));
@@ -790,7 +790,7 @@ rule a {
 #[test]
 fn test_variable_string_xor_fullword() {
     // Test fullword with xor
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -802,13 +802,14 @@ rule a {
 }"#,
     );
 
-    let check_xor = |mem: &[u8], prefix: &[u8], suffix: &[u8], xor_byte: u8, expected_res: bool| {
-        let mut out = Vec::new();
-        out.extend(prefix);
-        out.extend(mem.iter().map(|c| c ^ xor_byte));
-        out.extend(suffix);
-        checker.check(&out, expected_res);
-    };
+    let mut check_xor =
+        |mem: &[u8], prefix: &[u8], suffix: &[u8], xor_byte: u8, expected_res: bool| {
+            let mut out = Vec::new();
+            out.extend(prefix);
+            out.extend(mem.iter().map(|c| c ^ xor_byte));
+            out.extend(suffix);
+            checker.check(&out, expected_res);
+        };
 
     // ascii xor fullword
     let mem = b"rykard";
@@ -876,7 +877,7 @@ fn base64_encode<T: AsRef<[u8]>>(s: T) -> Vec<u8> {
 
 #[test]
 fn test_variable_base64_small() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -906,7 +907,7 @@ rule a {
 
 #[test]
 fn test_variable_base64() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -969,7 +970,7 @@ rule a {
 
 #[test]
 fn test_variable_base64wide() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1053,7 +1054,7 @@ rule a {
 
 #[test]
 fn test_variable_base64_base64wide() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1179,7 +1180,7 @@ rule a {
 
 #[test]
 fn test_variable_find() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
         rule a {
             strings:
@@ -1195,7 +1196,7 @@ fn test_variable_find() {
     checker.check(b"1234678", false);
     checker.check(b"465", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
         rule a {
             strings:
@@ -1210,7 +1211,7 @@ fn test_variable_find() {
     checker.check(b"44", false);
     checker.check(b"4\n5", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
         rule a {
             strings:
@@ -1225,7 +1226,7 @@ fn test_variable_find() {
     checker.check(b"fo", false);
     checker.check(b"FO", false);
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
         rule a {
             strings:
@@ -1349,7 +1350,7 @@ fn test_variable_find_in_invalid() {
 
 #[test]
 fn test_variable_hex_string_masks() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1412,7 +1413,7 @@ rule a {
         )],
     );
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1465,7 +1466,7 @@ rule a {
 
 #[test]
 fn test_variable_hex_string_jumps() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1557,7 +1558,7 @@ rule a {
 
 #[test]
 fn test_variable_hex_string_alternations() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1620,7 +1621,7 @@ rule a {
 
 #[test]
 fn test_variable_hex_string_atoms() {
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1655,7 +1656,7 @@ rule a {
         )],
     );
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1700,7 +1701,7 @@ rule a {
 fn test_hex_string_atoms_multiple_matches() {
     // Define variables with the atom after some ungreedy repetitions.
     // This means that for one literal match, there might be multiple actual matches.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1766,7 +1767,7 @@ rule a {
     );
 
     // Do the same with greedy repetitions.
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1852,7 +1853,7 @@ rule a {
 fn test_variable_hex_string_negation() {
     let input = (0_u8..=255_u8).collect::<Vec<_>>();
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1876,7 +1877,7 @@ rule a {
         )],
     );
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1900,7 +1901,7 @@ rule a {
         )],
     );
 
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:
@@ -1928,7 +1929,7 @@ rule a {
 #[test]
 fn test_variable_no_literals() {
     // Test a var with no literals extracted
-    let checker = Checker::new(
+    let mut checker = Checker::new(
         r#"
 rule a {
     strings:


### PR DESCRIPTION
All scan methods now return a Result, with the error type being a tuple of the error and partial results. This will allows upgrading the ScanError with new errors related to process memory.