### PR TITLE
Add compiler param to disable includes

### DIFF
--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -504,6 +504,12 @@ impl Compiler {
         self.params = params;
     }
 
+    /// Get compilation parameters.
+    #[must_use]
+    pub fn params(&self) -> &CompilerParams {
+        &self.params
+    }
+
     /// Names of modules that are available for use in rules.
     pub fn available_modules(&self) -> impl Iterator<Item = &str> {
         self.available_modules.keys().map(|v| &**v)

--- a/boreal/src/compiler/params.rs
+++ b/boreal/src/compiler/params.rs
@@ -11,6 +11,9 @@ pub struct CompilerParams {
 
     /// Compute statistics when compiling rules.
     pub(crate) compute_statistics: bool,
+
+    /// Disable includes in YARA documents.
+    pub(crate) disable_includes: bool,
 }
 
 impl Default for CompilerParams {
@@ -19,6 +22,7 @@ impl Default for CompilerParams {
             max_condition_depth: 40,
             fail_on_warnings: false,
             compute_statistics: false,
+            disable_includes: false,
         }
     }
 }
@@ -65,6 +69,18 @@ impl CompilerParams {
     #[must_use]
     pub fn compute_statistics(mut self, compute_statistics: bool) -> Self {
         self.compute_statistics = compute_statistics;
+        self
+    }
+
+    /// Disable the possibility to include yara files.
+    ///
+    /// If true, an error is returned if the `include` keyword is used in a YARA document.
+    /// Compute statistics during compilation.
+    ///
+    /// Default value is false.
+    #[must_use]
+    pub fn disable_includes(mut self, disable_includes: bool) -> Self {
+        self.disable_includes = disable_includes;
         self
     }
 }

