### PR TITLE
address unused_qualifications lint issues from nightly

### DIFF
--- a/boreal-parser/src/expression/for_expression.rs
+++ b/boreal-parser/src/expression/for_expression.rs
@@ -284,7 +284,7 @@ fn string_enum_element(input: Input) -> ParseResult<SetElement> {
 /// Equivalent to the `for_variables` pattern in grammar.y in libyara.
 fn for_variables(input: Input) -> ParseResult<(Vec<String>, Range<usize>)> {
     let start = input.pos();
-    let (input, identifiers) = separated_list1(rtrim(char(',')), crate::string::identifier)(input)?;
+    let (input, identifiers) = separated_list1(rtrim(char(',')), string::identifier)(input)?;
     Ok((input, (identifiers, input.get_span_from(start))))
 }
 

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -629,7 +629,7 @@ mod tests {
 
     #[test]
     fn test_types_traits() {
-        test_type_traits_non_clonable(compile_module(&crate::module::Time));
+        test_type_traits_non_clonable(compile_module(&module::Time));
         test_type_traits_non_clonable(ValueOperation::Subfield("a".to_owned()));
         test_type_traits_non_clonable(BoundedValueIndex::Module(0));
         test_type_traits_non_clonable(ModuleOperations {

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -2004,7 +2004,7 @@ impl Pe {
 
         // Compute offset of checksum in the file: this is replaced by 0 when computing the
         // checksum
-        let dos_header = pe::ImageDosHeader::parse(mem).ok()?;
+        let dos_header = ImageDosHeader::parse(mem).ok()?;
         // 64 is the offset of the checksum in the optional header, and 24 is the offset of the
         // optional header in the nt headers: See
         // <https://docs.microsoft.com/en-us/windows/win32/debug/pe-format>

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use visitor::{visit, VisitAction, Visitor};
 /// Regex following the YARA format.
 #[derive(Clone, Debug)]
 pub struct Regex {
-    meta: regex_automata::meta::Regex,
+    meta: meta::Regex,
     expr: String,
 }
 

--- a/boreal/src/scanner/process/sys/linux.rs
+++ b/boreal/src/scanner/process/sys/linux.rs
@@ -219,7 +219,7 @@ impl MapRegion {
             return None;
         }
 
-        let file = std::fs::File::open(path).ok()?;
+        let file = File::open(path).ok()?;
 
         // Then, redo the checks but on the metadata of the opened files, to prevent
         // any TOCTOU issues.


### PR DESCRIPTION
This is another change that is currently breaking the coverage task.

rustc 1.78.0-nightly (b6d2d841b 2024-03-05)

Similar to #121 , this is only here to address compilation issues highlighted by the coverage task with latest nightly. 