### PR TITLE
Add many options to boreal-cli

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -144,6 +144,14 @@ fn build_command() -> Command {
                 .help("Print rule tags"),
         )
         .arg(
+            Arg::new("identifier")
+                .short('i')
+                .long("identifier")
+                .value_name("IDENTIFIER")
+                .value_parser(value_parser!(String))
+                .help("Print only rules with the given name"),
+        )
+        .arg(
             Arg::new("tag")
                 .short('t')
                 .long("tag")
@@ -366,6 +374,7 @@ struct ScanOptions {
     print_string_length: bool,
     print_tags: bool,
     no_mmap: bool,
+    identifier: Option<String>,
     tag: Option<String>,
 }
 
@@ -381,6 +390,7 @@ impl ScanOptions {
             } else {
                 false
             },
+            identifier: args.get_one("identifier").cloned(),
             tag: args.get_one("tag").cloned(),
         }
     }
@@ -443,6 +453,11 @@ fn display_scan_results(res: ScanResult, what: &str, options: &ScanOptions) {
 
     // Then, print matching rules.
     for rule in res.matched_rules {
+        if let Some(id) = options.identifier.as_ref() {
+            if rule.name != id {
+                continue;
+            }
+        }
         if let Some(tag) = options.tag.as_ref() {
             if rule.tags.iter().all(|t| t != tag) {
                 continue;
@@ -683,6 +698,7 @@ mod tests {
             print_string_length: false,
             print_tags: false,
             no_mmap: false,
+            identifier: None,
             tag: None,
         });
         test_non_clonable(Input::Process(32));

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -181,6 +181,13 @@ fn build_command() -> Command {
                 .value_name("SECONDS")
                 .value_parser(value_parser!(u64))
                 .help("Set the timeout duration before scanning is aborted"),
+        )
+        .arg(
+            Arg::new("no_warnings")
+                .short('w')
+                .long("no-warnings")
+                .action(ArgAction::SetTrue)
+                .help("Do not print warnings"),
         );
 
     if cfg!(feature = "memmap") {
@@ -246,8 +253,10 @@ fn main() -> ExitCode {
 
         match compiler.add_rules_file(rules_file) {
             Ok(status) => {
-                for warn in status.warnings() {
-                    display_diagnostic(rules_file, warn);
+                if !args.get_flag("no_warnings") {
+                    for warn in status.warnings() {
+                        display_diagnostic(rules_file, warn);
+                    }
                 }
                 for rule_stat in status.statistics() {
                     display_rule_stats(rule_stat);

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -114,6 +114,13 @@ fn build_command() -> Command {
                 .help("Specify scan mode for fragmented memory (e.g. process scanning)"),
         )
         .arg(
+            Arg::new("print_namespace")
+                .short('e')
+                .long("print-namespace")
+                .action(ArgAction::SetTrue)
+                .help("Print rule namespace"),
+        )
+        .arg(
             Arg::new("print_strings")
                 .short('s')
                 .long("print-strings")
@@ -402,6 +409,7 @@ struct ScanOptions {
     print_strings_matches_data: bool,
     print_string_length: bool,
     print_metadata: bool,
+    print_namespace: bool,
     print_tags: bool,
     no_mmap: bool,
     identifier: Option<String>,
@@ -415,6 +423,7 @@ impl ScanOptions {
             print_strings_matches_data: args.get_flag("print_strings"),
             print_string_length: args.get_flag("print_string_length"),
             print_metadata: args.get_flag("print_metadata"),
+            print_namespace: args.get_flag("print_namespace"),
             print_tags: args.get_flag("print_tags"),
             no_mmap: if cfg!(feature = "memmap") {
                 args.get_flag("no_mmap")
@@ -495,7 +504,10 @@ fn display_scan_results(res: ScanResult, what: &str, options: &ScanOptions) {
             }
         }
 
-        // <rulename> [<ruletags>] <matched object>
+        // <rule_namespace>:<rule_name> [<ruletags>] <matched object>
+        if options.print_namespace {
+            print!("{}:", rule.namespace.unwrap_or("default"));
+        }
         print!("{}", &rule.name);
         if options.print_tags {
             print!(" [{}]", rule.tags.join(","));
@@ -759,6 +771,7 @@ mod tests {
             print_strings_matches_data: false,
             print_string_length: false,
             print_metadata: false,
+            print_namespace: false,
             print_tags: false,
             no_mmap: false,
             identifier: None,

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1219,7 +1219,6 @@ fn test_scan_list() {
     // dir1 + c, will match the 3 filse
     let list = test_file(format!("{}\n{}\n", dir1.path().display(), file_c.display()).as_bytes());
     cmd()
-        .arg("--threads=1")
         .arg("--scan-list")
         .arg(rule_file.path())
         .arg(list.path())
@@ -1235,8 +1234,6 @@ fn test_scan_list() {
     // a + dir2, but not recursive, will match only a
     let list = test_file(format!("{}\n{}\n", file_a.display(), dir2.path().display()).as_bytes());
     cmd()
-        // TODO: avoid messing up the output with multiple threads
-        .arg("--threads=1")
         .arg("--scan-list")
         .arg(rule_file.path())
         .arg(list.path())
@@ -1251,7 +1248,6 @@ fn test_scan_list() {
 
     // When recursive, will match c
     cmd()
-        .arg("--threads=1")
         .arg("--scan-list")
         .arg("-r")
         .arg(rule_file.path())

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -72,10 +72,7 @@ rule my_rule {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
-            "my_rule {}\n",
-            input.path().display()
-        )))
+        .stdout(format!("my_rule {}\n", input.path().display()))
         .stderr("")
         .success();
 }
@@ -104,7 +101,7 @@ rule process_scan {
         .arg(rule_file.path())
         .arg(pid.to_string())
         .assert()
-        .stdout(predicate::eq(format!("process_scan {}\n", pid)))
+        .stdout(format!("process_scan {}\n", pid))
         .stderr("")
         .success();
 }
@@ -126,10 +123,7 @@ fn test_scan_process_not_found() {
         .arg(pid.to_string())
         .assert()
         .stdout("")
-        .stderr(predicate::eq(format!(
-            "Cannot scan {}: unknown process\n",
-            pid
-        )))
+        .stderr(format!("Cannot scan {}: unknown process\n", pid))
         .failure();
 }
 
@@ -156,7 +150,7 @@ rule is_file {
         .arg(rule_file.path())
         .arg("1")
         .assert()
-        .stdout(predicate::eq("is_file 1\n"))
+        .stdout("is_file 1\n")
         .stderr("")
         .success();
 }
@@ -200,10 +194,7 @@ fn test_rule_warning() {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
-            "rule_with_warning {}\n",
-            input.path().display()
-        )))
+        .stdout(format!("rule_with_warning {}\n", input.path().display()))
         .stderr(
             predicate::str::contains("warning").and(predicate::str::contains(
                 "implicit cast from a bytes value to a boolean",
@@ -266,10 +257,7 @@ rule includer {
         .arg(&rule_a)
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
-            "included {}\n",
-            input.path().display()
-        )))
+        .stdout(format!("included {}\n", input.path().display()))
         .success();
 
     // Match on both
@@ -630,11 +618,11 @@ rule a {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             "default:a (from {}){}",
             rule_file.path().display(),
             stats
-        )))
+        ))
         .stderr("")
         .success();
 }
@@ -753,7 +741,7 @@ rule second {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!("first {}\n", input.path().display())))
+        .stdout(format!("first {}\n", input.path().display()))
         .stderr("")
         .success();
 }
@@ -775,10 +763,10 @@ rule logger {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             "this is a log\nlogger {}\n",
             input.path().display()
-        )))
+        ))
         .stderr("")
         .success();
 }
@@ -828,11 +816,11 @@ rule tag3: first second third {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             "notag [] {path}\n\
              tag1 [first] {path}\n\
              tag3 [first,second,third] {path}\n"
-        )))
+        ))
         .stderr("")
         .success();
 
