### PR TITLE
Handle range access on fragmented memory for hash and math modules.

### DIFF
--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -26,7 +26,7 @@ pub(super) fn evaluate_read_integer(
 
     let mem = addr
         .checked_add(length)
-        .and_then(|end| evaluator.scan_data.mem.get(addr, end))
+        .and_then(|end| evaluator.scan_data.mem.get_contiguous(addr, end))
         .ok_or(PoisonKind::Undefined)?;
 
     match ty {

--- a/boreal/src/memory.rs
+++ b/boreal/src/memory.rs
@@ -95,7 +95,6 @@ impl Memory<'_> {
                 if start >= mem.len() {
                     None
                 } else {
-                    let end = std::cmp::min(mem.len(), end);
                     mem.get(start..end)
                 }
             }
@@ -112,10 +111,9 @@ impl Memory<'_> {
                     if relative_start >= region.length {
                         continue;
                     }
-                    let end = std::cmp::min(region.length, end - region.start);
 
                     let region = fragmented.obj.fetch(&fragmented.params)?;
-                    return region.mem.get(relative_start..end);
+                    return region.mem.get(relative_start..(end - region.start));
                 }
 
                 None


### PR DESCRIPTION
For some expressions, we want to be able to make them work even if regions are chunked. To do so, we need a new API to iterate on multiple distinct byte slices. This is done with the new Memory::on_range method.

This uses a callback instead of returning an iterator to guarantee that only one region can be fetched at a given time, which is a constraint used in the memory trait.