### PR TITLE
Add bytes intern pool to reduce memory consumption

### DIFF
--- a/boreal/src/bytes_pool.rs
+++ b/boreal/src/bytes_pool.rs
@@ -1,0 +1,76 @@
+/// Bytes intern pool.
+#[derive(Default, Debug)]
+pub(crate) struct BytesPool {
+    buffer: Vec<u8>,
+}
+
+/// Symbol for a bytes string stored in a bytes intern pool.
+#[derive(Copy, Clone, Debug)]
+pub struct BytesSymbol {
+    from: usize,
+    to: usize,
+}
+
+/// Symbol for a string stored in a bytes intern pool.
+#[derive(Copy, Clone, Debug)]
+pub struct StringSymbol {
+    from: usize,
+    to: usize,
+}
+
+impl BytesPool {
+    /// Insert bytes into the bytes pool.
+    ///
+    /// The returned symbol can then be used to retrieve those bytes from the pool.
+    pub(crate) fn insert(&mut self, v: &[u8]) -> BytesSymbol {
+        let from = self.buffer.len();
+        self.buffer.extend(v);
+
+        BytesSymbol {
+            from,
+            to: self.buffer.len(),
+        }
+    }
+
+    /// Insert a string into the bytes pool.
+    ///
+    /// The returned symbol can then be used to retrieve the string from the pool.
+    pub(crate) fn insert_str(&mut self, v: &str) -> StringSymbol {
+        let from = self.buffer.len();
+        self.buffer.extend(v.as_bytes());
+
+        StringSymbol {
+            from,
+            to: self.buffer.len(),
+        }
+    }
+
+    /// Get a byte string from the pool
+    pub(crate) fn get(&self, symbol: BytesSymbol) -> &[u8] {
+        &self.buffer[symbol.from..symbol.to]
+    }
+
+    /// Get a string from the pool
+    pub(crate) fn get_str(&self, symbol: StringSymbol) -> &str {
+        // Safety:
+        // - A StringSymbol can only be constructed from `insert_str`
+        // - Once a symbol is created, it is guaranteed that the indexes in the symbol
+        //   will always refer to the same bytes (the buffer can only grow).
+        // It is thus safe to rebuild the string from the stored bytes.
+        unsafe { std::str::from_utf8_unchecked(&self.buffer[symbol.from..symbol.to]) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
+
+    use super::*;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(BytesPool::default());
+        test_type_traits(BytesSymbol { from: 0, to: 0 });
+        test_type_traits(StringSymbol { from: 0, to: 0 });
+    }
+}

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -10,6 +10,7 @@ use super::rule::RuleCompiler;
 use super::{module, CompilationError};
 use crate::module::Type as ModuleType;
 use crate::regex::{regex_ast_to_hir, regex_hir_to_string, Regex};
+use crate::BytesSymbol;
 
 /// Type of a parsed expression
 ///
@@ -351,8 +352,8 @@ pub enum Expression {
     /// The value is the index into the external symbols vector stored in the compiled rules.
     ExternalSymbol(usize),
 
-    /// A byte string.
-    Bytes(Vec<u8>),
+    /// An interned byte string.
+    Bytes(BytesSymbol),
 
     /// A regex.
     Regex(Regex),
@@ -876,7 +877,7 @@ pub(super) fn compile_expression(
             Ok(Expr { expr, ty, span })
         }
         parser::ExpressionKind::Bytes(s) => Ok(Expr {
-            expr: Expression::Bytes(s),
+            expr: Expression::Bytes(compiler.bytes_pool.insert(&s)),
             ty: Type::Bytes,
             span,
         }),

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -21,6 +21,7 @@ pub use params::CompilerParams;
 pub(crate) mod rule;
 pub(crate) mod variable;
 
+use crate::bytes_pool::BytesPool;
 use crate::{statistics, Scanner};
 
 /// Object used to compile rules.
@@ -58,6 +59,11 @@ pub struct Compiler {
 
     /// Externally defined symbols.
     external_symbols: Vec<external_symbol::ExternalSymbol>,
+
+    /// Bytes intern pool.
+    ///
+    /// This is used to reduce memory footprint and share byte strings.
+    bytes_pool: BytesPool,
 
     /// Compilation parameters
     params: CompilerParams,
@@ -103,6 +109,7 @@ impl Default for Compiler {
             available_modules: HashMap::new(),
             imported_modules: Vec::new(),
             external_symbols: Vec::new(),
+            bytes_pool: BytesPool::default(),
             params: CompilerParams::default(),
         }
     }
@@ -395,6 +402,7 @@ impl Compiler {
                     &self.external_symbols,
                     &self.params,
                     parsed_contents,
+                    &mut self.bytes_pool,
                 )
                 .map_err(|error| AddRuleError {
                     path: current_filepath.map(Path::to_path_buf),
@@ -517,6 +525,7 @@ impl Compiler {
             self.imported_modules,
             self.external_symbols,
             namespaces,
+            self.bytes_pool,
         )
     }
 }

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -21,7 +21,7 @@ pub use params::CompilerParams;
 pub(crate) mod rule;
 pub(crate) mod variable;
 
-use crate::bytes_pool::BytesPool;
+use crate::bytes_pool::BytesPoolBuilder;
 use crate::{statistics, Scanner};
 
 /// Object used to compile rules.
@@ -63,7 +63,7 @@ pub struct Compiler {
     /// Bytes intern pool.
     ///
     /// This is used to reduce memory footprint and share byte strings.
-    bytes_pool: BytesPool,
+    bytes_pool: BytesPoolBuilder,
 
     /// Compilation parameters
     params: CompilerParams,
@@ -109,7 +109,7 @@ impl Default for Compiler {
             available_modules: HashMap::new(),
             imported_modules: Vec::new(),
             external_symbols: Vec::new(),
-            bytes_pool: BytesPool::default(),
+            bytes_pool: BytesPoolBuilder::default(),
             params: CompilerParams::default(),
         }
     }
@@ -525,7 +525,7 @@ impl Compiler {
             self.imported_modules,
             self.external_symbols,
             namespaces,
-            self.bytes_pool,
+            self.bytes_pool.into_pool(),
         )
     }
 }

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -51,7 +51,7 @@ pub struct Compiler {
     /// Modules declared in the compiler, added with [`Compiler::add_module`].
     ///
     /// These are modules that can be imported and used in the namespaces.
-    available_modules: HashMap<String, AvailableModule>,
+    available_modules: HashMap<&'static str, AvailableModule>,
 
     /// List of imported modules, passed to the scanner.
     imported_modules: Vec<Box<dyn crate::module::Module>>,
@@ -163,7 +163,7 @@ impl Compiler {
     pub fn add_module<M: crate::module::Module + 'static>(&mut self, module: M) -> bool {
         let m = module::compile_module(&module);
 
-        match self.available_modules.entry(m.name.to_owned()) {
+        match self.available_modules.entry(m.name) {
             Entry::Occupied(_) => false,
             Entry::Vacant(v) => {
                 let _r = v.insert(AvailableModule {
@@ -322,7 +322,7 @@ impl Compiler {
                 self.add_rules_file_inner(&path, namespace_name, status)?;
             }
             YaraFileComponent::Import(import) => {
-                match self.available_modules.get_mut(&import.name) {
+                match self.available_modules.get_mut(&*import.name) {
                     Some(module) => {
                         // XXX: this is a bit ugly, but i haven't found a better way to get
                         // ownership of the module.

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -347,7 +347,7 @@ impl ModuleUse<'_, '_> {
                     // we can directly generate a primitive expression.
                     StaticValue::Integer(v) => Expression::Integer(*v),
                     StaticValue::Float(v) => Expression::Double(*v),
-                    StaticValue::Bytes(v) => Expression::Bytes(v.clone()),
+                    StaticValue::Bytes(v) => Expression::Bytes(self.compiler.bytes_pool.insert(v)),
                     StaticValue::Boolean(v) => Expression::Boolean(*v),
 
                     StaticValue::Object(_) => return None,

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -8,7 +8,7 @@ use boreal_parser::rule;
 use super::expression::{compile_bool_expression, Expression, VariableIndex};
 use super::external_symbol::ExternalSymbol;
 use super::{variable, CompilationError, CompilerParams, Namespace};
-use crate::bytes_pool::BytesPool;
+use crate::bytes_pool::BytesPoolBuilder;
 use crate::bytes_pool::BytesSymbol;
 use crate::bytes_pool::StringSymbol;
 use crate::module::Type as ModuleType;
@@ -235,7 +235,7 @@ pub(super) fn compile_rule(
     external_symbols: &Vec<ExternalSymbol>,
     params: &CompilerParams,
     parsed_contents: &str,
-    bytes_pool: &mut BytesPool,
+    bytes_pool: &mut BytesPoolBuilder,
 ) -> Result<CompiledRule, CompilationError> {
     // Check duplication of tags
     let mut tags_spans = HashMap::with_capacity(rule.tags.len());
@@ -348,7 +348,7 @@ mod tests {
             name: "a".to_owned(),
             used: false,
         });
-        let mut pool = BytesPool::default();
+        let mut pool = BytesPoolBuilder::default();
         test_type_traits_non_clonable(Metadata {
             name: pool.insert_str(""),
             value: MetadataValue::Boolean(true),

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -7,6 +7,7 @@ use super::{
     AddRuleError, AddRuleErrorKind, AddRuleStatus, AvailableModule, CompilationError, Compiler,
     CompilerParams, ImportedModule, ModuleLocation, Namespace,
 };
+use crate::bytes_pool::BytesPoolBuilder;
 use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
 use boreal_parser::parse;
 
@@ -30,12 +31,14 @@ fn compile_expr(expression_str: &str, expected_type: Type) {
     assert!(compiler.define_symbol("sym_bool", true));
     assert!(compiler.define_symbol("sym_bytes", "keyboard"));
 
+    let mut bytes_pool = BytesPoolBuilder::default();
     let ns = Namespace::default();
     let mut rule_compiler = RuleCompiler::new(
         &rule.variables,
         &ns,
         &compiler.external_symbols,
         &compiler.params,
+        &mut bytes_pool,
     )
     .unwrap();
     let res = compile_expression(&mut rule_compiler, rule.condition).unwrap();

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -154,6 +154,7 @@ mod tests {
     use boreal_parser::rule::VariableModifiers;
 
     use super::*;
+    use crate::bytes_pool::BytesPoolBuilder;
     use crate::compiler::{CompilerParams, Namespace};
     use crate::regex::Regex;
     use crate::test_helpers::test_type_traits_non_clonable;
@@ -169,6 +170,7 @@ mod tests {
             params: &CompilerParams::default(),
             condition_depth: 0,
             warnings: Vec::new(),
+            bytes_pool: &mut BytesPoolBuilder::default(),
         };
         test_type_traits_non_clonable(
             compile_variable(

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -92,6 +92,8 @@ use tlsh2 as _;
 
 pub(crate) mod atoms;
 mod bitmaps;
+mod bytes_pool;
+pub use bytes_pool::{BytesSymbol, StringSymbol};
 pub mod compiler;
 pub use compiler::rule::{Metadata, MetadataValue};
 pub use compiler::Compiler;

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -93,6 +93,7 @@ use tlsh2 as _;
 pub(crate) mod atoms;
 mod bitmaps;
 pub mod compiler;
+pub use compiler::rule::{Metadata, MetadataValue};
 pub use compiler::Compiler;
 mod evaluator;
 mod matcher;
@@ -103,10 +104,6 @@ pub mod scanner;
 pub use scanner::Scanner;
 pub mod statistics;
 mod timeout;
-
-// Re-exports those symbols since they are exposed in the results of a scan. This avoids
-// having to depend on boreal-parser simply to match on those metadatas.
-pub use boreal_parser::rule::{Metadata, MetadataValue};
 
 #[cfg(test)]
 mod test_helpers;

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -9,8 +9,8 @@ use crate::compiler::variable::Variable;
 use crate::evaluator::{self, evaluate_rule, EvalError};
 use crate::memory::{FragmentedMemory, Memory, Region};
 use crate::module::{Module, ModuleData, ModuleUserData};
-use crate::statistics;
 use crate::timeout::TimeoutChecker;
+use crate::{statistics, Metadata};
 
 pub use crate::evaluator::variable::StringMatch;
 
@@ -817,7 +817,7 @@ pub struct MatchedRule<'scanner> {
     pub tags: &'scanner [String],
 
     /// Metadata associated with the rule.
-    pub metadatas: &'scanner [boreal_parser::rule::Metadata],
+    pub metadatas: &'scanner [Metadata],
 
     /// List of matched strings, with details on their matches.
     pub matches: Vec<StringMatches<'scanner>>,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -709,6 +709,7 @@ impl EvalContext {
             rule,
             var_matches.as_deref(),
             &self.previous_results,
+            &scanner.bytes_pool,
             scan_data,
         )?;
 
@@ -989,13 +990,22 @@ mod tests {
         let mut previous_results = Vec::new();
         let rules = &scanner.inner.rules;
         for rule in &rules[..(rules.len() - 1)] {
-            previous_results
-                .push(evaluate_rule(rule, None, &previous_results, &mut scan_data).unwrap());
+            previous_results.push(
+                evaluate_rule(
+                    rule,
+                    None,
+                    &previous_results,
+                    &scanner.inner.bytes_pool,
+                    &mut scan_data,
+                )
+                .unwrap(),
+            );
         }
         let last_res = evaluate_rule(
             &rules[rules.len() - 1],
             None,
             &previous_results,
+            &scanner.inner.bytes_pool,
             &mut scan_data,
         );
 


### PR DESCRIPTION
Intern literal bytes in a pool to reduce the memory it takes in compiled rules. This is used for literals in conditions, but mainly for metadata keys and values.

For example, the icewater ruleset have a lot of metadata for each rule, which always the same names. With this optimization, the memory consumption of the icewater compiled rules goes from 76MB to 62MB.