### PR TITLE
Remove once_cell dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,6 @@ dependencies = [
  "memchr",
  "memmap2",
  "object",
- "once_cell",
  "regex-automata",
  "regex-syntax",
  "sha1",
@@ -494,12 +493,6 @@ source = "git+https://github.com/vthib/boreal-object?branch=version-0.32#6576d42
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "peeking_take_while"

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -74,9 +74,5 @@ glob = "0.3.1"
 tempfile = "3.8"
 yara = { version = "0.21", features = ["vendored"] }
 
-# Only needed in tests because Mutex::new is not const
-# in 1.62 MSRV. Can be removed once MSRV is bumped above it.
-once_cell = "1.18"
-
 [package.metadata.docs.rs]
 features = ["authenticode", "memmap"]

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -79,8 +79,6 @@ use base64 as _;
 #[cfg(test)]
 use glob as _;
 #[cfg(test)]
-use once_cell as _;
-#[cfg(test)]
 use tempfile as _;
 #[cfg(test)]
 use yara as _;


### PR DESCRIPTION
Now that MSRV is 1.65, we can replace the once_cell dependency by using a standard mutex.