### PR TITLE
Handle global rules per namespace

### DIFF
--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -450,6 +450,7 @@ impl Compiler {
                 } = rule::compile_rule(
                     *rule,
                     namespace,
+                    ns_index,
                     &self.external_symbols,
                     &self.params,
                     parsed_contents,
@@ -475,7 +476,7 @@ impl Compiler {
                 if self.params.compute_statistics {
                     status.statistics.push(statistics::CompiledRule {
                         filepath: current_filepath.map(ToOwned::to_owned),
-                        namespace: rule.namespace.clone(),
+                        namespace: namespace.name.clone(),
                         name: rule.name.clone(),
                         strings: variables_statistics,
                     });
@@ -566,12 +567,15 @@ impl Compiler {
     /// Can fail if generating a set of all rules variables is not possible.
     #[must_use]
     pub fn into_scanner(self) -> Scanner {
+        let namespaces = self.namespaces.into_iter().map(|v| v.name).collect();
+
         Scanner::new(
             self.rules,
             self.global_rules,
             self.variables,
             self.imported_modules,
             self.external_symbols,
+            namespaces,
         )
     }
 }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -18,10 +18,11 @@ pub(crate) struct Rule {
     /// Name of the rule.
     pub(crate) name: String,
 
-    /// Namespace containing the rule.
+    /// Index of the namespace containing the rule.
     ///
-    /// [`None`] if in the default namespace.
-    pub(crate) namespace: Option<String>,
+    /// This refers to the [`super::Compiler::namespaces`] or
+    /// [`crate::Scanner::namespaces`] list.
+    pub(crate) namespace_index: usize,
 
     /// Tags associated with the rule.
     pub(crate) tags: Vec<String>,
@@ -203,6 +204,7 @@ impl<'a> RuleCompiler<'a> {
 pub(super) fn compile_rule(
     rule: boreal_parser::rule::Rule,
     namespace: &Namespace,
+    namespace_index: usize,
     external_symbols: &Vec<ExternalSymbol>,
     params: &CompilerParams,
     parsed_contents: &str,
@@ -243,7 +245,7 @@ pub(super) fn compile_rule(
     Ok(CompiledRule {
         rule: Rule {
             name: rule.name,
-            namespace: namespace.name.clone(),
+            namespace_index,
             tags: rule.tags.into_iter().map(|v| v.tag).collect(),
             metadatas: rule.metadatas,
             nb_variables: variables.len(),
@@ -286,7 +288,7 @@ mod tests {
         });
         let build_rule = || Rule {
             name: "a".to_owned(),
-            namespace: None,
+            namespace_index: 0,
             tags: Vec::new(),
             metadatas: Vec::new(),
             nb_variables: 0,

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -30,9 +30,10 @@ fn compile_expr(expression_str: &str, expected_type: Type) {
     assert!(compiler.define_symbol("sym_bool", true));
     assert!(compiler.define_symbol("sym_bytes", "keyboard"));
 
+    let ns = Namespace::default();
     let mut rule_compiler = RuleCompiler::new(
         &rule.variables,
-        &compiler.default_namespace,
+        &ns,
         &compiler.external_symbols,
         &compiler.params,
     )


### PR DESCRIPTION
Global rules were applied to all namespaces instead of their own namespace, which was invalid.
Instead, each global rule will only invalidate the rules in its own namespace if it does not match.