### PR TITLE
Fix bug on validation of matches in fragmented memory

### DIFF
--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -321,7 +321,8 @@ impl Evaluator<'_, '_, '_> {
                             var_matches.find_match_occurence(var_index, v - 1)
                         })?;
 
-                        mat.and_then(|mat| i64::try_from(mat.offset).ok())
+                        mat.and_then(|mat| mat.offset.checked_add(mat.base))
+                            .and_then(|offset| i64::try_from(offset).ok())
                             .map(Value::Integer)
                             .ok_or(PoisonKind::Undefined)
                     }

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -52,9 +52,10 @@ impl<'a> VarMatches<'a> {
         // TODO: improve algorithm for searching in matches
         let mut count = 0;
         for mat in &self.matches[var_index] {
-            if mat.offset > to {
+            let mat_offset = mat.offset.saturating_add(mat.base);
+            if mat_offset > to {
                 return count;
-            } else if mat.offset >= from {
+            } else if mat_offset >= from {
                 count += 1;
             }
         }
@@ -66,7 +67,8 @@ impl<'a> VarMatches<'a> {
     pub fn find_at(&self, var_index: usize, offset: usize) -> bool {
         // TODO: improve algorithm for searching in matches
         for mat in &self.matches[var_index] {
-            match mat.offset.cmp(&offset) {
+            let mat_offset = mat.offset.saturating_add(mat.base);
+            match mat_offset.cmp(&offset) {
                 Ordering::Less => (),
                 Ordering::Equal => return true,
                 Ordering::Greater => return false,
@@ -80,9 +82,10 @@ impl<'a> VarMatches<'a> {
     pub fn find_in(&self, var_index: usize, from: usize, to: usize) -> bool {
         // TODO: improve algorithm for searching in matches
         for mat in &self.matches[var_index] {
-            if mat.offset > to {
+            let mat_offset = mat.offset.saturating_add(mat.base);
+            if mat_offset > to {
                 return false;
-            } else if mat.offset >= from {
+            } else if mat_offset >= from {
                 return true;
             }
         }

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -227,7 +227,13 @@ impl AcScan {
             // This is invalid, only one match per starting byte can happen.
             // To avoid this, ensure the mem given to check_ac_match starts one byte after the last
             // saved match.
-            let start_position = var_matches.last().map_or(0, |mat| mat.offset + 1);
+            //
+            // This must only be done if the match is in the same region, otherwise the offset
+            // of the previous match makes no sense for this match, and will falsify results.
+            let start_position = match var_matches.last() {
+                Some(mat) if mat.base == region.start => mat.offset + 1,
+                _ => 0,
+            };
 
             let res = var.process_ac_match(region.mem, m, start_position, match_type);
 

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -552,7 +552,7 @@ fn get_boreal_full_matches<'a>(res: &'a ScanResult<'a>) -> FullMatches<'a> {
                         str_match
                             .matches
                             .iter()
-                            .map(|m| (&*m.data, m.offset, m.length))
+                            .map(|m| (&*m.data, m.base + m.offset, m.length))
                             .collect(),
                     )
                 })


### PR DESCRIPTION
The optimization preventing quadratic validation of string matches was buggy when matches are on separate regions, when scanning fragmented memory. This is fixed by splitting the region base from the match offset in the string match, and using this base to validate which match to take into account when finding a bound for the reverse validator.