@@ -843,7 +831,7 @@ rule tag3: first second third {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!("tag1 {path}\ntag3 {path}\n")))
+        .stdout(format!("tag1 {path}\ntag3 {path}\n"))
         .stderr("")
         .success();
     cmd()
@@ -851,7 +839,7 @@ rule tag3: first second third {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!("tag3 {path}\n")))
+        .stdout(format!("tag3 {path}\n"))
         .stderr("")
         .success();
     cmd()
@@ -897,7 +885,7 @@ rule my_rule {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             r#"my_rule {path}
 0x0:$a: <a>
 0x5:$a: <<abc>
@@ -907,7 +895,7 @@ rule my_rule {
 0x1c:$a: <a\xff>
 0x7:$b: abc
 "#
-        )))
+        ))
         .stderr("")
         .success();
 
@@ -917,7 +905,7 @@ rule my_rule {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             r#"my_rule {path}
 0x0:3:$a
 0x5:6:$a
@@ -927,7 +915,7 @@ rule my_rule {
 0x1c:4:$a
 0x7:3:$b
 "#
-        )))
+        ))
         .stderr("")
         .success();
 
@@ -938,7 +926,7 @@ rule my_rule {
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(predicate::eq(format!(
+        .stdout(format!(
             r#"my_rule {path}
 0x0:3:$a: <a>
 0x5:6:$a: <<abc>
@@ -948,7 +936,7 @@ rule my_rule {
 0x1c:4:$a: <a\xff>
 0x7:3:$b: abc
 "#
-        )))
+        ))
         .stderr("")
         .success();
 }

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1094,3 +1094,25 @@ rule too_long {
         .stderr(format!("Cannot scan {path}: timeout\n"))
         .failure();
 }
+
+#[test]
+fn test_print_namespace() {
+    let rule_file = test_file(
+        br#"
+rule first { condition: true }
+"#,
+    );
+
+    let input = test_file(b"");
+    let path = input.path().display();
+
+    // Test filter by identifier
+    cmd()
+        .arg("-e")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("default:first {path}\n"))
+        .stderr("")
+        .success();
+}

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -801,7 +801,7 @@ fn test_invalid_fragmented_scan_mode() {
 }
 
 #[test]
