### PR TITLE
exclude test assets in package

### DIFF
--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["text-processing"]
 edition = "2021"
 # MSRV
 rust-version = "1.65"
+exclude = ["/tests"]
 
 [features]
 default = ["hash", "object", "memmap", "process"]


### PR DESCRIPTION
This PR excludes the test assets from the published package for the crate.  As is, a number of AVs trigger on the contents of the resulting package, which impacts mirrors of crates.io.

As the test & assets are used by crate contributors, but not crate consumers, I believe this should not have any downsides.