### PR TITLE
chore: fix new clippy warnings in 1.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### boreal
+
+Breaking changes:
+
+- The `ScanResult::statistics` field is now boxed. This reduces the size of the
+  object greatly.
+
 ## [0.9.0] - 2024-10-11
 
 This release brings several memory optimizations and small API improvements.

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -432,7 +432,7 @@ impl Inner {
         let results = ScanResult {
             matched_rules: scan_data.matched_rules,
             module_values: scan_data.module_values.values,
-            statistics: scan_data.statistics,
+            statistics: scan_data.statistics.map(Box::new),
         };
 
         match res {
@@ -827,7 +827,9 @@ pub struct ScanResult<'scanner> {
     pub module_values: Vec<(&'static str, crate::module::Value)>,
 
     /// Statistics related to the scan.
-    pub statistics: Option<statistics::Evaluation>,
+    // This is boxed to reduce the size of the struct, especially as this field
+    // is pratically never set outside of test/debug runs.
+    pub statistics: Option<Box<statistics::Evaluation>>,
 }
 
 /// Description of a rule that matched during a scan.


### PR DESCRIPTION
Box the statistics object to reduce the size of the result of scan_* methods.