### PR TITLE
Implement macos process scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,24 @@ jobs:
       - name: Run tests
         env:
           YARA_CRYPTO_LIB: openssl
-        run: cargo test
+        run: |
+          cargo test -- --skip process::
 
       - name: Run tests with Openssl
         env:
           YARA_CRYPTO_LIB: openssl
-        run: cargo test --features authenticode
+        run: |
+          cargo test --features authenticode -- --skip macos_need_sudo
+
+      # Some tests on macos need to be super user
+      - name: Run process tests
+        env:
+          YARA_CRYPTO_LIB: openssl
+        # --test-threads=1 to avoid a bug that makes the vm_read_overwrite
+        # fail when multiple tests are running in parallel.
+        # This is very suspect, and should be investigated and reported.
+        run: |
+          sudo env "CARGO_HOME=$HOME/.cargo" cargo test --features authenticode macos_need_sudo -- --test-threads=1
 
   clippy:
     name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "glob",
  "hex",
  "libc",
+ "mach2",
  "md-5",
  "memchr",
  "memmap2",
@@ -454,6 +455,15 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "md-5"
@@ -910,7 +920,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 [[package]]
 name = "yara"
 version = "0.24.0"
-source = "git+https://github.com/vthib/yara-rust?branch=version-0.24.0#1bbfc6b66c272000848e8eb32191907244ad6f55"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.24.0#cb66bbedbdf416bc56f1dcc16b5674d71699f3c8"
 dependencies = [
  "bitflags 2.4.1",
  "lazy_static",
@@ -921,7 +931,7 @@ dependencies = [
 [[package]]
 name = "yara-sys"
 version = "0.24.0"
-source = "git+https://github.com/vthib/yara-rust?branch=version-0.24.0#1bbfc6b66c272000848e8eb32191907244ad6f55"
+source = "git+https://github.com/vthib/yara-rust?branch=version-0.24.0#cb66bbedbdf416bc56f1dcc16b5674d71699f3c8"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ object = { git = 'https://github.com/vthib/boreal-object', branch = "version-0.3
 # - Add base address to elf entrypoint: https://github.com/VirusTotal/yara/pull/1989
 # - Fixes for macho module and process memory: https://github.com/VirusTotal/yara/pull/1995
 # - Fix for elf module and process memory: https://github.com/VirusTotal/yara/pull/1996
+# - Fix for macos process scanning: https://github.com/VirusTotal/yara/pull/2033
 yara = { git = 'https://github.com/vthib/yara-rust', branch = 'version-0.24.0' }

--- a/boreal-test-helpers/src/main.rs
+++ b/boreal-test-helpers/src/main.rs
@@ -234,10 +234,12 @@ impl Region {
     }
 }
 
+#[inline(never)]
 fn xor_bytes(v: &[u8], xor_byte: u8) -> Vec<u8> {
     v.iter().map(|b| *b ^ xor_byte).collect()
 }
 
+#[inline(never)]
 fn xor_bytes_into(v: &[u8], xor_byte: u8, dest: &mut [u8]) {
     for (v, d) in v.iter().zip(dest.iter_mut()) {
         *d = *v ^ xor_byte;

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -31,7 +31,7 @@ authenticode = ["dep:authenticode-parser"]
 memmap = ["dep:memmap2"]
 
 # Adds APIs to scan process memories.
-process = ["dep:libc", "dep:windows"]
+process = ["dep:libc", "dep:windows", "dep:mach2"]
 
 # Enables computation of statistics during scanning.
 profiling = []
@@ -72,6 +72,10 @@ memmap2 = { version = "0.9", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2", optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { version = "0.2", optional = true }
+mach2 = { version = "0.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.52", optional = true, features = [

--- a/boreal/src/scanner/process/sys.rs
+++ b/boreal/src/scanner/process/sys.rs
@@ -8,7 +8,12 @@ mod windows;
 #[cfg(windows)]
 pub use windows::*;
 
-#[cfg(not(any(target_os = "linux", windows)))]
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+pub use macos::*;
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 mod default;
-#[cfg(not(any(target_os = "linux", windows)))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
 pub use default::*;

--- a/boreal/src/scanner/process/sys/macos.rs
+++ b/boreal/src/scanner/process/sys/macos.rs
@@ -1,0 +1,203 @@
+use std::mem::size_of;
+
+use mach2::kern_return::{KERN_NO_SPACE, KERN_SUCCESS};
+use mach2::mach_port::mach_port_deallocate;
+use mach2::port::{mach_port_name_t, MACH_PORT_NULL};
+use mach2::traps::{mach_task_self, task_for_pid};
+use mach2::vm::{mach_vm_read_overwrite, mach_vm_region_recurse};
+use mach2::vm_prot::VM_PROT_READ;
+use mach2::vm_region::vm_region_submap_info_64;
+
+use crate::memory::{FragmentedMemory, MemoryParams, Region, RegionDescription};
+use crate::scanner::ScanError;
+
+pub fn process_memory(pid: u32) -> Result<Box<dyn FragmentedMemory>, ScanError> {
+    #[allow(clippy::cast_possible_wrap)]
+    let pid = pid as i32;
+
+    let mut task_port_name = MACH_PORT_NULL;
+    // Safety:
+    // - mach_task_self is always safe to call
+    // - task_for_pid is provided a valid port name
+    let ret = unsafe { task_for_pid(mach_task_self(), pid, &mut task_port_name) };
+    if ret != KERN_SUCCESS {
+        // There is no errno or detailed error, simply KERN_FAILURE.
+        // Try to find out if the pid does not exist, so that the error type can be improved.
+        // Safety: always safe to call.
+        let kill_res = unsafe { libc::kill(pid, 0) };
+        if kill_res == -1 {
+            let kill_error = std::io::Error::last_os_error();
+            if kill_error.raw_os_error() == Some(libc::ESRCH) {
+                return Err(ScanError::UnknownProcess);
+            }
+        }
+
+        // Otherwise, just return a generic error
+        return Err(ScanError::CannotListProcessRegions(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "cannot open process",
+        )));
+    }
+
+    Ok(Box::new(MacosProcessMemory {
+        task_port: MachPort {
+            name: task_port_name,
+        },
+        buffer: Vec::new(),
+        current_region: None,
+    }))
+}
+
+#[derive(Debug)]
+struct MachPort {
+    name: mach_port_name_t,
+}
+
+impl Drop for MachPort {
+    fn drop(&mut self) {
+        // Safety:
+        // - mach_task_self is always safe to call
+        // - self.name is a valid port name (returned by task_for_pid).
+        let _ = unsafe { mach_port_deallocate(mach_task_self(), self.name) };
+    }
+}
+
+#[derive(Debug)]
+struct MacosProcessMemory {
+    // Task port on the process
+    task_port: MachPort,
+
+    // Buffer used to hold the duplicated process memory when fetched.
+    buffer: Vec<u8>,
+
+    // Current region.
+    current_region: Option<RegionDescription>,
+}
+
+impl MacosProcessMemory {
+    fn next_region(&mut self, params: &MemoryParams) -> Option<RegionDescription> {
+        let next_addr = match self.current_region {
+            Some(desc) => {
+                if let Some(chunk_size) = params.memory_chunk_size {
+                    if chunk_size < desc.length {
+                        // Region has a next chunk, so simply select it.
+                        return Some(RegionDescription {
+                            start: desc.start.saturating_add(chunk_size),
+                            length: desc.length.saturating_sub(chunk_size),
+                        });
+                    }
+                }
+
+                desc.start.checked_add(desc.length)?
+            }
+            None => 0,
+        };
+
+        query_next_region(self.task_port.name, next_addr)
+    }
+}
+
+// See https://github.com/apple/darwin-xnu/blob/2ff845c2e03/osfmk/mach/vm_region.h#L320
+const VM_REGION_SUBMAP_INFO_COUNT_64: usize =
+    size_of::<vm_region_submap_info_64>() / size_of::<i32>();
+
+#[allow(clippy::cast_possible_truncation)]
+fn query_next_region(
+    task_port: mach_port_name_t,
+    mut next_addr: usize,
+) -> Option<RegionDescription> {
+    loop {
+        let mut info = vm_region_submap_info_64::default();
+        let mut size = 0;
+        let mut count = VM_REGION_SUBMAP_INFO_COUNT_64 as u32;
+        let mut addr = next_addr as u64;
+
+        // Safety:
+        // - the handle is a valid process handle and has the PROCESS_QUERY_INFORMATION
+        //   permission.
+        let res = unsafe {
+            mach_vm_region_recurse(
+                task_port,
+                &mut addr,
+                &mut size,
+                &mut 0,
+                std::ptr::addr_of_mut!(info).cast(),
+                &mut count,
+            )
+        };
+
+        if res == KERN_NO_SPACE {
+            // No more regions
+            return None;
+        }
+
+        if res != KERN_SUCCESS {
+            return None;
+        }
+
+        if info.is_submap == 0 && info.protection & VM_PROT_READ != 0 {
+            return Some(RegionDescription {
+                start: addr as usize,
+                length: size as usize,
+            });
+        }
+        next_addr = (addr + size) as usize;
+    }
+}
+
+impl FragmentedMemory for MacosProcessMemory {
+    fn reset(&mut self) {
+        self.current_region = None;
+    }
+
+    fn next(&mut self, params: &MemoryParams) -> Option<RegionDescription> {
+        self.current_region = self.next_region(params);
+        self.current_region
+            .map(|region| get_chunked_region(region, params))
+    }
+
+    fn fetch(&mut self, params: &MemoryParams) -> Option<Region> {
+        let desc = get_chunked_region(self.current_region?, params);
+
+        self.buffer.resize(
+            std::cmp::min(desc.length, params.max_fetched_region_size),
+            0,
+        );
+
+        let mut out_size = self.buffer.len() as _;
+
+        // Safety:
+        // - the handle is a valid process handle and has the PROCESS_VM_READ permissions.
+        // - The provided buffer pointer is allocated and has at least `nsize` bytes available.
+        let res = unsafe {
+            mach_vm_read_overwrite(
+                self.task_port.name,
+                desc.start as _,
+                self.buffer.len() as u64,
+                self.buffer.as_mut_ptr() as usize as u64,
+                &mut out_size,
+            )
+        };
+
+        if res != KERN_SUCCESS {
+            return None;
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        self.buffer.truncate(out_size as usize);
+        Some(Region {
+            start: desc.start,
+            mem: &self.buffer,
+        })
+    }
+}
+
+fn get_chunked_region(desc: RegionDescription, params: &MemoryParams) -> RegionDescription {
+    match params.memory_chunk_size {
+        Some(chunk_size) => RegionDescription {
+            start: desc.start,
+            length: std::cmp::min(chunk_size, desc.length),
+        },
+        None => desc,
+    }
+}

--- a/boreal/tests/it/main.rs
+++ b/boreal/tests/it/main.rs
@@ -32,7 +32,7 @@ mod limits;
 
 // Tests related to process memory scanning
 #[cfg(feature = "process")]
-#[cfg(any(target_os = "linux", windows))]
+#[cfg(any(target_os = "linux", target_os = "macos", windows))]
 mod process;
 
 // Tests related to modules

--- a/boreal/tests/it/process.rs
+++ b/boreal/tests/it/process.rs
@@ -6,7 +6,7 @@ use boreal::scanner::ScanError;
 const PAGE_SIZE: usize = 4 * 1024 * 1024;
 
 #[test]
-fn test_scan_process() {
+fn test_scan_process_macos_need_sudo() {
     // Scan for strings found in the bss and the stack of the test process.
     let mut checker = Checker::new(
         r#"
@@ -25,7 +25,7 @@ rule a {
 
 /// Test scanning a pid that do not exist.
 #[test]
-fn test_process_not_found() {
+fn test_process_not_found_macos_need_sudo() {
     let pid = 999_999_999;
 
     let mut checker = Checker::new(r#" rule a { condition: true }"#);
@@ -100,7 +100,7 @@ fn euid_is_root() -> bool {
 }
 
 #[test]
-fn test_process_multiple_passes() {
+fn test_process_multiple_passes_macos_need_sudo() {
     let mut checker = Checker::new(
         r#"
 rule a {
@@ -119,7 +119,7 @@ rule a {
 }
 
 #[test]
-fn test_process_max_fetched_region_size() {
+fn test_process_max_fetched_region_size_macos_need_sudo() {
     use boreal::scanner::ScanParams;
 
     use crate::utils::get_boreal_full_matches;
@@ -170,7 +170,7 @@ rule a {
 }
 
 #[test]
-fn test_process_memory_chunk_size() {
+fn test_process_memory_chunk_size_macos_need_sudo() {
     use boreal::scanner::ScanParams;
 
     use crate::utils::get_boreal_full_matches;
@@ -221,7 +221,7 @@ rule a {
 }
 
 #[test]
-fn test_process_file_copy_on_write() {
+fn test_process_file_copy_on_write_macos_need_sudo() {
     let mut checker = Checker::new(
         r#"
 rule a {

--- a/boreal/tests/it/process.rs
+++ b/boreal/tests/it/process.rs
@@ -69,6 +69,10 @@ fn test_process_permission_denied() {
                     err
                 );
             }
+            #[cfg(target_os = "macos")]
+            {
+                assert_eq!(err.kind(), std::io::ErrorKind::Other, "{:?}", err);
+            }
         }
         err => panic!("Unexpected last err: {err:?}"),
     }

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -321,7 +321,7 @@ impl Checker {
 
     #[track_caller]
     #[cfg(feature = "process")]
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     pub fn check_process_full_matches(&mut self, pid: u32, expected: FullMatches) {
         // We need to compute the full matches for this test
         {
@@ -333,7 +333,8 @@ impl Checker {
         }
 
         if let Some(rules) = &self.yara_rules {
-            let res = rules.scan_process(pid, 1).unwrap();
+            let mut scanner = rules.scanner().unwrap();
+            let res = scanner.scan_process(pid).unwrap();
             check_yara_full_matches(&res, expected);
         }
     }
@@ -454,7 +455,7 @@ impl Checker {
 
     #[track_caller]
     #[cfg(feature = "process")]
-    #[cfg(any(target_os = "linux", windows))]
+    #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     pub fn check_process(&mut self, pid: u32, expected_res: bool) {
         let res = match self.scanner.scan_process(pid) {
             Ok(v) => {


### PR DESCRIPTION
Use `mach_vm_region_recurse` to get the list of memory regions, and use `mach_vm_read_overwrite` to read each region.
We skip submaps, as they can be massive and do not provide much in the context of detection. Those are badly handled in yara, so they are not scanned either.