### PR TITLE
Add fragmented scan mode parameter

### DIFF
--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -782,3 +782,20 @@ rule logger {
         .stderr("")
         .success();
 }
+
+#[test]
+fn test_invalid_fragmented_scan_mode() {
+    // Invalid path to rule
+    cmd()
+        .arg("--fragmented-scan-mode")
+        .arg("bad_value")
+        .arg("rules.yar")
+        .arg("input")
+        .assert()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "invalid value 'bad_value' for \
+            '--fragmented-scan-mode <legacy|fast|singlepass>\': invalid value",
+        ))
+        .failure();
+}

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -115,10 +115,12 @@
 // Do the same for clippy
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
+// Allow some useless pedantic lints
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::range_plus_one)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::single_match_else)]
+#![allow(clippy::struct_field_names)]
 #![deny(clippy::cargo)]
 
 // Parsing uses the [`nom`] crate, adapted for textual parsing.

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -56,15 +56,15 @@
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::undocumented_unsafe_blocks)]
+// Allow some useless pedantic lints
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::unnested_or_patterns)]
 #![allow(clippy::match_same_arms)]
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::single_match_else)]
 #![allow(clippy::inline_always)]
-// Completely useless lint
+#![allow(clippy::struct_field_names)]
 #![allow(clippy::struct_excessive_bools)]
