### PR TITLE
ci:  update vcpkg baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           appendedCacheKey: ${{matrix.vcpkg_triplet}}
           vcpkgDirectory: '${{ runner.workspace }}/vcpkg'
-          vcpkgGitCommitId: '163fe7bd3d67c41200617caaa245b5ba2ba854e6'
+          vcpkgGitCommitId: '4cac260c4b7331538d31886f57739fea0bffa27e'
           runVcpkgInstall: true
 
       - name: Export VCPKGRS_TRIPLET and OPENSSL_DIR env var

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,5 +8,5 @@
         "name": "openssl",
         "version-string": "1.1.1n"
     }],
-    "builtin-baseline": "163fe7bd3d67c41200617caaa245b5ba2ba854e6"
+    "builtin-baseline": "4cac260c4b7331538d31886f57739fea0bffa27e"
 }


### PR DESCRIPTION
Looks like vcpkg based builds are starting to fail:

https://github.com/vthib/boreal/actions/runs/7040069300/

Lets update the vcpkg repo to see if it fixes things.