### PR TITLE
Improve linux process scan using pagemap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,7 @@ dependencies = [
  "crc32fast",
  "glob",
  "hex",
+ "libc",
  "md-5",
  "memchr",
  "memmap2",

--- a/boreal-test-helpers/src/main.rs
+++ b/boreal-test-helpers/src/main.rs
@@ -15,6 +15,7 @@ fn main() {
         "stack" => stack(),
         "max_fetched_region_size" => max_fetched_region_size(),
         "memory_chunk_size" => memory_chunk_size(),
+        "file_copy_on_write" => file_copy_on_write(),
         _ => panic!("unknown arg {}", arg),
     }
 }
@@ -100,6 +101,37 @@ fn memory_chunk_size() {
     std::thread::sleep(std::time::Duration::from_secs(500));
 }
 
+fn file_copy_on_write() {
+    // Bad pattern, must not be matched
+    let bad = b"]NbJ{m^iYJ";
+    // Good pattern, must be matched
+    let good = b"|{j<Lk6[j7";
+
+    // Create a file, and write "RAmEtbQfVE" in it
+    let mut contents = vec![0; 4 * 4096];
+    xor_bytes_into(bad, 15, &mut contents[2048..2058]);
+    // Map at offset 500
+    let mut region1 = Region::copy_on_write(contents, 500);
+    // overwrite what is written in it to write "ste3Cd9Te8"
+    region1.write_at(2048 - 500, good);
+
+    // New file, with:
+    // - the good pattern at 1000
+    // - the bad pattern at 4096 - 5 (between two pages)
+    // Send the base addresses of the region back to the test
+    let mut contents = vec![0; 2 * 4096];
+    xor_bytes_into(good, 15, &mut contents[1000..1010]);
+    xor_bytes_into(bad, 15, &mut contents[4091..5001]);
+    let mut region2 = Region::copy_on_write(contents, 0);
+    region2.write_at(4091, good);
+
+    println!("{:x}", region1.addr());
+    println!("{:x}", region2.addr());
+
+    println!("ready");
+    std::thread::sleep(std::time::Duration::from_secs(500));
+}
+
 impl Region {
     fn new(contents: &[u8]) -> Self {
         let mut this = Self::zeroed(contents.len());
@@ -112,6 +144,26 @@ impl Region {
         let contents = vec![0; size];
         file.write_all(&contents).unwrap();
         let map = unsafe { memmap2::MmapMut::map_mut(file.as_file()).unwrap() };
+
+        Self { _file: file, map }
+    }
+
+    fn copy_on_write(mut contents: Vec<u8>, offset: u64) -> Self {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&contents).unwrap();
+
+        // Erase contents to not let it live in our RAM.
+        for b in &mut contents {
+            *b = 0;
+        }
+        drop(contents);
+
+        let map = unsafe {
+            memmap2::MmapOptions::new()
+                .offset(offset)
+                .map_copy(file.as_file())
+                .unwrap()
+        };
 
         Self { _file: file, map }
     }

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -68,6 +68,9 @@ authenticode-parser = { version = "0.3", optional = true }
 # "memmap" feature
 memmap2 = { version = "0.9", optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.48", features = [
     "Win32_Foundation",

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -56,15 +56,6 @@ impl Memory<'_> {
         }
     }
 
