### PR TITLE
ci: do not use -Dwarnings rust flag on coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ on:
   schedule:
     - cron: '45 4 * * 3'
 
-env:
-  RUSTFLAGS: -Dwarnings
-
 jobs:
   test-linux:
     name: Test ${{matrix.build}}
     runs-on: ubuntu-22.04
+
+    env:
+      RUSTFLAGS: -Dwarnings
 
     steps:
       - name: Install openssl x86 and 32 support for gcc
@@ -70,6 +70,9 @@ jobs:
   test-windows:
     name: Test ${{matrix.build}}
     runs-on: windows-2022
+
+    env:
+      RUSTFLAGS: -Dwarnings
 
     steps:
       - uses: actions/checkout@v3
@@ -129,6 +132,9 @@ jobs:
     name: Test Macos 12
     runs-on: macos-12
 
+    env:
+      RUSTFLAGS: -Dwarnings
+
     steps:
       - uses: actions/checkout@v3
 
@@ -162,6 +168,8 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-22.04
+    env:
+      RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -222,6 +230,8 @@ jobs:
   msrv:
     name: Rust 1.65.0
     runs-on: ubuntu-22.04
+    env:
+      RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@1.65.0


### PR DESCRIPTION
The coverage job uses the nightly toolchain due to a dependency on a nightly feature. Since all jobs uses the -Dwarnings rust flag however, this meant this job can break every day as the nightly toolchain adds new warnings.

To avoid this issue and have a more stable job, stop setting this flag for all jobs, and only do it for jobs where it makes sense.