### PR TITLE
Add compiler profile to prioritize memory speed

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -64,15 +64,20 @@ A few observations:
 
 ## Memory usage:
 
-| rules set      | boreal  | yara   |
-| -------------- | ----    | ----   |
-| orion          | 12.8 MB | 12.3MB |
-| atr            | 12.6 MB | 14.0MB |
-| reversinglabs  | 14.9 MB | 15.8MB |
-| panopticon     | 10.9 MB | 13.4MB |
-| c0ffee         | 22.9 MB | 200MB  |
-| icewater       | 77.9 MB | 55.1MB |
-| signature-base | 78.9 MB | 27.8MB |
+In `boreal`, different compiler profiles can be used, with one prioritizing scanning speed,
+and the other one prioritzing memory usage. Those two profiles are presented separately to
+show the memory consumption impact.
+
+| rules set      | boreal (speed) | boreal (memory) | yara    |
+| -------------- | -------------- | --------------- | ------- |
+| orion          | 10.9 MB        | 9.71 MB         | 14.8 MB |
+| atr            | 10.7 MB        | 8.53 MB         | 15.7 MB |
+| reversinglabs  | 13.6 MB        | 12.2 MB         | 17.7 MB |
+| panopticon     | 9.07 MB        | 7.71 MB         | 15.3 MB |
+| c0ffee         | 16.7 MB        | 13.4 MB         | 198 MB  |
+| icewater       | 61.6 MB        | 55.6 MB         | 56.3 MB |
+| signature-base | 70.3 MB        | 44.2 MB         | 35.5 MB |
+| yara-rules     | 99.3 MB        | 74.0 MB         | 45.4 MB |
 
 Note that optimizing memory usage has not been a priority for the moment, as the focus was
 on optimizing performances. However, the next release will provide a way to proritize