-fn test_print_tags() {
+fn test_tags() {
     let rule_file = test_file(
         br#"
 rule notag {
@@ -822,7 +822,7 @@ rule tag3: first second third {
     let input = test_file(b"");
     let path = input.path().display();
 
-    // Test match data only
+    // Test print tags
     cmd()
         .arg("-g")
         .arg(rule_file.path())
@@ -833,6 +833,34 @@ rule tag3: first second third {
              tag1 [first] {path}\n\
              tag3 [first,second,third] {path}\n"
         )))
+        .stderr("")
+        .success();
+
+    // Test filter by tag
+    cmd()
+        .arg("-t")
+        .arg("first")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(predicate::eq(format!("tag1 {path}\ntag3 {path}\n")))
+        .stderr("")
+        .success();
+    cmd()
+        .arg("--tag=third")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(predicate::eq(format!("tag3 {path}\n")))
+        .stderr("")
+        .success();
+    cmd()
+        .arg("-t")
+        .arg("")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout("")
         .stderr("")
         .success();
 }

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1050,3 +1050,36 @@ rule my_rule {
         .stderr("")
         .success();
 }
+
+#[test]
+fn test_timeout() {
+    let rule_file = test_file(
+        br#"
+rule too_long {
+    condition:
+        for all i in (0..9223372036854775807) : (
+            for all j in (0..9223372036854775807) : (
+                for all k in (0..9223372036854775807) : (
+                    for all l in (0..9223372036854775807) : (
+                        i + j + k + l >= 0
+                    )
+                )
+            )
+        )
+}"#,
+    );
+
+    let input = test_file(b"");
+    let path = input.path().display();
+
+    // Test filter by identifier
+    cmd()
+        .arg("-a")
+        .arg("1")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout("")
+        .stderr(format!("Cannot scan {path}: timeout\n"))
+        .failure();
+}

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -863,6 +863,46 @@ rule tag3: first second third {
 }
 
 #[test]
+fn test_identifier() {
+    let rule_file = test_file(
+        br#"
+rule first { condition: true }
+rule second { condition: true }
+"#,
+    );
+
+    let input = test_file(b"");
+    let path = input.path().display();
+
+    // Test filter by identifier
+    cmd()
+        .arg("-i")
+        .arg("first")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("first {path}\n"))
+        .stderr("")
+        .success();
+    cmd()
+        .arg("--identifier=second")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("second {path}\n"))
+        .stderr("")
+        .success();
+    cmd()
+        .arg("--identifier=third")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout("")
+        .stderr("")
+        .success();
+}
+
+#[test]
 fn test_print_string_matches() {
     let rule_file = test_file(
         br#"

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -759,14 +759,23 @@ rule logger {
     );
 
     let input = test_file(b"");
+    let path = input.path().display();
+
     cmd()
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(format!(
-            "this is a log\nlogger {}\n",
-            input.path().display()
-        ))
+        .stdout(format!("this is a log\nlogger {path}\n"))
+        .stderr("")
+        .success();
+
+    // Logs can be disabled with the -q flag
+    cmd()
+        .arg("-q")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("logger {path}\n"))
         .stderr("")
         .success();
 }

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -903,6 +903,67 @@ rule second { condition: true }
 }
 
 #[test]
