### PR TITLE
feat: Add tags and metadatas in MatchedRule details

### DIFF
--- a/boreal-parser/src/expression/for_expression.rs
+++ b/boreal-parser/src/expression/for_expression.rs
@@ -150,7 +150,7 @@ fn for_expression_kind(input: Input) -> ParseResult<ForExprKind> {
             preceded(rtrim(ttag("at")), cut(primary_expression)),
             |expr| ForExprKind::At(Box::new(expr)),
         ),
-        map(success(()), |_| ForExprKind::None),
+        map(success(()), |()| ForExprKind::None),
     ))(input)
 }
 

--- a/boreal-parser/src/file.rs
+++ b/boreal-parser/src/file.rs
@@ -64,7 +64,7 @@ pub struct Include {
 /// If the input cannot be parsed properly and entirely as a list
 /// of yara rules, an error is returned.
 pub(crate) fn parse_yara_file(input: Input) -> ParseResult<YaraFile> {
-    let (mut input, _) = ltrim(input)?;
+    let (mut input, ()) = ltrim(input)?;
 
     let mut file = YaraFile {
         components: Vec::new(),

--- a/boreal-parser/src/nom_recipes.rs
+++ b/boreal-parser/src/nom_recipes.rs
@@ -41,7 +41,7 @@ pub(crate) fn ltrim(mut input: Input) -> ParseResult<()> {
             value((), multispace1),
         ))(input)
         {
-            Ok((i, _)) => input = i,
+            Ok((i, ())) => input = i,
             Err(nom::Err::Error(_)) => return Ok((input, ())),
             err @ Err(_) => return err,
         }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -14,20 +14,20 @@ use crate::statistics;
 
 /// A compiled scanning rule.
 #[derive(Debug)]
-pub struct Rule {
+pub(crate) struct Rule {
     /// Name of the rule.
-    pub name: String,
+    pub(crate) name: String,
 
     /// Namespace containing the rule.
     ///
-    /// `None` if in the default namespace.
-    pub namespace: Option<String>,
+    /// [`None`] if in the default namespace.
+    pub(crate) namespace: Option<String>,
 
     /// Tags associated with the rule.
-    pub tags: Vec<String>,
+    pub(crate) tags: Vec<String>,
 
     /// Metadata associated with the rule.
-    pub metadatas: Vec<Metadata>,
+    pub(crate) metadatas: Vec<Metadata>,
 
     /// Number of variables used by the rule.
     pub(crate) nb_variables: usize,
@@ -35,7 +35,8 @@ pub struct Rule {
     /// Condition of the rule.
     pub(crate) condition: Expression,
 
-    pub is_private: bool,
+    /// Is the rule marked as private.
+    pub(crate) is_private: bool,
 }
 
 /// Object used to compile a rule.

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -95,5 +95,9 @@ pub mod scanner;
 pub use scanner::Scanner;
 pub mod statistics;
 
+// Re-exports those symbols since they are exposed in the results of a scan. This avoids
+// having to depend on boreal-parser simply to match on those metadatas.
+pub use boreal_parser::rule::{Metadata, MetadataValue};
+
 #[cfg(test)]
 mod test_helpers;

--- a/boreal/src/module/pe/debug.rs
+++ b/boreal/src/module/pe/debug.rs
@@ -41,7 +41,7 @@ pub fn pdb_path(data_dirs: &DataDirectories, mem: &[u8], sections: &SectionTable
         let mut info = Bytes(info);
         let sig = match info.read_bytes(4) {
             Ok(v) => v.0,
-            Err(_) => continue,
+            Err(()) => continue,
         };
 
         let pdb_path_offset = match sig {

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -460,8 +460,10 @@ fn build_matched_rule<'a>(
     }
 
     MatchedRule {
-        namespace: rule.namespace.as_deref(),
         name: &rule.name,
+        namespace: rule.namespace.as_deref(),
+        tags: &rule.tags,
+        metadatas: &rule.metadatas,
         matches: var_evals
             .into_iter()
             .filter(|eval| !eval.var.is_private)
@@ -525,11 +527,17 @@ impl<'scanner> ScanResult<'scanner> {
 /// Description of a rule that matched during a scan.
 #[derive(Debug)]
 pub struct MatchedRule<'scanner> {
+    /// Name of the rule.
+    pub name: &'scanner str,
+
     /// Namespace containing the rule. None if in the default namespace.
     pub namespace: Option<&'scanner str>,
 
-    /// Name of the rule.
-    pub name: &'scanner str,
+    /// Tags associated with the rule.
+    pub tags: &'scanner [String],
+
+    /// Metadata associated with the rule.
+    pub metadatas: &'scanner [boreal_parser::rule::Metadata],
 
     /// List of matched strings, with details on their matches.
     pub matches: Vec<StringMatches<'scanner>>,
@@ -1209,8 +1217,10 @@ mod tests {
             statistics: None,
         });
         test_type_traits_non_clonable(MatchedRule {
-            namespace: None,
             name: "a",
+            namespace: None,
+            tags: &[],
+            metadatas: &[],
             matches: Vec::new(),
         });
         test_type_traits_non_clonable(StringMatches {


### PR DESCRIPTION
Add tags and metadatas of matched rules in the scan results, instead of only the name and namespace.
They were saved for this purpose, but were not exposed by mistake.