-    /// True if all the memory is readily available.
-    #[must_use]
-    pub fn is_direct(&self) -> bool {
-        match self {
-            Self::Direct(_) => true,
-            Self::Fragmented { .. } => false,
-        }
-    }
-
     /// Returns the byte slice of the whole scanned memory if available.
     #[must_use]
     pub fn get_direct(&self) -> Option<&[u8]> {

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -145,7 +145,7 @@ pub trait FragmentedMemory: Send + Sync + std::fmt::Debug {
 }
 
 /// A description of a region of memory to scan.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct RegionDescription {
     /// Index of the start of the region.
     pub start: usize,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -357,7 +357,7 @@ impl Inner {
                     scan_data.params.process_memory,
                 );
 
-                if !scan_data.params.compute_full_matches && scan_data.mem.is_direct() {
+                if !scan_data.params.compute_full_matches {
                     #[cfg(feature = "profiling")]
                     let start = std::time::Instant::now();
 

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -152,6 +152,9 @@ impl ScanParams {
     /// tweaking the [`ScanParams::memory_chunk_size`] parameter, to bound
     /// memory consumption while still ensuring every byte is scanned.
     ///
+    /// Please note that this value may be adjusted to ensure it is a
+    /// multiple of the page size.
+    ///
     /// By default, this parameter is set to 1GB.
     #[must_use]
     pub fn max_fetched_region_size(mut self, max_fetched_region_size: usize) -> Self {
@@ -187,6 +190,9 @@ impl ScanParams {
     /// scanning for the string `boreal`, if one chunk ends with
     /// `bor`, and the next one starts with `eal`, the string will
     /// **not** match.
+    ///
+    /// Please note that, if set, this value may be adjusted to ensure it
+    /// is a multiple of the page size.
     ///
     /// By default, this parameter is unset.
     #[must_use]

--- a/boreal/src/scanner/process/sys/linux.rs
+++ b/boreal/src/scanner/process/sys/linux.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::memory::{FragmentedMemory, MemoryParams, Region, RegionDescription};
 use crate::scanner::ScanError;
@@ -8,7 +8,6 @@ use crate::scanner::ScanError;
 pub fn process_memory(pid: u32) -> Result<Box<dyn FragmentedMemory>, ScanError> {
     let proc_pid_path = Path::new("/proc").join(pid.to_string());
 
-    // TODO: improve errors by at least detecting ENOTFOUND for unknown pid
     let mem_file = File::open(proc_pid_path.join("mem")).map_err(open_error_to_scan_error)?;
 
     // Use /proc/pid/maps to list the memory regions to scan.
@@ -23,28 +22,77 @@ pub fn process_memory(pid: u32) -> Result<Box<dyn FragmentedMemory>, ScanError> 
     }))
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct MapLine {
+    start: usize,
+    length: usize,
+    dev_major: u32,
+    dev_minor: u32,
+    inode: u64,
+    offset: u64,
+    path: Option<PathBuf>,
+}
+
 // Parse a line from the /proc/pid/maps file.
-fn parse_map_line(line: &str) -> Option<RegionDescription> {
+fn parse_map_line(line: &str) -> Option<MapLine> {
     // See man proc(5). Each line is:
     //
     // <start addr>-<end addr> <perms> <offset> <dev-major>:<dev-minor> <inode> <pathname>
-    let mut splits = line.split_whitespace();
+    //
+    // We cannot use split_whitespace here, since the path can contain spaces and
+    // this method do not allow taking the rest of the string.
+    // Once https://doc.rust-lang.org/std/str/struct.SplitWhitespace.html#method.remainder is
+    // stable, it could be used.
+    // Instead, we used "split_once" as many times as possible, trimming the rest to remove extra
+    // whitespaces. It is a bit ugly but it works fine.
+    let mut rest = line;
+    let mut next_elem = || {
+        let (elem, next) = rest.split_once(' ')?;
+        rest = next.trim_start();
+        Some(elem)
+    };
 
-    let mut addrs = splits.next()?.split('-');
+    let mut addrs = next_elem()?.split('-');
     let start_addr = addrs.next()?;
     let start_addr = usize::from_str_radix(start_addr, 16).ok()?;
     let end_addr = addrs.next()?;
     let end_addr = usize::from_str_radix(end_addr, 16).ok()?;
 
-    let perms = splits.next()?;
+    let perms = next_elem()?;
     if !perms.starts_with('r') {
         // Region is not readable, so ignore.
         return None;
     }
 
-    Some(RegionDescription {
+    let offset = next_elem()?;
+    let offset = u64::from_str_radix(offset, 16).ok()?;
+
+    let mut device = next_elem()?.split(':');
+    let dev_major: u32 = device.next()?.parse().ok()?;
+    let dev_minor: u32 = device.next()?.parse().ok()?;
+
+    let (inode, path) = match next_elem() {
+        Some(inode) => {
+            let inode: u64 = inode.parse().ok()?;
+            // Rest of the string may be empty, a special name that looks like `[...]`, or a path.
+            let path = rest.starts_with('/').then(|| PathBuf::from(rest.trim()));
+            (inode, path)
+        }
+        // Not space left in the string, so the rest is only the inode
+        None => {
+            let inode: u64 = rest.parse().ok()?;
+            (inode, None)
+        }
+    };
+
+    Some(MapLine {
         start: start_addr,
         length: end_addr.checked_sub(start_addr)?,
+        dev_major,
+        dev_minor,
+        inode,
+        offset,
+        path,
     })
 }
 
@@ -67,7 +115,7 @@ struct LinuxProcessMemory {
     buffer: Vec<u8>,
 
     // Current position: current region and offset in the region of the current chunk.
-    current_position: Option<(RegionDescription, usize)>,
+    current_position: Option<(MapLine, usize)>,
 
     // Current region returned by the next call, which needs to be fetched.
     region: Option<RegionDescription>,
@@ -76,11 +124,11 @@ struct LinuxProcessMemory {
 impl LinuxProcessMemory {
     fn next_position(&mut self, params: &MemoryParams) {
         if let Some(chunk_size) = params.memory_chunk_size {
-            if let Some((desc, mut offset)) = self.current_position {
-                offset = offset.saturating_add(chunk_size);
-                if offset < desc.length {
+            if let Some((desc, offset)) = &mut self.current_position {
+                let new_offset = offset.saturating_add(chunk_size);
+                if new_offset < desc.length {
                     // Region has a next chunk, so simply select it.
-                    self.current_position = Some((desc, offset));
+                    *offset = new_offset;
                     return;
                 }
             }
@@ -111,15 +159,19 @@ impl FragmentedMemory for LinuxProcessMemory {
     fn next(&mut self, params: &MemoryParams) -> Option<RegionDescription> {
         self.next_position(params);
 
-        self.region = self
-            .current_position
-            .map(|(desc, offset)| match params.memory_chunk_size {
-                Some(chunk_size) => RegionDescription {
-                    start: desc.start.saturating_add(offset),
-                    length: std::cmp::min(chunk_size, desc.length),
-                },
-                None => desc,
-            });
+        self.region =
+            self.current_position
+                .as_ref()
+                .map(|(desc, offset)| match params.memory_chunk_size {
+                    Some(chunk_size) => RegionDescription {
+                        start: desc.start.saturating_add(*offset),
+                        length: std::cmp::min(chunk_size, desc.length),
+                    },
+                    None => RegionDescription {
+                        start: desc.start,
+                        length: desc.length,
+                    },
+                });
         self.region
     }
 
@@ -152,5 +204,97 @@ mod tests {
     fn test_types_traits() {
         let memory = process_memory(std::process::id()).unwrap();
         test_type_traits_non_clonable(memory);
+        test_type_traits_non_clonable(MapLine {
+            start: 0,
+            length: 0,
+            dev_major: 0,
+            dev_minor: 0,
+            inode: 0,
+            offset: 0,
+            path: None,
+        });
+    }
+
+    #[test]
+    fn test_parse_maps() {
+        assert_eq!(
+            parse_map_line(
+                "00400000-00452000 r-xp 00051000 08:02 173521      /usr/bin/dbus-daemon"
+            ),
+            Some(MapLine {
+                start: 0x40_00_00,
+                length: 0x05_20_00,
+                dev_major: 8,
+                dev_minor: 2,
+                inode: 173_521,
+                offset: 0x05_10_00,
+                path: Some(PathBuf::from("/usr/bin/dbus-daemon")),
+            })
+        );
+        // Test with a special name that isn't a path
+        assert_eq!(
+            parse_map_line("00e03000-00e24000 rw-p 00000000 00:00 0           [heap]",),
+            Some(MapLine {
+                start: 0xe0_30_00,
+                length: 0x02_10_00,
+                dev_major: 0,
+                dev_minor: 0,
+                inode: 0,
+                offset: 0,
+                path: None,
+            })
+        );
+        // Test with a path containing spaces
+        assert_eq!(
+            parse_map_line(
+                "7f122cd4-7f123cd4  r--p  0002c000   08:10    \
+                 37209  /usr/lib/x86_64 linux gnu/ld-2.31.so\n"
+            ),
+            Some(MapLine {
+                start: 0x7f_12_2c_d4,
+                length: 0x10_00,
+                dev_major: 8,
+                dev_minor: 10,
+                inode: 37_209,
+                offset: 0x2c000,
+                path: Some(PathBuf::from("/usr/lib/x86_64 linux gnu/ld-2.31.so")),
+            })
+        );
+        // Test with no special name or path
+        assert_eq!(
+            parse_map_line("7f122cd4-7f123cd4 r--p 0002c000 08:10 37209"),
+            Some(MapLine {
+                start: 0x7f_12_2c_d4,
+                length: 0x10_00,
+                dev_major: 8,
+                dev_minor: 10,
+                inode: 37_209,
+                offset: 0x2c000,
+                path: None,
+            })
+        );
+
+        // If the region is not readable, it's not returned.
+        assert_eq!(
+            parse_map_line("7f122cd4-7f123cd4 ---p 0002c000 08:10 37209"),
+            None
+        );
+
+        // Error cases
+        assert_eq!(parse_map_line(""), None);
+        assert_eq!(parse_map_line(" "), None);
+        assert_eq!(parse_map_line("00400000 00452000"), None);
+        assert_eq!(parse_map_line("0040000g-00452000 r-xp"), None);
+        assert_eq!(parse_map_line("00400000-0045200g r-xp"), None);
+        assert_eq!(parse_map_line("00400000-00452000 "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp g "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 12 "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 a:2 "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 1:a "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 1:2 "), None);
+        assert_eq!(parse_map_line("00400000-00452000 r-xp 0 1:2 g "), None);
+        assert_eq!(parse_map_line("2-1 r--p 0002c000 08:10 37209"), None);
     }
 }

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -320,6 +320,23 @@ impl Checker {
     }
 
     #[track_caller]
+    pub fn check_process_full_matches(&mut self, pid: u32, expected: FullMatches) {
+        // We need to compute the full matches for this test
+        {
+            let mut scanner = self.scanner.clone();
+            scanner.set_scan_params(scanner.scan_params().clone().compute_full_matches(true));
+            let res = scanner.scan_process(pid).unwrap();
+            let res = get_boreal_full_matches(&res);
+            assert_eq!(res, expected, "test failed for boreal");
+        }
+
+        if let Some(rules) = &self.yara_rules {
+            let res = rules.scan_process(pid, 1).unwrap();
+            check_yara_full_matches(&res, expected);
+        }
+    }
+
+    #[track_caller]
     pub fn check_boreal(&mut self, mem: &[u8], expected_res: bool) {
         let res = self.scan_mem(mem);
         let res = !res.matched_rules.is_empty();


### PR DESCRIPTION
Read memory from the file backing the region if possible, reading from proc mem when the page has been modified by the process.