+fn test_print_meta() {
+    let rule_file = test_file(
+        br#"
+rule first: tag {
+    meta:
+        integer = -15
+        string = "d mol"
+        test = true
+    condition:
+        true
+}
+rule second: tag {
+    condition:
+        true
+}
+rule third: tag {
+    meta:
+        value = "ok"
+    condition:
+        true
+}
+rule fourth { condition: true }
+"#,
+    );
+
+    let input = test_file(b"");
+    let path = input.path().display();
+
+    // Test print meta
+    cmd()
+        .arg("-m")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!(
+            "first [integer=-15,string=\"d mol\",test=true] {path}\n\
+             second [] {path}\n\
+             third [value=\"ok\"] {path}\n\
+             fourth [] {path}\n"
+        ))
+        .stderr("")
+        .success();
+
+    // Test print meta + tag
+    cmd()
+        .arg("-g")
+        .arg("--print-meta")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!(
+            "first [tag] [integer=-15,string=\"d mol\",test=true] {path}\n\
+             second [tag] [] {path}\n\
+             third [tag] [value=\"ok\"] {path}\n\
+             fourth [] [] {path}\n"
+        ))
+        .stderr("")
+        .success();
+}
+
+#[test]
 fn test_print_string_matches() {
     let rule_file = test_file(
         br#"

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -188,13 +188,14 @@ fn test_rule_warning() {
     );
 
     let input = test_file(b"");
+    let path = input.path().display();
 
     // Warning is OK and rule is eval'ed
     cmd()
         .arg(rule_file.path())
         .arg(input.path())
         .assert()
-        .stdout(format!("rule_with_warning {}\n", input.path().display()))
+        .stdout(format!("rule_with_warning {path}\n"))
         .stderr(
             predicate::str::contains("warning").and(predicate::str::contains(
                 "implicit cast from a bytes value to a boolean",
@@ -215,6 +216,16 @@ fn test_rule_warning() {
             )),
         )
         .failure();
+
+    // Ignore warnings
+    cmd()
+        .arg("-w")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("rule_with_warning {path}\n"))
+        .stderr("")
+        .success();
 }
 
 #[test]


### PR DESCRIPTION
Add a lot of options that were missing compared to the yara cli binary:

- `-s` to print strings
- `-L` to print strings length
- `-g` to print rule tags
- `-m` to print rule metadatas
- `-e` to print rule namespaces
- `-t` to print rule matching a given tag
- `-i` to print rule matching a given name
- `-q` to disable console logs
- `-a` to specify a timeout
- `-w` to disable warnings
- `-d` to define symbols
- `--scan-list` to provide a list of files/directories to scan

There are still a few options that exist in YARA that have not been implemented, but they should not be planned for the moment:
- `-n` to print non matching rules. The boreal API does not really make this trivial to print, and i'm unsure what the purpose of this flag is.
- `-X` to print the xor key. This would require a non trivial feature during scanning to compute and return the xor key of a match, so it's not done for the moment.
- `-c` to print the number of matching rules. I fail to really see the point of this flag compared to a `./boreal ... | wc -l`.