### PR TITLE
fix bug in global rules declared after normal rules

### DIFF
--- a/boreal/tests/it/evaluation.rs
+++ b/boreal/tests/it/evaluation.rs
@@ -1199,16 +1199,17 @@ global rule g1 {
     condition: all of them
 }
 
-private global rule g2 {
-    strings:
-        $ = "g2"
-    condition: all of them
-}
-
 rule foo {
     strings:
         $ = "foo"
     condition: all of them
+}
+
+private global rule g2 {
+    strings:
+        $ = "g2"
+        $ = "g3"
+    condition: any of them
 }
 
 rule bar {
@@ -1229,7 +1230,7 @@ rule bar {
 
     // Matching both globals work
     checker.check_rule_matches(b"g1 foo g2", &["default:g1", "default:foo", "default:bar"]);
-    checker.check_rule_matches(b"g1 g2", &["default:g1", "default:bar"]);
+    checker.check_rule_matches(b"g1 g3", &["default:g1", "default:bar"]);
 }
 
 #[test]


### PR DESCRIPTION
When a global rule was declared before a normal rule, and both declared strings, the matches of the strings of the normal rule were used to evaluate the global rule.

This is fixed by splicing the variables of the global rules earlier in the variables vec, so that the whole variables vec respects the global_rules ++ rules order.