### PR TITLE
feat: improve error reporting on invalid rules file path

### DIFF
--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -30,7 +30,9 @@ fn test_invalid_path() {
         .arg("input")
         .assert()
         .stdout("")
-        .stderr(predicate::str::contains("IO error"))
+        .stderr(predicate::str::contains(
+            "Cannot read rules file do_not_exist: ",
+        ))
         .failure();
 
     // Invalid path to input

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -39,14 +39,14 @@ fn test_add_rules_file_err() {
     let err = compiler.add_rules_file(path).unwrap_err();
     assert!(err
         .to_short_description(path, "")
-        .starts_with("error: IO error: "));
+        .starts_with("error: Cannot read rules file non_existing: "));
 
     let err = compiler
         .add_rules_file_in_namespace(path, "ns")
         .unwrap_err();
     assert!(err
         .to_short_description(path, "")
-        .starts_with("error: IO error: "));
+        .starts_with("error: Cannot read rules file non_existing: "));
 }
 
 // An import is reused in the same namespace


### PR DESCRIPTION
The error reported when the rules file given to boreal-cli is missing was not very good, since it did not indicate the path to the file. This is now improved.