--- a/boreal/tests/assets/invalid_files/compilation/duplicated_identifier_binding.yar
+++ b/boreal/tests/assets/invalid_files/compilation/duplicated_identifier_binding.yar
@@ -1,3 +1,4 @@
+// [error: duplicated loop identifier i]
 rule duplicated_binding {
     condition:
         for any i in (1..5): (

--- a/boreal/tests/assets/invalid_files/compilation/duplicated_rule_name.yar
+++ b/boreal/tests/assets/invalid_files/compilation/duplicated_rule_name.yar
@@ -1,3 +1,4 @@
+// [error: rule `a` is already declared in this namespace]
 rule a {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/duplicated_rule_tag.yar
+++ b/boreal/tests/assets/invalid_files/compilation/duplicated_rule_tag.yar
@@ -1,3 +1,4 @@
+// [error: tag `foo` specified multiple times]
 rule a: foo bar foo {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/duplicated_variable.yar
+++ b/boreal/tests/assets/invalid_files/compilation/duplicated_variable.yar
@@ -1,3 +1,4 @@
+// [error: variable $m is declared more than once]
 rule a {
     strings:
         $m = /alg/

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         15 + "foo" == 3

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types2.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         /a/ - 1.2 == 3

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types3.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         "a" * 1.2 == 3

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types4.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         1 \ "b" == 3

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types5.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types5.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         "a" > 1.2 == 3

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types6.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types6.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         3 == /ab/

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types7.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types7.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         3 != /ab/

--- a/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types8.yar
+++ b/boreal/tests/assets/invalid_files/compilation/expression_incompatible_types8.yar
@@ -1,3 +1,4 @@
+// [error: expressions have invalid types]
 rule a {
     condition:
         for any i in ("a", "b"):

--- a/boreal/tests/assets/invalid_files/compilation/import_invalid.yar
+++ b/boreal/tests/assets/invalid_files/compilation/import_invalid.yar
@@ -1,3 +1,4 @@
+// [error: syntax error]
 import "time"
 import ""
 

--- a/boreal/tests/assets/invalid_files/compilation/import_unknown.yar
+++ b/boreal/tests/assets/invalid_files/compilation/import_unknown.yar
@@ -1,3 +1,4 @@
+// [error: unknown import mohg]
 import "time"
 import "mohg"
 

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding.yar
@@ -1,3 +1,4 @@
+// [error: expected 2 identifiers to bind, got 1]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding2.yar
@@ -1,3 +1,4 @@
+// [error: expected 1 identifiers to bind, got 2]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding3.yar
@@ -1,3 +1,4 @@
+// [error: expected 1 identifiers to bind, got 2]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_binding4.yar
@@ -1,3 +1,4 @@
+// [error: expected 1 identifiers to bind, got 3]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_call.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_call.yar
@@ -1,3 +1,4 @@
+// [error: invalid arguments types: [integer]]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_index_type.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_index_type.yar
@@ -1,3 +1,4 @@
+// [error: expected an expression of type integer]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type.yar
@@ -1,3 +1,4 @@
+// [error: invalid identifier type]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type2.yar
@@ -1,3 +1,4 @@
+// [error: invalid identifier type]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type3.yar
@@ -1,3 +1,4 @@
+// [error: invalid identifier type]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type4.yar
@@ -1,3 +1,4 @@
+// [error: invalid identifier type]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type5.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_type5.yar
@@ -1,3 +1,4 @@
+// [error: invalid identifier type]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use.yar
@@ -1,3 +1,4 @@
+// [error: wrong use of identifier]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use2.yar
@@ -1,3 +1,4 @@
+// [error: wrong use of identifier]
 rule a {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use3.yar
@@ -1,3 +1,4 @@
+// [error: wrong use of identifier]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_identifier_use4.yar
@@ -1,3 +1,4 @@
+// [error: wrong use of identifier]
 import "pe"
 
 rule c {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_include.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_include.yar
@@ -1,3 +1,4 @@
+// [error: cannot include]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_included.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_included.yar
@@ -1,3 +1,4 @@
+// [error: variable $a is unused]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/invalid_type.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_type.yar
@@ -1,3 +1,4 @@
+// [error: expression has an invalid type]
 rule a {
     condition:
         uint16("str") == 3

--- a/boreal/tests/assets/invalid_files/compilation/invalid_type2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_type2.yar
@@ -1,3 +1,4 @@
+// [error: expression has an invalid type]
 rule a {
     condition:
         for any i in (true, false): (i)

--- a/boreal/tests/assets/invalid_files/compilation/invalid_type3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_type3.yar
@@ -1,3 +1,4 @@
+// [error: expression has an invalid type]
 rule a {
     condition:
         for any i in (1, 2, "a", 3): (i)

--- a/boreal/tests/assets/invalid_files/compilation/invalid_type4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/invalid_type4.yar
@@ -1,3 +1,4 @@
+// [error: expression has an invalid type]
 rule a {
     condition:
         for any i in (1, 2, 3):

--- a/boreal/tests/assets/invalid_files/compilation/match_on_wildcard_rule_set.yar
+++ b/boreal/tests/assets/invalid_files/compilation/match_on_wildcard_rule_set.yar
@@ -1,3 +1,4 @@
+// [error: rule "a125" matches a previous rule set "a*"]
 rule a0 {
     condition:
         true

--- a/boreal/tests/assets/invalid_files/compilation/non_iterable_identifier.yar
+++ b/boreal/tests/assets/invalid_files/compilation/non_iterable_identifier.yar
@@ -1,3 +1,4 @@
+// [error: identifier is not iterable]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/non_iterable_identifier2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/non_iterable_identifier2.yar
@@ -1,3 +1,4 @@
+// [error: identifier is not iterable]
 import "pe"
 
 rule z {

--- a/boreal/tests/assets/invalid_files/compilation/regex_error.yar
+++ b/boreal/tests/assets/invalid_files/compilation/regex_error.yar
@@ -1,3 +1,4 @@
+// [error: regex failed to build: Error("Compiled regex exceeds size limit of 10485760 bytes.")]
 rule a {
     condition:
         "aa" matches /.{1,999999}/

--- a/boreal/tests/assets/invalid_files/compilation/regex_error2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/regex_error2.yar
@@ -1,3 +1,4 @@
+// [error: regex failed to build: Error("Compiled regex exceeds size limit of 10485760 bytes.")]
 rule a {
     condition:
         /.{1,999999}/

--- a/boreal/tests/assets/invalid_files/compilation/unauthorized_include.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unauthorized_include.yar
@@ -1,0 +1,6 @@
+// [disable includes]
+rule a {
+    condition: true
+}
+
+include "./valid.yar"

--- a/boreal/tests/assets/invalid_files/compilation/unauthorized_include.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unauthorized_include.yar
@@ -1,3 +1,4 @@
+// [error: includes are not allowed]
 // [disable includes]
 rule a {
     condition: true

--- a/boreal/tests/assets/invalid_files/compilation/unknown_identifier.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_identifier.yar
@@ -1,3 +1,4 @@
+// [error: unknown identifier "foo"]
 rule a {
     condition: foo
 }

--- a/boreal/tests/assets/invalid_files/compilation/unknown_identifier2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_identifier2.yar
@@ -1,3 +1,4 @@
+// [error: unknown identifier "foo"]
 rule a {
     condition:
         for any a in foo: (true)

--- a/boreal/tests/assets/invalid_files/compilation/unknown_identifier_field.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_identifier_field.yar
@@ -1,3 +1,4 @@
+// [error: unknown field "myn"]
 import "pe"
 
 rule a {

--- a/boreal/tests/assets/invalid_files/compilation/unknown_identifier_ruleset.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_identifier_ruleset.yar
@@ -1,3 +1,4 @@
+// [error: unknown identifier "b*"]
 rule a1 {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/unknown_identifier_ruleset2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_identifier_ruleset2.yar
@@ -1,3 +1,4 @@
+// [error: unknown identifier "b"]
 rule a1 {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/unknown_import.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_import.yar
@@ -1,3 +1,4 @@
+// [error: unknown import bags]
 rule a {
     condition: true
 }

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         $b

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable2.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         #b == 2

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable3.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable3.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         !b == 2

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable4.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable4.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         #b in (2..3)

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable5.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable5.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         @b

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable6.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable6.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     condition:
         $b at 100

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable_variableset.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable_variableset.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b*]
 rule a {
     strings:
         $a0 = "a0"

--- a/boreal/tests/assets/invalid_files/compilation/unknown_variable_variableset2.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unknown_variable_variableset2.yar
@@ -1,3 +1,4 @@
+// [error: unknown variable $b]
 rule a {
     strings:
         $a0 = "a0"

--- a/boreal/tests/assets/invalid_files/compilation/unused_variable.yar
+++ b/boreal/tests/assets/invalid_files/compilation/unused_variable.yar
@@ -1,3 +1,4 @@
+// [error: variable $a is unused]
 rule a {
     strings:
         $a = "a"

--- a/boreal/tests/assets/invalid_files/compilation/valid.yar
+++ b/boreal/tests/assets/invalid_files/compilation/valid.yar
@@ -1,0 +1,7 @@
+// [skip]
+// This file is used to be included by others, without this include causing errors.
+// It is skipped when iterating on all files since it does not cause any errors
+// when compiled.
+rule b {
+    condition: true
+}

--- a/boreal/tests/assets/invalid_files/compilation/variable_compilation.yar
+++ b/boreal/tests/assets/invalid_files/compilation/variable_compilation.yar
@@ -1,3 +1,4 @@
+// [error: variable $a cannot be compiled: Compiled regex exceeds size limit of 10485760 bytes.]
 rule a {
     strings:
         $a = /.{1,999999}/

--- a/boreal/tests/assets/invalid_files/compilation/variable_empty.yar
+++ b/boreal/tests/assets/invalid_files/compilation/variable_empty.yar
@@ -1,3 +1,4 @@
+// [error: variable $foo cannot be compiled: variable is empty]
 rule a {
     strings:
         $foo = "" wide base64

--- a/boreal/tests/assets/invalid_files/parsing/base64_alphabets_incompatible.yar
+++ b/boreal/tests/assets/invalid_files/parsing/base64_alphabets_incompatible.yar
@@ -1,3 +1,4 @@
+// [error: alphabets used for base64 and base64wide must be identical]
 rule a {
     strings:
         $a = "a" base64("/=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789") base64wide

--- a/boreal/tests/assets/invalid_files/parsing/base64_alphabets_incompatible2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/base64_alphabets_incompatible2.yar
@@ -1,3 +1,4 @@
+// [error: alphabets used for base64 and base64wide must be identical]
 rule a {
     strings:
         $a = "a" base64 base64wide("/=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")

--- a/boreal/tests/assets/invalid_files/parsing/base64_invalid_length.yar
+++ b/boreal/tests/assets/invalid_files/parsing/base64_invalid_length.yar
@@ -1,3 +1,4 @@
+// [error: base64 modifier alphabet must contain exactly 64 characters]
 rule a {
     strings:
         $a = "a" base64("abc")

--- a/boreal/tests/assets/invalid_files/parsing/empty_regex.yar
+++ b/boreal/tests/assets/invalid_files/parsing/empty_regex.yar
@@ -1,3 +1,4 @@
+// [error: syntax error]
 rule a {
     strings:
         $a = //

--- a/boreal/tests/assets/invalid_files/parsing/expr_too_deep.yar
+++ b/boreal/tests/assets/invalid_files/parsing/expr_too_deep.yar
@@ -1,3 +1,4 @@
+// [error: too many imbricated expressions]
 // [no libyara conformance]
 // Disabled on libyara as there isn't a depth limit afaict
 rule a {

--- a/boreal/tests/assets/invalid_files/parsing/hex_string_invalid_not.yar
+++ b/boreal/tests/assets/invalid_files/parsing/hex_string_invalid_not.yar
@@ -1,3 +1,4 @@
+// [error: syntax error]
 rule a {
     strings:
         $a = { AB ~ ?? 0F }

--- a/boreal/tests/assets/invalid_files/parsing/hex_string_not_mask_all.yar
+++ b/boreal/tests/assets/invalid_files/parsing/hex_string_not_mask_all.yar
@@ -1,3 +1,4 @@
+// [error: negating an unknown byte is not allowed]
 rule a {
     strings:
         $a = { AB ~?? 0F }

--- a/boreal/tests/assets/invalid_files/parsing/hex_string_too_deep.yar
+++ b/boreal/tests/assets/invalid_files/parsing/hex_string_too_deep.yar
@@ -1,3 +1,4 @@
+// [error: too many imbricated groups in the hex string]
 // [no libyara conformance]
 // Disabled on libyara as there isn't a depth limit afaict
 rule a {

--- a/boreal/tests/assets/invalid_files/parsing/jump_at_bound.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_at_bound.yar
@@ -1,3 +1,4 @@
+// [error: a list of tokens cannot start or end with a jump]
 rule a {
     strings:
         $a = { [1-2] AB }

--- a/boreal/tests/assets/invalid_files/parsing/jump_at_bound2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_at_bound2.yar
@@ -1,3 +1,4 @@
+// [error: a list of tokens cannot start or end with a jump]
 rule a {
     strings:
         $a = { ( CD EF | AB [-2] ) 85 }

--- a/boreal/tests/assets/invalid_files/parsing/jump_empty.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_empty.yar
@@ -1,3 +1,4 @@
+// [error: jump cannot have a length of 0]
 rule a {
     strings:
         $a = { AB [0] 0F }

--- a/boreal/tests/assets/invalid_files/parsing/jump_range_invalid.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_range_invalid.yar
@@ -1,3 +1,4 @@
+// [error: invalid range for the jump: 5 > 2]
 rule a {
     strings:
         $a = { AB [5-2] 85 }

--- a/boreal/tests/assets/invalid_files/parsing/jump_too_big_in_alternation.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_too_big_in_alternation.yar
@@ -1,3 +1,4 @@
+// [error: jumps over 200 not allowed inside alternations (|)]
 rule a {
     strings:
         $a = { ( CD | AB [0-201] 85 ) }

--- a/boreal/tests/assets/invalid_files/parsing/jump_unbounded_in_alternation.yar
+++ b/boreal/tests/assets/invalid_files/parsing/jump_unbounded_in_alternation.yar
@@ -1,3 +1,4 @@
+// [error: unbounded jumps not allowed inside alternations (|)]
 rule a {
     strings:
         $a = { ( CD | AB [-] 85 ) }

--- a/boreal/tests/assets/invalid_files/parsing/mul_overflow.yar
+++ b/boreal/tests/assets/invalid_files/parsing/mul_overflow.yar
@@ -1,3 +1,4 @@
+// [error: multiplication 10000000000001 * 1048576 overflows]
 rule a {
     condition:
         15 == 10000000000001MB

--- a/boreal/tests/assets/invalid_files/parsing/regex_class_range_invalid.yar
+++ b/boreal/tests/assets/invalid_files/parsing/regex_class_range_invalid.yar
@@ -1,3 +1,4 @@
+// [error: invalid regex class range, start must be <= to end]
 rule a {
     strings:
         $a = /[z-a]/

--- a/boreal/tests/assets/invalid_files/parsing/regex_non_ascii_byte.yar
+++ b/boreal/tests/assets/invalid_files/parsing/regex_non_ascii_byte.yar
@@ -1,3 +1,4 @@
+// [error: regex should only contain ascii bytes]
 rule a {
     strings:
         $a = /[é]/

--- a/boreal/tests/assets/invalid_files/parsing/regex_range_invalid.yar
+++ b/boreal/tests/assets/invalid_files/parsing/regex_range_invalid.yar
@@ -1,3 +1,4 @@
+// [error: invalid regex range, start must be <= to end]
 rule a {
     strings:
         $a = /a{5,4}/

--- a/boreal/tests/assets/invalid_files/parsing/regex_too_deep.yar
+++ b/boreal/tests/assets/invalid_files/parsing/regex_too_deep.yar
@@ -1,3 +1,4 @@
+// [error: too many imbricated groups in the regex]
 // [no libyara conformance]
 // Disabled on libyara as there isn't a depth limit afaict
 rule a {

--- a/boreal/tests/assets/invalid_files/parsing/str_to_hex_int.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_hex_int.yar
@@ -1,3 +1,4 @@
+// [error: error converting hexadecimal notation to integer: number too large to fit in target type]
 rule a {
     condition:
         0x0123456789ABCDEFabcd

--- a/boreal/tests/assets/invalid_files/parsing/str_to_hex_int2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_hex_int2.yar
@@ -1,3 +1,4 @@
+// [error: error converting hexadecimal notation to integer: invalid digit found in string]
 rule a {
     strings:
         $a = /\xGR/

--- a/boreal/tests/assets/invalid_files/parsing/str_to_hex_int3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_hex_int3.yar
@@ -1,3 +1,4 @@
+// [error: error converting hexadecimal notation to integer: invalid digit found in string]
 rule a {
     strings:
         $a = /\x1/

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 rule a {
     condition:
         10000000000000000000000000000

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int2.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 rule a {
     strings:
         $a = /a{10000000000}/

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int3.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 rule a {
     strings:
         $a = /a{10000000000,}/

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int4.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int4.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 rule a {
     strings:
         $a = /a{0,10000000000}/

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int_range.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int_range.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 // [no libyara conformance]
 // Test disabled against yara because of https://github.com/VirusTotal/yara/issues/1791,
 // yara returning an error depends on the platform.

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int_range2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int_range2.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 // [no libyara conformance]
 // Test disabled against yara because of https://github.com/VirusTotal/yara/issues/1791,
 // yara returning an error depends on the platform.

--- a/boreal/tests/assets/invalid_files/parsing/str_to_int_range3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_int_range3.yar
@@ -1,3 +1,4 @@
+// [error: error converting to integer: number too large to fit in target type]
 // [no libyara conformance]
 // Test disabled against yara because of https://github.com/VirusTotal/yara/issues/1791,
 // yara returning an error depends on the platform.

--- a/boreal/tests/assets/invalid_files/parsing/str_to_oct_int.yar
+++ b/boreal/tests/assets/invalid_files/parsing/str_to_oct_int.yar
@@ -1,3 +1,4 @@
+// [error: error converting octal notation to integer: number too large to fit in target type]
 rule a {
     condition:
         0o012345670123456701234567

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated.yar
@@ -1,3 +1,4 @@
+// [error: string modifier private appears multiple times]
 rule a {
     strings:
         $a = "a" private wide private

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated2.yar
@@ -1,3 +1,4 @@
+// [error: string modifier xor appears multiple times]
 rule a {
     strings:
         $a = "a" wide xor xor(0-100)

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated3.yar
@@ -1,3 +1,4 @@
+// [error: string modifier base64 appears multiple times]
 rule a {
     strings:
         $a = "a" base64 xor base64

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated4.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_duplicated4.yar
@@ -1,3 +1,4 @@
+// [error: string modifier base64wide appears multiple times]
 rule a {
     strings:
         $a = "a" base64wide xor base64wide("/=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers xor and nocase are incompatible]
 rule a {
     strings:
         $a = "a" xor private nocase

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible2.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64 and xor are incompatible]
 rule a {
     strings:
         $a = "a" base64 xor

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible3.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64wide and xor are incompatible]
 rule a {
     strings:
         $a = "a" private xor base64wide

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible4.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible4.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64 and nocase are incompatible]
 rule a {
     strings:
         $a = "a" base64 nocase

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible5.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible5.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64wide and nocase are incompatible]
 rule a {
     strings:
         $a = "a" nocase base64wide

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible6.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible6.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64 and fullword are incompatible]
 rule a {
     strings:
         $a = "a" base64 private fullword

--- a/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible7.yar
+++ b/boreal/tests/assets/invalid_files/parsing/string_modifier_incompatible7.yar
@@ -1,3 +1,4 @@
+// [error: string modifiers base64wide and fullword are incompatible]
 rule a {
     strings:
         $a = "a" fullword wide base64wide private

--- a/boreal/tests/assets/invalid_files/parsing/xor_invalid.yar
+++ b/boreal/tests/assets/invalid_files/parsing/xor_invalid.yar
@@ -1,3 +1,4 @@
+// [error: xor range invalid: 50 > 25]
 rule a {
     strings:
         $a = "a" xor(50-25)

--- a/boreal/tests/assets/invalid_files/parsing/xor_invalid_value.yar
+++ b/boreal/tests/assets/invalid_files/parsing/xor_invalid_value.yar
@@ -1,3 +1,4 @@
+// [error: xor range value 500 invalid, must be in [0-255]]
 rule a {
     strings:
         $a = "a" xor(0-500)

--- a/boreal/tests/assets/invalid_files/parsing/xor_invalid_value2.yar
+++ b/boreal/tests/assets/invalid_files/parsing/xor_invalid_value2.yar
@@ -1,3 +1,4 @@
+// [error: xor range value 300 invalid, must be in [0-255]]
 rule a {
     strings:
         $a = "a" xor(300-301)

--- a/boreal/tests/assets/invalid_files/parsing/xor_invalid_value3.yar
+++ b/boreal/tests/assets/invalid_files/parsing/xor_invalid_value3.yar
@@ -1,3 +1,4 @@
+// [error: syntax error]
 rule a {
     strings:
         $a = "a" xor(-50-5)

--- a/boreal/tests/it/error.rs
+++ b/boreal/tests/it/error.rs
@@ -1,4 +1,4 @@
-use crate::utils::{check_err, Compiler};
+use crate::utils::Compiler;
 
 #[test]
 fn test_invalid_files() {
@@ -10,23 +10,62 @@ fn test_invalid_files() {
         let contents = std::fs::read_to_string(&file)
             .unwrap_or_else(|e| panic!("cannot read file {file:?}: {e}"));
 
-        println!("checking file {file:?}");
-        if contents.starts_with("// [no libyara conformance]") {
-            #[cfg(debug_assertions)]
-            let compiler = {
+        // Files can start with comments that indicate directives.
+        let directives = extract_directives(&contents);
+
+        if directives.skip {
+            println!("skipping file {file:?}");
+            continue;
+        } else {
+            println!("checking file {file:?}");
+        }
+
+        let mut compiler = if directives.without_yara {
+            if cfg!(debug_assertions) {
                 let mut compiler = Compiler::new_without_yara();
                 let params = boreal::compiler::CompilerParams::default().max_condition_depth(15);
                 compiler.set_params(params);
                 compiler
-            };
-            #[cfg(not(debug_assertions))]
-            let compiler = Compiler::new_without_yara();
-
-            compiler.check_add_rules_err(&contents, "");
+            } else {
+                Compiler::new_without_yara()
+            }
         } else {
-            // Maybe including the expected prefix in each file (as a comment) would be a nice
-            // addition.
-            check_err(&contents, "");
+            Compiler::new()
+        };
+
+        if directives.disable_includes {
+            let params = compiler.params().clone();
+            compiler.set_params(params.disable_includes(true));
+        }
+
+        compiler.check_add_rules_err(&contents, "");
+    }
+}
+
+#[derive(Default)]
+struct Directives {
+    without_yara: bool,
+    disable_includes: bool,
+    skip: bool,
+}
+
+fn extract_directives(contents: &str) -> Directives {
+    let mut directives = Directives::default();
+
+    for line in contents.lines() {
+        let Some(dir) = line.strip_prefix("// [") else {
+            break;
+        };
+        let Some(dir) = dir.strip_suffix("]") else {
+            break;
+        };
+        match dir {
+            "no libyara conformance" => directives.without_yara = true,
+            "disable includes" => directives.disable_includes = true,
+            "skip" => directives.skip = true,
+            dir => panic!("unknown directive {}", dir),
         }
     }
+
+    directives
 }

--- a/boreal/tests/it/error.rs
+++ b/boreal/tests/it/error.rs
@@ -1,3 +1,5 @@
+use boreal::compiler::CompilerParams;
+
 use crate::utils::Compiler;
 
 #[test]
@@ -71,4 +73,16 @@ fn extract_directives(contents: &str) -> Directives {
     }
 
     directives
+}
+
+#[test]
+fn test_disable_include() {
+    let mut compiler = Compiler::new();
+    compiler.set_params(CompilerParams::default().disable_includes(true));
+    if let Some(yara_compiler) = compiler.yara_compiler.as_mut() {
+        yara_compiler.disable_include_directive();
+    }
+
+    let rules = r#"include "toto.yar""#;
+    compiler.check_add_rules_err(rules, "mem:1:1: error: includes are not allowed");
 }

--- a/boreal/tests/it/error.rs
+++ b/boreal/tests/it/error.rs
@@ -36,9 +36,12 @@ fn test_invalid_files() {
         if directives.disable_includes {
             let params = compiler.params().clone();
             compiler.set_params(params.disable_includes(true));
+            if let Some(yara_compiler) = compiler.yara_compiler.as_mut() {
+                yara_compiler.disable_include_directive();
+            }
         }
 
-        compiler.check_add_rules_err(&contents, "");
+        compiler.check_add_file_err(&file, "");
     }
 }
 

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
+use boreal::compiler::CompilerParams;
 use boreal::memory::{FragmentedMemory, MemoryParams, Region, RegionDescription};
 use boreal::module::{Module, StaticValue, Value as ModuleValue};
 use boreal::scanner::{ScanError, ScanParams, ScanResult};
@@ -167,8 +168,12 @@ impl Compiler {
     define_symbol_compiler_method!(define_symbol_str, &str);
     define_symbol_compiler_method!(define_symbol_bool, bool);
 
-    pub fn set_params(&mut self, params: boreal::compiler::CompilerParams) {
+    pub fn set_params(&mut self, params: CompilerParams) {
         self.compiler.set_params(params);
+    }
+
+    pub fn params(&self) -> &CompilerParams {
+        self.compiler.params()
     }
 
     pub fn into_checker(self) -> Checker {

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -153,9 +153,14 @@ impl Compiler {
     }
 
     #[track_caller]
-    pub fn check_add_file_err_boreal(&mut self, file: &Path, expected_prefix: &str) {
-        let err = self.compiler.add_rules_file(file).unwrap_err();
-        let desc = add_rule_error_get_desc(&err, &std::fs::read_to_string(file).unwrap());
+    pub fn check_add_file_err_boreal(&mut self, path: &Path, expected_prefix: &str) {
+        let err = self.compiler.add_rules_file(path).unwrap_err();
+        let desc = err.to_short_description(
+            &path.file_name().unwrap().to_string_lossy(),
+            &std::fs::read_to_string(path).unwrap(),
+        );
+        // Remove the prefix up to the "error: " string
+        let desc = desc.split("error: ").nth(1).unwrap();
         assert!(
             desc.starts_with(expected_prefix),
             "error: {desc}\nexpected prefix: {expected_prefix}"


### PR DESCRIPTION
- Add a parameter to disallow the use of include directives in yara rules.
- Add a public method in Compiler to retrieve the current params.
- improve the tests on invalid files to ensure they do check the right error.