### PR TITLE
Add set_module_data api

### DIFF
--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -7,19 +7,21 @@ use crate::compiler::module::{
     BoundedValueIndex, ModuleExpression, ModuleExpressionKind, ModuleOperations, ValueOperation,
 };
 use crate::memory::Region;
-use crate::module::{EvalContext, Module, ModuleDataMap, ScanContext, Value as ModuleValue};
+use crate::module::{
+    EvalContext, Module, ModuleDataMap, ModuleUserData, ScanContext, Value as ModuleValue,
+};
 
 use super::{Evaluator, PoisonKind, Value};
 
 #[derive(Debug)]
-pub struct EvalData {
+pub struct EvalData<'scanner> {
     pub values: Vec<(&'static str, ModuleValue)>,
-    pub data_map: ModuleDataMap,
+    pub data_map: ModuleDataMap<'scanner>,
 }
 
-impl EvalData {
-    pub fn new(modules: &[Box<dyn Module>]) -> Self {
-        let mut data_map = ModuleDataMap::default();
+impl<'scanner> EvalData<'scanner> {
+    pub fn new(modules: &[Box<dyn Module>], user_data: &'scanner ModuleUserData) -> Self {
+        let mut data_map = ModuleDataMap::new(user_data);
 
         let values = modules
             .iter()
@@ -216,7 +218,7 @@ mod tests {
     fn test_types_traits() {
         test_type_traits_non_clonable(EvalData {
             values: Vec::new(),
-            data_map: ModuleDataMap::default(),
+            data_map: ModuleDataMap::new(&HashMap::new()),
         });
     }
 }

--- a/boreal/src/module/console.rs
+++ b/boreal/src/module/console.rs
@@ -57,7 +57,7 @@ pub struct Data {
 }
 
 impl ModuleData for Console {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 impl Console {

--- a/boreal/src/module/console.rs
+++ b/boreal/src/module/console.rs
@@ -58,6 +58,7 @@ pub struct Data {
 
 impl ModuleData for Console {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 impl Console {

--- a/boreal/src/module/dex.rs
+++ b/boreal/src/module/dex.rs
@@ -364,7 +364,7 @@ impl Data {
 }
 
 impl ModuleData for Dex {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 fn parse_file(mem: &[u8], data: &mut Data) -> Option<HashMap<&'static str, Value>> {

--- a/boreal/src/module/dex.rs
+++ b/boreal/src/module/dex.rs
@@ -365,6 +365,7 @@ impl Data {
 
 impl ModuleData for Dex {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 fn parse_file(mem: &[u8], data: &mut Data) -> Option<HashMap<&'static str, Value>> {

--- a/boreal/src/module/dotnet.rs
+++ b/boreal/src/module/dotnet.rs
@@ -177,6 +177,7 @@ pub struct Data {
 
 impl ModuleData for Dotnet {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 fn parse_file<HEADERS: ImageNtHeaders>(

--- a/boreal/src/module/dotnet.rs
+++ b/boreal/src/module/dotnet.rs
@@ -176,7 +176,7 @@ pub struct Data {
 }
 
 impl ModuleData for Dotnet {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 fn parse_file<HEADERS: ImageNtHeaders>(

--- a/boreal/src/module/elf.rs
+++ b/boreal/src/module/elf.rs
@@ -264,7 +264,7 @@ impl Module for Elf {
 }
 
 impl ModuleData for Elf {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 #[derive(Default)]

--- a/boreal/src/module/elf.rs
+++ b/boreal/src/module/elf.rs
@@ -265,6 +265,7 @@ impl Module for Elf {
 
 impl ModuleData for Elf {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 #[derive(Default)]

--- a/boreal/src/module/hash.rs
+++ b/boreal/src/module/hash.rs
@@ -80,6 +80,7 @@ pub struct Cache {
 
 impl ModuleData for Hash {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 fn compute_hash_from_bytes<D: Digest>(bytes: &[u8]) -> Value {

--- a/boreal/src/module/hash.rs
+++ b/boreal/src/module/hash.rs
@@ -79,7 +79,7 @@ pub struct Cache {
 }
 
 impl ModuleData for Hash {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 fn compute_hash_from_bytes<D: Digest>(bytes: &[u8]) -> Value {

--- a/boreal/src/module/macho.rs
+++ b/boreal/src/module/macho.rs
@@ -718,6 +718,7 @@ struct FileData {
 
 impl ModuleData for MachO {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 impl MachO {

--- a/boreal/src/module/macho.rs
+++ b/boreal/src/module/macho.rs
@@ -717,7 +717,7 @@ struct FileData {
 }
 
 impl ModuleData for MachO {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 impl MachO {

--- a/boreal/src/module/magic.rs
+++ b/boreal/src/module/magic.rs
@@ -53,6 +53,7 @@ pub enum CacheEntry {
 
 impl ModuleData for Magic {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 impl Magic {

--- a/boreal/src/module/magic.rs
+++ b/boreal/src/module/magic.rs
@@ -52,7 +52,7 @@ pub enum CacheEntry {
 }
 
 impl ModuleData for Magic {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 impl Magic {

--- a/boreal/src/module/math.rs
+++ b/boreal/src/module/math.rs
@@ -627,10 +627,10 @@ mod tests {
     use super::*;
 
     macro_rules! ctx {
-        () => {
+        ($v:expr) => {
             EvalContext {
                 mem: &mut Memory::Direct(b""),
-                module_data: &ModuleDataMap::default(),
+                module_data: &ModuleDataMap::new($v),
                 process_memory: false,
             }
         };
@@ -638,7 +638,8 @@ mod tests {
 
     #[test]
     fn test_in_range_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::in_range(&mut ctx, vec![]).is_none());
         assert!(Math::in_range(&mut ctx, vec![0.5.into()]).is_none());
@@ -650,7 +651,8 @@ mod tests {
 
     #[test]
     fn test_deviation_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::deviation(&mut ctx, vec![]).is_none());
         assert!(Math::deviation(&mut ctx, vec![0.5.into()]).is_none());
@@ -664,7 +666,8 @@ mod tests {
 
     #[test]
     fn test_mean_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::mean(&mut ctx, vec![]).is_none());
         assert!(Math::mean(&mut ctx, vec![0.5.into()]).is_none());
@@ -674,7 +677,8 @@ mod tests {
 
     #[test]
     fn test_serial_correlation_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::serial_correlation(&mut ctx, vec![]).is_none());
         assert!(Math::serial_correlation(&mut ctx, vec![0.5.into()]).is_none());
@@ -684,7 +688,8 @@ mod tests {
 
     #[test]
     fn test_monte_carlo_pi_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::monte_carlo_pi(&mut ctx, vec![]).is_none());
         assert!(Math::monte_carlo_pi(&mut ctx, vec![0.5.into()]).is_none());
@@ -694,7 +699,8 @@ mod tests {
 
     #[test]
     fn test_entropy_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::entropy(&mut ctx, vec![]).is_none());
         assert!(Math::entropy(&mut ctx, vec![0.5.into()]).is_none());
@@ -704,7 +710,8 @@ mod tests {
 
     #[test]
     fn test_min_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::min(&mut ctx, vec![]).is_none());
         assert!(Math::min(&mut ctx, vec![0.5.into()]).is_none());
@@ -714,7 +721,8 @@ mod tests {
 
     #[test]
     fn test_max_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::max(&mut ctx, vec![]).is_none());
         assert!(Math::max(&mut ctx, vec![0.5.into()]).is_none());
@@ -724,7 +732,8 @@ mod tests {
 
     #[test]
     fn test_to_number_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::to_number(&mut ctx, vec![]).is_none());
         assert!(Math::to_number(&mut ctx, vec![0.into()]).is_none());
@@ -732,7 +741,8 @@ mod tests {
 
     #[test]
     fn test_abs_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::abs(&mut ctx, vec![]).is_none());
         assert!(Math::abs(&mut ctx, vec![0.5.into()]).is_none());
@@ -740,7 +750,8 @@ mod tests {
 
     #[test]
     fn test_count_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::count(&mut ctx, vec![]).is_none());
         assert!(Math::count(&mut ctx, vec![0.5.into()]).is_none());
@@ -749,7 +760,8 @@ mod tests {
 
     #[test]
     fn test_percentage_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::percentage(&mut ctx, vec![]).is_none());
         assert!(Math::percentage(&mut ctx, vec![0.5.into()]).is_none());
@@ -758,7 +770,8 @@ mod tests {
 
     #[test]
     fn test_mode_invalid_args() {
-        let mut ctx = ctx!();
+        let user_data = HashMap::new();
+        let mut ctx = ctx!(&user_data);
 
         assert!(Math::mode(&mut ctx, vec![0.5.into()]).is_none());
     }

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -275,6 +275,7 @@ impl std::fmt::Debug for ModuleDataMap {
 ///
 /// impl ModuleData for Foo {
 ///     type PrivateData = FooData;
+///     type UserData = ();
 /// }
 ///
 /// impl Module for Foo {
@@ -308,8 +309,15 @@ impl std::fmt::Debug for ModuleDataMap {
 /// }
 /// ```
 pub trait ModuleData: Module {
-    /// Data to associate with the module.
+    /// Private Data to associate with the module.
+    ///
+    /// This is the data that the module can store and retrieve during a scan.
     type PrivateData: Any + Send + Sync;
+
+    /// Data that the user can provide to the module.
+    ///
+    /// The data can be provided by the user through the [`boreal::scanner::ScanParams`].
+    type UserData: Any + Send + Sync;
 }
 
 impl ModuleDataMap {

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -274,7 +274,7 @@ impl std::fmt::Debug for ModuleDataMap {
 /// }
 ///
 /// impl ModuleData for Foo {
-///     type Data = FooData;
+///     type PrivateData = FooData;
 /// }
 ///
 /// impl Module for Foo {
@@ -309,26 +309,26 @@ impl std::fmt::Debug for ModuleDataMap {
 /// ```
 pub trait ModuleData: Module {
     /// Data to associate with the module.
-    type Data: Any + Send + Sync;
+    type PrivateData: Any + Send + Sync;
 }
 
 impl ModuleDataMap {
-    /// Insert the data of a module in the map.
-    pub fn insert<T: Module + ModuleData + 'static>(&mut self, data: T::Data) {
+    /// Insert the private data of a module in the map.
+    pub fn insert<T: Module + ModuleData + 'static>(&mut self, data: T::PrivateData) {
         let _r = self.0.insert(TypeId::of::<T>(), Box::new(data));
     }
 
-    /// Retrieve the data of a module.
+    /// Retrieve the private data of a module.
     #[must_use]
-    pub fn get<T: Module + ModuleData + 'static>(&self) -> Option<&T::Data> {
+    pub fn get<T: Module + ModuleData + 'static>(&self) -> Option<&T::PrivateData> {
         self.0
             .get(&TypeId::of::<T>())
             .and_then(|v| v.downcast_ref())
     }
 
-    /// Retrieve a mutable borrow on the data of a module.
+    /// Retrieve a mutable borrow on the private data of a module.
     #[must_use]
-    pub fn get_mut<T: Module + ModuleData + 'static>(&mut self) -> Option<&mut T::Data> {
+    pub fn get_mut<T: Module + ModuleData + 'static>(&mut self) -> Option<&mut T::PrivateData> {
         self.0
             .get_mut(&TypeId::of::<T>())
             .and_then(|v| v.downcast_mut())

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1140,7 +1140,7 @@ impl Module for Pe {
 }
 
 impl ModuleData for Pe {
-    type Data = Data;
+    type PrivateData = Data;
 }
 
 impl Pe {

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -1141,6 +1141,7 @@ impl Module for Pe {
 
 impl ModuleData for Pe {
     type PrivateData = Data;
+    type UserData = ();
 }
 
 impl Pe {


### PR DESCRIPTION
Update the ModuleData trait to be able to associate two types of data with a module:

- private data, that the module can create and fill during a scan
- user data, that can be provided by the user by calling `Scanner::set_module_data`.

This is for the moment not used, but will be in the future cuckoo module.