### PR TITLE
Make Scanner object unwind safe

### DIFF
--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -218,7 +218,7 @@ mod tests {
     fn test_types_traits() {
         test_type_traits_non_clonable(EvalData {
             values: Vec::new(),
-            data_map: ModuleDataMap::new(&HashMap::new()),
+            data_map: ModuleDataMap::new(&ModuleUserData::default()),
         });
     }
 }

--- a/boreal/src/matcher/validator/dfa.rs
+++ b/boreal/src/matcher/validator/dfa.rs
@@ -1,3 +1,4 @@
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::sync::Arc;
 
 use regex_automata::hybrid::dfa::{Builder, Cache, DFA};
@@ -11,7 +12,7 @@ use crate::matcher::widener::widen_hir;
 use crate::matcher::{MatchType, Modifiers};
 use crate::regex::{regex_hir_to_string, Hir};
 
-type PoolCreateFn = Box<dyn Fn() -> Cache + Send + Sync>;
+type PoolCreateFn = Box<dyn Fn() -> Cache + Send + Sync + UnwindSafe + RefUnwindSafe>;
 
 #[derive(Debug)]
 pub(crate) struct DfaValidator {

--- a/boreal/src/module/console.rs
+++ b/boreal/src/module/console.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::{collections::HashMap, sync::Arc};
 
 use super::{EvalContext, Module, ModuleData, ModuleDataMap, StaticValue, Type, Value};
@@ -9,7 +10,7 @@ pub struct Console {
 }
 
 /// Type of callback called when a message is logged.
-pub type LogCallback = dyn Fn(String) + Send + Sync;
+pub type LogCallback = dyn Fn(String) + Send + Sync + UnwindSafe + RefUnwindSafe;
 
 impl Module for Console {
     fn get_name(&self) -> &'static str {
@@ -69,7 +70,7 @@ impl Console {
     #[must_use]
     pub fn with_callback<T>(callback: T) -> Self
     where
-        T: Fn(String) + Send + Sync + 'static,
+        T: Fn(String) + Send + Sync + UnwindSafe + RefUnwindSafe + 'static,
     {
         Self {
             callback: Arc::new(callback),

--- a/boreal/src/module/math.rs
+++ b/boreal/src/module/math.rs
@@ -622,7 +622,7 @@ fn offset_length_to_start_end(offset: i64, length: i64) -> Option<(usize, usize)
 #[cfg(test)]
 mod tests {
     use crate::memory::Memory;
-    use crate::module::ModuleDataMap;
+    use crate::module::{ModuleDataMap, ModuleUserData};
 
     use super::*;
 
@@ -638,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_in_range_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::in_range(&mut ctx, vec![]).is_none());
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn test_deviation_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::deviation(&mut ctx, vec![]).is_none());
@@ -666,7 +666,7 @@ mod tests {
 
     #[test]
     fn test_mean_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::mean(&mut ctx, vec![]).is_none());
@@ -677,7 +677,7 @@ mod tests {
 
     #[test]
     fn test_serial_correlation_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::serial_correlation(&mut ctx, vec![]).is_none());
@@ -688,7 +688,7 @@ mod tests {
 
     #[test]
     fn test_monte_carlo_pi_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::monte_carlo_pi(&mut ctx, vec![]).is_none());
@@ -699,7 +699,7 @@ mod tests {
 
     #[test]
     fn test_entropy_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::entropy(&mut ctx, vec![]).is_none());
@@ -710,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_min_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::min(&mut ctx, vec![]).is_none());
@@ -721,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_max_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::max(&mut ctx, vec![]).is_none());
@@ -732,7 +732,7 @@ mod tests {
 
     #[test]
     fn test_to_number_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::to_number(&mut ctx, vec![]).is_none());
@@ -741,7 +741,7 @@ mod tests {
 
     #[test]
     fn test_abs_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::abs(&mut ctx, vec![]).is_none());
@@ -750,7 +750,7 @@ mod tests {
 
     #[test]
     fn test_count_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::count(&mut ctx, vec![]).is_none());
@@ -760,7 +760,7 @@ mod tests {
 
     #[test]
     fn test_percentage_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::percentage(&mut ctx, vec![]).is_none());
@@ -770,7 +770,7 @@ mod tests {
 
     #[test]
     fn test_mode_invalid_args() {
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut ctx = ctx!(&user_data);
 
         assert!(Math::mode(&mut ctx, vec![0.5.into()]).is_none());

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -109,7 +109,7 @@ pub use self::cuckoo::{Cuckoo, CuckooData};
 ///
 /// - As dynamic values, whose shape depend on the memory being scanned. This often includes
 ///   arrays such as `elf.sections`, or raw values such as `pe.machine`.
-pub trait Module: Send + Sync {
+pub trait Module: Send + Sync + UnwindSafe + RefUnwindSafe {
     /// Name of the module, used in `import` clauses.
     fn get_name(&self) -> &'static str;
 

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -882,7 +882,9 @@ impl std::fmt::Display for DefineSymbolError {
 #[cfg(test)]
 mod tests {
     use crate::module::{EvalContext, ScanContext, StaticValue, Type, Value as ModuleValue};
-    use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};
+    use crate::test_helpers::{
+        test_type_traits, test_type_traits_non_clonable, test_type_unwind_safe,
+    };
     use crate::Compiler;
 
     use super::*;
@@ -1515,6 +1517,8 @@ mod tests {
             Vec::new(),
             BytesPool::default(),
         ));
+        test_type_unwind_safe::<Scanner>();
+
         test_type_traits_non_clonable(ScanResult {
             matched_rules: Vec::new(),
             module_values: Vec::new(),

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -136,7 +136,7 @@ impl Scanner {
             }),
             scan_params: ScanParams::default(),
             external_symbols_values,
-            module_user_data: HashMap::new(),
+            module_user_data: ModuleUserData::default(),
         }
     }
 
@@ -330,6 +330,7 @@ impl Scanner {
     {
         let _r = self
             .module_user_data
+            .0
             .insert(TypeId::of::<Module>(), Arc::new(data));
     }
 
@@ -972,7 +973,7 @@ mod tests {
         let _r = compiler.add_rules_str(rule_str).unwrap();
         let scanner = compiler.into_scanner();
 
-        let user_data = HashMap::new();
+        let user_data = ModuleUserData::default();
         let mut module_values =
             evaluator::module::EvalData::new(&scanner.inner.modules, &user_data);
         module_values.scan_region(&Region { start: 0, mem }, &scanner.inner.modules, false);
@@ -1537,7 +1538,7 @@ mod tests {
             matched_rules: Vec::new(),
             module_values: evaluator::module::EvalData {
                 values: Vec::new(),
-                data_map: crate::module::ModuleDataMap::new(&HashMap::new()),
+                data_map: crate::module::ModuleDataMap::new(&ModuleUserData::default()),
             },
             statistics: None,
             timeout_checker: None,

--- a/boreal/src/test_helpers.rs
+++ b/boreal/src/test_helpers.rs
@@ -1,3 +1,5 @@
+use std::panic::{RefUnwindSafe, UnwindSafe};
+
 use boreal_parser::hex_string::parse_hex_string;
 use boreal_parser::regex::parse_regex;
 
@@ -19,9 +21,11 @@ pub fn expr_to_hir(expr: &str) -> Hir {
 pub fn test_type_traits<T: Clone + std::fmt::Debug + Send + Sync>(t: T) {
     #[allow(clippy::redundant_clone)]
     let _r = t.clone();
-    let _r = format!("{:?}", &t);
+    test_type_traits_non_clonable(t);
 }
 
 pub fn test_type_traits_non_clonable<T: std::fmt::Debug + Send + Sync>(t: T) {
     let _r = format!("{:?}", &t);
 }
+
+pub fn test_type_unwind_safe<T: UnwindSafe + RefUnwindSafe>() {}


### PR DESCRIPTION
Add UnwindSafe and RefUnwindSafe bounds on objects stored in the Scanner. This makes the Scanner object unwind safe, and thus usable across a catch_unwind, which can be useful in some contexts.