-// Would be nice to not need this, thanks macho module
 #![allow(unsafe_code)]
 #![deny(missing_docs)]
 #![deny(clippy::cargo)]

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -37,6 +37,12 @@ pub struct MemoryParams {
     /// See [`crate::scanner::ScanParams::memory_chunk_size`]
     /// for more details.
     pub memory_chunk_size: Option<usize>,
+
+    /// Regions can be fetched multiple times.
+    ///
+    /// See [`crate::scanner::FragmentedScanMode`]
+    /// for more details.
+    pub can_refetch_regions: bool,
 }
 
 impl<'a> Memory<'a> {
@@ -86,6 +92,10 @@ impl Memory<'_> {
                 }
             }
             Self::Fragmented(fragmented) => {
+                if !fragmented.params.can_refetch_regions {
+                    return None;
+                }
+
                 fragmented.obj.reset();
                 while let Some(region) = fragmented.obj.next(&fragmented.params) {
                     let Some(relative_start) = start.checked_sub(region.start) else {
@@ -199,6 +209,7 @@ mod tests {
         test_type_traits_non_clonable(MemoryParams {
             max_fetched_region_size: 0,
             memory_chunk_size: None,
+            can_refetch_regions: false,
         });
         test_type_traits_non_clonable(DummyFragmented);
         test_type_traits_non_clonable(Fragmented {
@@ -206,6 +217,7 @@ mod tests {
             params: MemoryParams {
                 max_fetched_region_size: 0,
                 memory_chunk_size: None,
+                can_refetch_regions: false,
             },
         });
     }

--- a/boreal/src/module/macho.rs
+++ b/boreal/src/module/macho.rs
@@ -759,7 +759,7 @@ impl MachO {
             }
 
             let entry_point = file.entry_point?;
-            return file.arch_offset.saturating_add(entry_point).try_into().ok();
+            return Some(file.arch_offset.saturating_add(entry_point).into());
         }
         None
     }

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -660,15 +660,18 @@ impl Type {
     }
 }
 
+/// Error converting into a [`Value`].
+pub struct ValueTryFromError;
+
 macro_rules! try_from_value {
     ($ty:ty, $name:ident) => {
         impl TryFrom<Value> for $ty {
-            type Error = ();
+            type Error = ValueTryFromError;
 
-            fn try_from(value: Value) -> Result<$ty, ()> {
+            fn try_from(value: Value) -> Result<$ty, Self::Error> {
                 match value {
                     Value::$name(v) => Ok(v),
-                    _ => Err(()),
+                    _ => Err(ValueTryFromError),
                 }
             }
         }

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -2000,7 +2000,7 @@ impl Pe {
 
         // Finally, add the filesize
         #[allow(clippy::cast_possible_truncation)]
-        (csum as usize).wrapping_add(mem.len()).try_into().ok()
+        Some((csum as usize).wrapping_add(mem.len()).into())
     }
 
     fn section_index(ctx: &mut EvalContext, args: Vec<Value>) -> Option<Value> {
@@ -2014,7 +2014,7 @@ impl Pe {
                 .sections
                 .iter()
                 .position(|sec| sec.name == section_name)
-                .and_then(|v| v.try_into().ok()),
+                .map(Into::into),
             Value::Integer(addr) => {
                 let index = if ctx.process_memory {
                     data.sections.iter().position(|sec| {
@@ -2027,7 +2027,7 @@ impl Pe {
                     })?
                 };
 
-                index.try_into().ok()
+                Some(index.into())
             }
             _ => None,
         }
@@ -2098,7 +2098,7 @@ impl Pe {
             _ => return None,
         };
 
-        res.try_into().ok()
+        Some(res.into())
     }
 
     fn imports(ctx: &mut EvalContext, args: Vec<Value>) -> Option<Value> {
@@ -2123,7 +2123,7 @@ impl Pe {
                 ))
             }
             (Value::Bytes(dll_name), None, None) => {
-                data.nb_functions(&dll_name, false).try_into().ok()
+                Some(data.nb_functions(&dll_name, false).into())
             }
             (Value::Regex(dll_name), Some(Value::Regex(function_name)), None) => Some(
                 data.nb_functions_regex(&dll_name, &function_name, false)
@@ -2181,7 +2181,7 @@ impl Pe {
                 if flags & (ImportType::Delayed as i64) != 0 {
                     res += data.nb_functions(&dll_name, true);
                 }
-                res.try_into().ok()
+                Some(res.into())
             }
             (
                 Value::Integer(flags),
@@ -2195,7 +2195,7 @@ impl Pe {
                 if flags & (ImportType::Delayed as i64) != 0 {
                     res += data.nb_functions_regex(&dll_name, &function_name, true);
                 }
-                res.try_into().ok()
+                Some(res.into())
             }
             _ => None,
         }
@@ -2291,7 +2291,7 @@ impl Pe {
             _ => return None,
         };
 
-        res.try_into().ok()
+        Some(res.into())
     }
 
     fn rich_signature_toolid(ctx: &mut EvalContext, args: Vec<Value>) -> Option<Value> {
@@ -2309,7 +2309,7 @@ impl Pe {
             _ => return None,
         };
 
-        res.try_into().ok()
+        Some(res.into())
     }
 
     #[cfg(feature = "hash")]

--- a/boreal/src/module/pe/signatures.rs
+++ b/boreal/src/module/pe/signatures.rs
@@ -113,7 +113,7 @@ fn countersig_to_value(countersig: &Countersignature) -> Value {
 fn get_legacy_signer_data(sig: &Authenticode) -> HashMap<&'static str, Value> {
     sig.signer()
         .as_ref()
-        .and_then(|signer| signer.certificate_chain().get(0))
+        .and_then(|signer| signer.certificate_chain().first())
         .map(|v| cert_to_map(v, true))
         .unwrap_or_default()
 }

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -24,6 +24,9 @@ pub struct ScanParams {
     /// This requires the `profiling` feature.
     pub(crate) compute_statistics: bool,
 
+    /// Scanning mode of fragmented memory.
+    pub(crate) fragmented_scan_mode: FragmentedScanMode,
+
     /// Scanned bytes are part of a process memory.
     pub(crate) process_memory: bool,
 
@@ -32,6 +35,171 @@ pub struct ScanParams {
 
     /// Size of memory chunks to scan.
     pub(crate) memory_chunk_size: Option<usize>,
+}
+
+/// Scan mode to use on fragmented memory, including process scanning.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub struct FragmentedScanMode {
+    /// Modules can parse scanned memory to generate dynamic values.
+    ///
+    /// If true, some modules (pe, elf, macho, etc) will parse
+    /// each region to generate dynamic values. For example, the pe
+    /// module will parse each region to detect which region
+    /// contains a PE header, and generate dynamic values accordingly
+    /// once found.
+    ///
+    /// Generally, these module will stop parsing regions once a
+    /// region matching their filetype is found, but their behavior
+    /// can differ.
+    ///
+    /// Enabling this parameter disables the no-scan optimization.
+    pub(crate) modules_dynamic_values: bool,
+
+    /// Regions can be fetched multiple times.
+    ///
+    /// If true, conditions that uses offsets into the scanned memory
+    /// can be evaluated, and may thus cause refetches of regions.
+    ///
+    /// If false, regions are fetched only once: to scan for strings
+    /// occurrences, as well as possibly evaluate modules dynamic
+    /// values.
+    ///
+    /// Enabling this parameter disables the no-scan optimization.
+    pub(crate) can_refetch_regions: bool,
+}
+
+impl FragmentedScanMode {
+    /// Legacy mode, i.e. same behavior as YARA.
+    ///
+    /// This mode ensures that the behavior is identical to a scan
+    /// done by libyara, and is set as the default for this reason.
+    /// However, the legacy behavior tends to actually be quite
+    /// surprising compared to initial expectations.
+    ///
+    /// In this mode:
+    /// - String scanning is done on each region, and results are
+    ///   accumulated.
+    /// - File scanning modules (PE, ELF, etc) parses each region
+    ///   until one region matches, then ignores the subsequent
+    ///   regions.
+    /// - Conditions that depend on offsets will trigger new
+    ///   fetches of data. For example, use of `uint32(offset)`
+    ///   or `hash.md5sum(offset, length)` will cause a new
+    ///   fetch of this data, separate from the fetch done
+    ///   for string scanning. This **can** add up if many
+    ///   such conditions are used, causing higher memory usage
+    ///   and longer scan durations.
+    /// - The filesize condition is undefined.
+    ///
+    /// In addition, the no-scan optimization is disabled in
+    /// this mode.
+    #[must_use]
+    pub fn legacy() -> Self {
+        Self {
+            modules_dynamic_values: true,
+            can_refetch_regions: true,
+        }
+    }
+
+    /// Fast mode.
+    ///
+    /// In this mode, most of the more surprising or ill-defined
+    /// semantics of the legacy mode are updated to guarantee
+    /// a faster scan. This includes disabling additional fetches
+    /// of data as well as disabling file scanning modules.
+    ///
+    /// In this mode:
+    /// - String scanning is done on each region, and results are
+    ///   accumulated.
+    /// - File scanning modules (PE, ELF, etc) do not
+    ///   scan the regions, so they act as if they did not parse
+    ///   a compatible file.
+    /// - Conditions that depend on offsets evaluate to undefined.
+    ///   For example, use of `uint32(offset)`
+    ///   or `hash.md5sum(offset, length)` will evaluate to
+    ///   the undefined value.
+    /// - The filesize condition is undefined.
+    ///
+    /// The no-scan optimization is enabled in this mode.
+    #[must_use]
+    pub fn fast() -> Self {
+        Self {
+            modules_dynamic_values: false,
+            can_refetch_regions: false,
+        }
+    }
+
+    /// Single-pass mode.
+    ///
+    /// In this mode, a single pass on the regions is guaranteed,
+    /// ensuring that each region is fetched only once. This
+    /// means scanning time should scale according to both the
+    /// number of strings and the sizes of the scanned data,
+    /// without risking pathological scanning times due to some
+    /// rules triggering refetches of memory regions.
+    ///
+    /// This mode has the same semantics as the legacy mode, but
+    /// conditions depending on offsets in the scanned data will
+    /// all evaluate to undefined.
+    ///
+    /// In this mode:
+    /// - String scanning is done on each region, and results are
+    ///   accumulated.
+    /// - File scanning modules (PE, ELF, etc) parses each region
+    ///   until one region matches, then ignores the subsequent
+    ///   regions.
+    /// - Conditions that depend on offsets evaluate to undefined.
+    ///   For example, use of `uint32(offset)`
+    ///   or `hash.md5sum(offset, length)` will evaluate to
+    ///   the undefined value.
+    /// - The filesize condition is undefined.
+    ///
+    /// The no-scan optimization is disabled in this mode.
+    #[must_use]
+    pub fn single_pass() -> Self {
+        Self {
+            modules_dynamic_values: true,
+            can_refetch_regions: false,
+        }
+    }
+
+    // Independent mode.
+    //
+    // In this mode, each region is scanned independently, as
+    // if [`crate::Scanner::scan_mem`] was called on each region.
+    // The semantics are thus identical to a direct memory scan.
+    // However, the match results are accumulated, so that if a
+    // rule matches on multiple regions, it will be returned
+    // multiple times.
+    //
+    // In this mode, the no-scan optimization is enabled.
+    //
+    // This mode can be faster than the legacy one, thanks to the
+    // fact that the no-scan optimization is enabled, and that
+    // there is no additional fetch of the data done during the
+    // evaluation of conditions.
+    // In legacy mode:
+    // - String scanning is done on each region, and results are
+    //   accumulated.
+    // - File scanning modules (PE, ELF, etc) parses each region
+    //   until one region matches, then ignores the subsequent
+    //   regions.
+    // - Conditions that depend on offsets will trigger new
+    //   fetches of data. For example, use of `uint32(offset)`
+    //   or `hash.md5sum(offset, length)` will cause a new
+    //   fetch of this data, separate from the fetch done
+    //   for string scanning. This **can** add up if many
+    //   such conditions are used, causing higher memory usage
+    //   and longer scan durations.
+    // - The filesize condition is undefined.
+    // TODO
+    // fn independent() -> Self {
+    //     Self {
+    //         independent: true,
+    //         modules_dynamic_values: true,
+    //         conditions_can_refetch_regions: true,
+    //     }
+    // }
 }
 
 impl Default for ScanParams {
@@ -45,6 +213,7 @@ impl Default for ScanParams {
             process_memory: false,
             max_fetched_region_size: 1024 * 1024 * 1024,
             memory_chunk_size: None,
+            fragmented_scan_mode: FragmentedScanMode::legacy(),
         }
     }
 }
@@ -201,6 +370,18 @@ impl ScanParams {
         self
     }
 
+    /// Scan mode on fragmented memory, including process memory.
+    ///
+    /// This parameter configures how fragmented memory is scanned.
+    /// See [`FragmentedScanMode`] for more details.
+    ///
+    /// By default, this parameter uses the legacy scan mode.
+    #[must_use]
+    pub fn fragmented_scan_mode(mut self, mode: FragmentedScanMode) -> Self {
+        self.fragmented_scan_mode = mode;
+        self
+    }
+
     /// Returns whether full matches are computed on matching rules.
     #[must_use]
     pub fn get_compute_full_matches(&self) -> bool {
@@ -249,10 +430,17 @@ impl ScanParams {
         self.memory_chunk_size
     }
 
+    /// Returns the scan mode for fragmented memory.
+    #[must_use]
+    pub fn get_fragmented_scan_mode(&self) -> FragmentedScanMode {
+        self.fragmented_scan_mode
+    }
+
     pub(crate) fn to_memory_params(&self) -> MemoryParams {
         MemoryParams {
             max_fetched_region_size: self.max_fetched_region_size,
             memory_chunk_size: self.memory_chunk_size,
+            can_refetch_regions: self.fragmented_scan_mode.can_refetch_regions,
         }
     }
 }
@@ -294,5 +482,11 @@ mod tests {
 
         let params = params.memory_chunk_size(Some(200));
         assert_eq!(params.get_memory_chunk_size(), Some(200));
+
+        let params = params.fragmented_scan_mode(FragmentedScanMode::fast());
+        assert_eq!(
+            params.get_fragmented_scan_mode(),
+            FragmentedScanMode::fast()
+        );
     }
 }

--- a/boreal/src/scanner/process/sys/linux.rs
+++ b/boreal/src/scanner/process/sys/linux.rs
@@ -576,6 +576,7 @@ mod tests {
         let mut params = MemoryParams {
             max_fetched_region_size: 500,
             memory_chunk_size: None,
+            can_refetch_regions: false,
         };
         assert_eq!(
             region.region_description(&params, 0x1000),


### PR DESCRIPTION
Add different modes of scanning for fragmented memory. This explicits the behavior of the scan to make it less magical, and exposes options for faster scans.