### PR TITLE
feat: remove hex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,6 @@ dependencies = [
  "codespan-reporting",
  "crc32fast",
  "glob",
- "hex",
  "libc",
  "mach2",
  "magic",

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -16,7 +16,7 @@ exclude = ["/tests"]
 default = ["hash", "object", "memmap", "process"]
 
 # Enables the "hash" module.
-hash = ["dep:md-5", "dep:sha1", "dep:sha2", "dep:hex", "dep:crc32fast", "dep:tlsh2"]
+hash = ["dep:md-5", "dep:sha1", "dep:sha2", "dep:crc32fast", "dep:tlsh2"]
 
 # Enables the "pe", "elf" and "macho" modules.
 #
@@ -32,7 +32,7 @@ cuckoo = ["dep:serde_json", "yara/module-cuckoo"]
 
 # Enables the "pe.signatures" module field.
 # The `object` feature must also be enabled to get access to the "pe" module.
-authenticode = ["dep:authenticode-parser", "dep:hex"]
+authenticode = ["dep:authenticode-parser"]
 
 # Adds an API to scan files using memory maps.
 memmap = ["dep:memmap2"]
@@ -59,7 +59,6 @@ regex-syntax = { version = "0.8", default-features = false }
 
 # "hash" feature
 crc32fast = { version = "1.4", optional = true }
-hex = { version = "0.4", optional = true }
 md-5 = { version = "0.10", optional = true }
 sha1 = { version = "0.10", optional = true }
 sha2 = { version = "0.10", optional = true }

--- a/boreal/src/module/elf.rs
+++ b/boreal/src/module/elf.rs
@@ -580,7 +580,7 @@ impl Elf {
 
         let hash = Md5::digest(import_string);
 
-        Some(Value::Bytes(hex::encode(hash).into_bytes()))
+        Some(Value::Bytes(super::hex_encode(hash)))
     }
 
     #[cfg(feature = "hash")]

--- a/boreal/src/module/hash.rs
+++ b/boreal/src/module/hash.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
-use super::{EvalContext, Module, ModuleData, ModuleDataMap, StaticValue, Type, Value};
+use super::{hex_encode, EvalContext, Module, ModuleData, ModuleDataMap, StaticValue, Type, Value};
 use md5::{Digest, Md5};
 use sha1::Sha1;
 use sha2::Sha256;
@@ -84,7 +84,7 @@ impl ModuleData for Hash {
 }
 
 fn compute_hash_from_bytes<D: Digest>(bytes: &[u8]) -> Value {
-    Value::bytes(hex::encode(D::digest(bytes)))
+    Value::Bytes(hex_encode(&D::digest(bytes)))
 }
 
 fn compute_hash_from_mem<D: Digest>(
@@ -95,7 +95,7 @@ fn compute_hash_from_mem<D: Digest>(
     let mut digest = D::new();
 
     ctx.mem.on_range(offset, end, |data| digest.update(data))?;
-    Some(Value::bytes(hex::encode(digest.finalize())))
+    Some(Value::Bytes(hex_encode(&digest.finalize())))
 }
 
 impl Hash {

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -839,6 +839,26 @@ where
     }
 }
 
+fn hex_encode<T: AsRef<[u8]>>(v: T) -> Vec<u8> {
+    hex_encode_inner(v.as_ref())
+}
+
+fn hex_encode_inner(v: &[u8]) -> Vec<u8> {
+    const DICT: &[u8] = b"0123456789abcdef";
+
+    // This code is actually the one i found generates the best codegen, with:
+    // - a single allocation for the vector with the right size
+    // - no bounds checking
+    v.iter()
+        .flat_map(|b| {
+            [
+                DICT[usize::from((*b & 0xF0) >> 4)],
+                DICT[usize::from(*b & 0x0F)],
+            ]
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -2390,7 +2390,7 @@ impl Pe {
             }
         }
 
-        Some(Value::Bytes(hex::encode(hasher.finalize()).into_bytes()))
+        Some(Value::Bytes(super::hex_encode(hasher.finalize())))
     }
 
     fn rva_to_offset(ctx: &mut EvalContext, args: Vec<Value>) -> Option<Value> {


### PR DESCRIPTION
Replace the dependency with a custom hex impl. Given how small the impl is, and how it replaces a complex call with a quite efficient one, this is a net gain.