--- a/benches/src/bench.rs
+++ b/benches/src/bench.rs
@@ -113,7 +113,9 @@ fn bench_scan_process(c: &mut Criterion) {
 }
 
 fn build_boreal_compiler() -> boreal::Compiler {
-    let mut boreal_compiler = boreal::Compiler::new();
+    let mut boreal_compiler = boreal::compiler::CompilerBuilder::new()
+        .profile(boreal::compiler::CompilerProfile::Speed)
+        .build();
     let _ = boreal_compiler.define_symbol("owner", "owner");
     let _ = boreal_compiler.define_symbol("filename", "filename");
     let _ = boreal_compiler.define_symbol("filepath", "filepath");

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -5,8 +5,8 @@ use std::process::ExitCode;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use boreal::compiler::ExternalValue;
-use boreal::module::Value as ModuleValue;
+use boreal::compiler::{CompilerBuilder, ExternalValue};
+use boreal::module::{Console, Value as ModuleValue};
 use boreal::scanner::{FragmentedScanMode, ScanError, ScanParams, ScanResult};
 use boreal::{statistics, Compiler, Metadata, MetadataValue, Scanner};
 
@@ -252,16 +252,15 @@ fn main() -> ExitCode {
     let mut scanner = {
         let rules_file: PathBuf = args.remove_one("rules_file").unwrap();
 
-        let mut compiler = Compiler::new();
-
         let no_console_logs = args.get_flag("no_console_logs");
         // Even if the console logs are disabled, add the module so that rules that use it
         // can still compile properly.
-        let _r = compiler.add_module(boreal::module::Console::with_callback(move |log| {
+        let builder = CompilerBuilder::new().add_module(Console::with_callback(move |log| {
             if !no_console_logs {
                 println!("{log}");
             }
         }));
+        let mut compiler = builder.build();
 
         compiler.set_params(
             boreal::compiler::CompilerParams::default()

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -814,6 +814,22 @@ fn test_invalid_fragmented_scan_mode() {
 }
 
 #[test]
+fn test_invalid_compiler_profile() {
+    cmd()
+        .arg("--profile")
+        .arg("bad_value")
+        .arg("rules.yar")
+        .arg("input")
+        .assert()
+        .stdout("")
+        .stderr(predicate::str::contains(
+            "invalid value 'bad_value' for \
+            '--profile <speed|memory>\': invalid value",
+        ))
+        .failure();
+}
+
+#[test]
 fn test_tags() {
     let rule_file = test_file(
         br#"

--- a/boreal/src/compiler/builder.rs
+++ b/boreal/src/compiler/builder.rs
@@ -1,0 +1,94 @@
+use std::{collections::HashMap, sync::Arc};
+
+use super::{AvailableModule, ModuleLocation};
+
+/// Configurable builder for the [`Compiler`] object.
+#[derive(Debug, Default)]
+pub struct CompilerBuilder {
+    /// Modules that can be imported when compiling rules.
+    modules: HashMap<&'static str, AvailableModule>,
+}
+
+impl CompilerBuilder {
+    /// Create a new builder with sane default values.
+    ///
+    /// Modules enabled by default:
+    /// - `time`
+    /// - `math`
+    /// - `string`
+    /// - `hash` if the `hash` feature is enabled
+    /// - `elf`, `macho`, `pe`, `dotnet` and `dex` if the `object` feature is enabled
+    /// - `magic` if the `magic` feature is enabled
+    /// - `cuckoo` if the `cuckoo` feature is enabled
+    ///
+    /// Modules disabled by default:
+    /// - `console`
+    ///
+    /// To create a builder without any modules, use [`CompilerBuilder::default`] to
+    /// create a [`CompilerBuilder`] without any modules, then add back only the desired modules.
+    #[must_use]
+    pub fn new() -> Self {
+        let this = Self::default();
+
+        let this = this.add_module(crate::module::Time);
+        let this = this.add_module(crate::module::Math);
+        let this = this.add_module(crate::module::String_);
+
+        #[cfg(feature = "hash")]
+        let this = this.add_module(crate::module::Hash);
+
+        #[cfg(feature = "object")]
+        let this = this.add_module(crate::module::Pe);
+        #[cfg(feature = "object")]
+        let this = this.add_module(crate::module::Elf);
+        #[cfg(feature = "object")]
+        let this = this.add_module(crate::module::MachO);
+        #[cfg(feature = "object")]
+        let this = this.add_module(crate::module::Dotnet);
+        #[cfg(feature = "object")]
+        let this = this.add_module(crate::module::Dex);
+
+        #[cfg(feature = "magic")]
+        let this = this.add_module(crate::module::Magic);
+
+        #[cfg(feature = "cuckoo")]
+        let this = this.add_module(crate::module::Cuckoo);
+
+        this
+    }
+
+    /// Add a module that will be importable in rules.
+    ///
+    /// If the same module has already been added, it will be replaced by this one.
+    /// This can be useful to change the parameters of a module.
+    #[must_use]
+    pub fn add_module<M: crate::module::Module + 'static>(mut self, module: M) -> Self {
+        let compiled_module = Arc::new(super::module::compile_module(&module));
+
+        let _r = self.modules.insert(
+            compiled_module.name,
+            AvailableModule {
+                compiled_module,
+                location: ModuleLocation::Module(Box::new(module)),
+            },
+        );
+        self
+    }
+
+    /// Build a [`Compiler`] object with the configuration set on this builder.
+    #[must_use]
+    pub fn build(self) -> super::Compiler {
+        super::Compiler::build(self.modules)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::test_type_traits_non_clonable;
+
+    #[test]
+    fn test_types_traits() {
+        test_type_traits_non_clonable(CompilerBuilder::default());
+    }
+}

--- a/boreal/src/compiler/builder.rs
+++ b/boreal/src/compiler/builder.rs
@@ -7,6 +7,9 @@ use super::{AvailableModule, ModuleLocation};
 pub struct CompilerBuilder {
     /// Modules that can be imported when compiling rules.
     modules: HashMap<&'static str, AvailableModule>,
+
+    /// Profile to use when compiling rules.
+    profile: super::CompilerProfile,
 }
 
 impl CompilerBuilder {
@@ -75,20 +78,44 @@ impl CompilerBuilder {
         self
     }
 
+    /// Set the profile to use when compiling rules.
+    ///
+    /// By default, [`CompilerProfile::Speed`] is used.
+    #[must_use]
+    pub fn profile(mut self, profile: super::CompilerProfile) -> Self {
+        self.profile = profile;
+        self
+    }
+
     /// Build a [`Compiler`] object with the configuration set on this builder.
     #[must_use]
     pub fn build(self) -> super::Compiler {
-        super::Compiler::build(self.modules)
+        super::Compiler::build(self.modules, self.profile)
+    }
+
+    /// Get the profile to use when compiling rules.
+    #[must_use]
+    pub fn get_profile(&self) -> super::CompilerProfile {
+        self.profile
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::CompilerProfile;
     use crate::test_helpers::test_type_traits_non_clonable;
 
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(CompilerBuilder::default());
+    }
+
+    #[test]
+    fn test_getters() {
+        let builder = CompilerBuilder::default();
+
+        let builder = builder.profile(CompilerProfile::Memory);
+        assert_eq!(builder.get_profile(), CompilerProfile::Memory);
     }
 }

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -69,6 +69,9 @@ pub struct Compiler {
 
     /// Compilation parameters
     params: CompilerParams,
+
+    /// Profile to use when compiling rules.
+    pub(crate) profile: CompilerProfile,
 }
 
 #[derive(Debug)]
@@ -98,6 +101,27 @@ struct ImportedModule {
     module_index: usize,
 }
 
+/// Profile to use when compiling rules.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CompilerProfile {
+    /// Prioritize scan speed.
+    ///
+    /// This profile will strive to get the best possible scan speed by using more memory
+    /// when possible.
+    Speed,
+    /// Prioritize memory usage
+    ///
+    /// This profile will strive to reduce memory usage as much as possible, even if it means
+    /// a slower scan speed overall.
+    Memory,
+}
+
+impl Default for CompilerProfile {
+    fn default() -> Self {
+        Self::Speed
+    }
+}
+
 impl Default for Compiler {
     fn default() -> Self {
         Self {
@@ -113,6 +137,7 @@ impl Default for Compiler {
             external_symbols: Vec::new(),
             bytes_pool: BytesPoolBuilder::default(),
             params: CompilerParams::default(),
+            profile: CompilerProfile::default(),
         }
     }
 }
@@ -143,9 +168,13 @@ impl Compiler {
     ///
     /// Returns false if a module with the same name is already registered, and the module
     /// was not added.
-    fn build(available_modules: HashMap<&'static str, AvailableModule>) -> Self {
+    fn build(
+        available_modules: HashMap<&'static str, AvailableModule>,
+        profile: CompilerProfile,
+    ) -> Self {
         Self {
             available_modules,
+            profile,
             ..Default::default()
         }
     }

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -30,13 +30,13 @@ use crate::{statistics, Scanner};
 #[derive(Debug)]
 pub struct Compiler {
     /// List of compiled rules.
-    rules: Vec<rule::Rule>,
+    pub(crate) rules: Vec<rule::Rule>,
 
     /// List of compiled, global rules.
-    global_rules: Vec<rule::Rule>,
+    pub(crate) global_rules: Vec<rule::Rule>,
 
     /// List of compiled variables.
-    variables: Vec<variable::Variable>,
+    pub(crate) variables: Vec<variable::Variable>,
 
     /// Number of variables used by global rules.
     nb_global_rules_variables: usize,
@@ -46,7 +46,7 @@ pub struct Compiler {
     /// This list always contains at least one namespace: the default one,
     /// at index 0. Other namespaces are added when rules are added in the
     /// non default namespace.
-    namespaces: Vec<Namespace>,
+    pub(crate) namespaces: Vec<Namespace>,
 
     /// Map from the namespace name to its index in the `namespaces` list.
     namespaces_indexes: HashMap<String, usize>,
@@ -57,15 +57,15 @@ pub struct Compiler {
     available_modules: HashMap<&'static str, AvailableModule>,
 
     /// List of imported modules, passed to the scanner.
-    imported_modules: Vec<Box<dyn crate::module::Module>>,
+    pub(crate) imported_modules: Vec<Box<dyn crate::module::Module>>,
 
     /// Externally defined symbols.
-    external_symbols: Vec<external_symbol::ExternalSymbol>,
+    pub(crate) external_symbols: Vec<external_symbol::ExternalSymbol>,
 
     /// Bytes intern pool.
     ///
     /// This is used to reduce memory footprint and share byte strings.
-    bytes_pool: BytesPoolBuilder,
+    pub(crate) bytes_pool: BytesPoolBuilder,
 
     /// Compilation parameters
     params: CompilerParams,
@@ -496,17 +496,7 @@ impl Compiler {
     /// Can fail if generating a set of all rules variables is not possible.
     #[must_use]
     pub fn into_scanner(self) -> Scanner {
-        let namespaces = self.namespaces.into_iter().map(|v| v.name).collect();
-
-        Scanner::new(
-            self.rules,
-            self.global_rules,
-            self.variables,
-            self.imported_modules,
-            self.external_symbols,
-            namespaces,
-            self.bytes_pool.into_pool(),
-        )
+        Scanner::new(self)
     }
 }
 
@@ -517,9 +507,9 @@ impl Compiler {
 /// - new rules can reference already existing rules
 /// - new rules can either import new modules, or directly use already imported modules
 #[derive(Debug, Default)]
-struct Namespace {
+pub(crate) struct Namespace {
     /// Name of the namespace, `None` if default.
-    name: Option<String>,
+    pub(crate) name: Option<String>,
 
     /// Map of a rule name to its index in the `rules` vector in [`Compiler`].
     ///

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -5,7 +5,7 @@ use super::module::compile_module;
 use super::rule::RuleCompiler;
 use super::{
     AddRuleError, AddRuleErrorKind, AddRuleStatus, AvailableModule, CompilationError, Compiler,
-    CompilerParams, ImportedModule, ModuleLocation, Namespace,
+    CompilerParams, CompilerProfile, ImportedModule, ModuleLocation, Namespace,
 };
 use crate::bytes_pool::BytesPoolBuilder;
 use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
@@ -289,6 +289,7 @@ fn test_types_traits() {
         }),
     });
     test_type_traits(CompilerParams::default());
+    test_type_traits(CompilerProfile::default());
     test_type_traits_non_clonable(AddRuleStatus {
         warnings: Vec::new(),
         statistics: Vec::new(),

--- a/boreal/src/module/cuckoo.rs
+++ b/boreal/src/module/cuckoo.rs
@@ -10,9 +10,9 @@ use super::{EvalContext, Module, ModuleData, StaticValue, Type, Value};
 ///
 /// ```
 /// use boreal::module::{Cuckoo, CuckooData};
+/// use boreal::compiler::CompilerBuilder;
 ///
-/// let mut compiler = boreal::Compiler::new();
-/// compiler.add_module(Cuckoo);
+/// let mut compiler = CompilerBuilder::new().add_module(Cuckoo).build();
 /// compiler.add_rules_str(r#"
 /// import "cuckoo"
 ///

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! ```
 //! use boreal::module::{Module, StaticValue};
-//! use boreal::Compiler;
+//! use boreal::compiler::CompilerBuilder;
 //! use std::collections::HashMap;
 //!
 //! struct Pi;
@@ -32,8 +32,7 @@
 //! "#;
 //!
 //! fn main() {
-//!     let mut compiler = Compiler::new();
-//!     compiler.add_module(Pi);
+//!     let mut compiler = CompilerBuilder::new().add_module(Pi).build();
 //!     assert!(compiler.add_rules_str(RULE).is_ok());
 //! }
 //! ```
@@ -339,6 +338,7 @@ impl std::fmt::Debug for ModuleDataMap<'_> {
 /// ```
 /// use std::collections::HashMap;
 /// use boreal::module::{EvalContext, Module, ModuleData, StaticValue, Value, Type};
+/// use boreal::compiler::CompilerBuilder;
 ///
 /// struct Bar;
 ///
@@ -371,8 +371,7 @@ impl std::fmt::Debug for ModuleDataMap<'_> {
 ///     }
 /// }
 ///
-/// let mut compiler = boreal::Compiler::new();
-/// compiler.add_module(Bar);
+/// let mut compiler = CompilerBuilder::new().add_module(Bar).build();
 /// compiler.add_rules_str(r#"
 /// import "bar"
 ///

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -881,11 +881,11 @@ impl std::fmt::Display for DefineSymbolError {
 
 #[cfg(test)]
 mod tests {
+    use crate::compiler::CompilerBuilder;
     use crate::module::{EvalContext, ScanContext, StaticValue, Type, Value as ModuleValue};
     use crate::test_helpers::{
         test_type_traits, test_type_traits_non_clonable, test_type_unwind_safe,
     };
-    use crate::Compiler;
 
     use super::*;
 
@@ -970,8 +970,7 @@ mod tests {
 
     #[track_caller]
     fn test_eval_with_poison(rule_str: &str, mem: &[u8], expected: Option<bool>) {
-        let mut compiler = Compiler::default();
-        _ = compiler.add_module(Test);
+        let mut compiler = CompilerBuilder::default().add_module(Test).build();
         let _r = compiler.add_rules_str(rule_str).unwrap();
         let scanner = compiler.into_scanner();
 

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -110,11 +110,12 @@ impl Scanner {
             imported_modules,
             external_symbols,
             bytes_pool,
+            profile,
             ..
         } = compiler;
         let namespaces = namespaces.into_iter().map(|v| v.name).collect();
 
-        let ac_scan = ac_scan::AcScan::new(&variables);
+        let ac_scan = ac_scan::AcScan::new(&variables, profile);
 
         let mut external_symbols_values = Vec::new();
         let mut external_symbols_map = HashMap::new();

--- a/boreal/tests/it/modules.rs
+++ b/boreal/tests/it/modules.rs
@@ -1,5 +1,7 @@
 use std::sync::Mutex;
 
+use boreal::compiler::CompilerBuilder;
+
 use crate::utils::{check, check_boreal, check_err, Compiler};
 
 #[track_caller]
@@ -446,13 +448,14 @@ fn test_module_hash() {
 #[test]
 fn test_module_console() {
     static LOGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
     let mut compiler = Compiler::new();
-    let res = compiler
-        .compiler
+    // Replace boreal compiler with a new one to add the console module
+    compiler.compiler = CompilerBuilder::new()
         .add_module(boreal::module::Console::with_callback(|log| {
             LOGS.lock().unwrap().push(log);
-        }));
-    assert!(res);
+        }))
+        .build();
 
     compiler.add_rules(
         r#"import "console"

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -43,8 +43,7 @@ impl Compiler {
     }
 
     fn new_inner(with_yara: bool) -> Self {
-        let mut compiler = build_compiler();
-        compiler.add_module(super::module_tests::Tests);
+        let compiler = build_compiler(true);
 
         let mut this = Self {
             compiler,
@@ -214,8 +213,14 @@ impl Compiler {
     }
 }
 
-fn build_compiler() -> boreal::Compiler {
-    boreal::Compiler::new()
+fn build_compiler(with_test_module: bool) -> boreal::Compiler {
+    if with_test_module {
+        boreal::compiler::CompilerBuilder::new()
+            .add_module(super::module_tests::Tests)
+            .build()
+    } else {
+        boreal::Compiler::new()
+    }
 }
 
 impl Checker {
@@ -800,7 +805,7 @@ pub fn compare_module_values_on_mem<M: Module>(
     ignored_diffs: &[&str],
 ) {
     // Setup boreal scanner
-    let mut compiler = build_compiler();
+    let mut compiler = build_compiler(false);
     compiler
         .add_rules_str(format!(
             "import \"{}\" rule a {{ condition: true }}",


### PR DESCRIPTION
- Add a new CompilerBuilder object, use it to improve the API of adding modules
- Add a CompilerProfile enum, so that memory usage can be selected instead of scanning speed

TODO: would be nice to run all tests on both profiles