### PR TITLE
Move lint configuration in workspace Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,13 +261,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   msrv:
-    name: Rust 1.66.0
+    name: Rust 1.74.0
     runs-on: ubuntu-22.04
     env:
       RUSTFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@v4.1.1
-      - uses: dtolnay/rust-toolchain@1.66.0
+      - uses: dtolnay/rust-toolchain@1.74.0
       # Only check boreal (and boreal-parser).
       # boreal-cli is a useful tool, but MSRV on it is not really useful.
       - run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,24 @@ rust_2024_prelude_collisions = "deny"
 # must_not_suspend = "deny"
 # non_exhaustive_omitted_patterns = "deny"
 # unqualified_local_imports = "deny"
+
+[workspace.lints.clippy]
+# groups
+all = { level = "deny", priority = -1 }
+cargo = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+
+# extras
+undocumented_unsafe_blocks = "deny"
+
+# exclusions, mostly from the pedantic group
+inline_always = "allow"
+match_same_arms = "allow"
+module_name_repetitions = "allow"
+# Handled by cargo-allow
+multiple_crate_versions = "allow"
+struct_excessive_bools = "allow"
+struct_field_names = "allow"
+single_match_else = "allow"
+too_many_lines = "allow"
+unnested_or_patterns = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,53 @@ members = [
     "boreal-parser",
     "boreal-test-helpers",
 ]
+
+[workspace.lints.rust]
+ambiguous_negative_literals = "deny"
+explicit_outlives_requirements = "deny"
+let_underscore_drop = "deny"
+macro_use_extern_crate = "deny"
+missing_abi = "deny"
+missing_docs = "deny"
+missing_unsafe_on_extern = "deny"
+non_ascii_idents = "deny"
+# This cannot really be enabled because of some functions that are in the prelude
+# now, but weren't at the MSRV version.
+# redundant_imports = "deny"
+redundant_lifetimes = "deny"
+single_use_lifetimes = "deny"
+# tail_expr_drop_order = "deny"
+trivial_casts = "deny"
+trivial_numeric_casts = "deny"
+unit_bindings = "deny"
+# unnameable_types = "deny"
+# unreachable_pub = "deny"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+unsafe_attr_outside_unsafe = "deny"
+unsafe_code = "deny"
+unsafe_op_in_unsafe_fn = "deny"
+unused_crate_dependencies = "deny"
+unused_extern_crates = "deny"
+unused_import_braces = "deny"
+unused_lifetimes = "deny"
+unused_macro_rules = "deny"
+unused_qualifications = "deny"
+unused_results = "deny"
+variant_size_differences = "deny"
+
+# edition 2024 lints
+deprecated_safe_2024 = "deny"
+# edition_2024_expr_fragment_specifier = "deny"
+# if_let_rescope = "deny"
+impl_trait_overcaptures = "deny"
+keyword_idents_2024 = "deny"
+rust_2024_guarded_string_incompatible_syntax = "deny"
+rust_2024_incompatible_pat = "deny"
+rust_2024_prelude_collisions = "deny"
+
+# unstable
+# fuzzy_provenance_casts = "deny"
+# lossy_provenance_casts = "deny"
+# must_not_suspend = "deny"
+# non_exhaustive_omitted_patterns = "deny"
+# unqualified_local_imports = "deny"

--- a/boreal-cli/Cargo.toml
+++ b/boreal-cli/Cargo.toml
@@ -49,3 +49,6 @@ walkdir = "2.5"
 assert_cmd = "2.0"
 tempfile = "3.10"
 predicates = { version = "3.1", default-features = false, features = ["regex"] }
+
+[lints]
+workspace = true

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -348,7 +348,7 @@ fn main() -> ExitCode {
         Ok(Input::Process(pid)) => match scan_process(&scanner, pid, &scan_options) {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
-                eprintln!("Cannot scan {}: {}", pid, err);
+                eprintln!("Cannot scan {pid}: {err}");
                 ExitCode::FAILURE
             }
         },
@@ -368,7 +368,7 @@ fn main() -> ExitCode {
             ExitCode::SUCCESS
         }
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             ExitCode::FAILURE
         }
     }
@@ -630,7 +630,7 @@ fn display_scan_results(scanner: &Scanner, res: ScanResult, what: &str, options:
         if options.print_metadata {
             print_metadata(&mut stdout, scanner, rule.metadatas);
         }
-        writeln!(stdout, " {}", what).unwrap();
+        writeln!(stdout, " {what}").unwrap();
 
         if options.print_strings_matches() {
             for string in &rule.matches {
@@ -653,7 +653,7 @@ fn display_scan_results(scanner: &Scanner, res: ScanResult, what: &str, options:
 
     // Finally, print the statistics
     if let Some(stats) = res.statistics {
-        writeln!(stdout, "{}: {:#?}", what, stats).unwrap();
+        writeln!(stdout, "{what}: {stats:#?}").unwrap();
     }
 }
 
@@ -671,10 +671,10 @@ fn print_metadata(stdout: &mut StdoutLock, scanner: &Scanner, metadatas: &[Metad
                 write!(stdout, "\"").unwrap();
             }
             MetadataValue::Integer(i) => {
-                write!(stdout, "{}", i).unwrap();
+                write!(stdout, "{i}").unwrap();
             }
             MetadataValue::Boolean(b) => {
-                write!(stdout, "{}", b).unwrap();
+                write!(stdout, "{b}").unwrap();
             }
         }
     }
@@ -703,7 +703,7 @@ impl ThreadPool {
             std::cmp::min(1, *nb)
         } else {
             std::thread::available_parallelism()
-                .map(|v| v.get())
+                .map(std::num::NonZero::get)
                 .unwrap_or(32)
         };
 

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -1,3 +1,15 @@
+//! CLI tool to scan files and processes using boreal.
+//!
+//! This tool attempts to expose the same interface as the yara CLI tool if possible,
+//! with some additional options added.
+#![allow(unsafe_code)]
+
+// Used in integration tests, not in the library.
+// This is to remove the "unused_crate_dependencies" warning, maybe a better solution
+// could be found.
+#[cfg(test)]
+use {assert_cmd as _, predicates as _, tempfile as _};
+
 use std::fs::File;
 use std::io::{BufRead, BufReader, StdoutLock, Write};
 use std::path::{Path, PathBuf};
@@ -284,7 +296,7 @@ fn main() -> ExitCode {
 
         if let Some(defines) = args.remove_many::<(String, ExternalValue)>("define") {
             for (name, value) in defines {
-                compiler.define_symbol(name, value);
+                let _r = compiler.define_symbol(name, value);
             }
         }
 

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 #![allow(unused_results)]
 #![allow(unused_crate_dependencies)]
+#![allow(clippy::pedantic)]
 
 use std::io::{BufRead, Write};
 use std::path::Path;

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1,3 +1,7 @@
+#![allow(missing_docs)]
+#![allow(unused_results)]
+#![allow(unused_crate_dependencies)]
+
 use std::io::{BufRead, Write};
 use std::path::Path;
 use std::{fs, io::BufReader};
@@ -1377,7 +1381,7 @@ impl BinHelper {
 
 impl Drop for BinHelper {
     fn drop(&mut self) {
-        let _ = self.proc.kill();
-        let _ = self.proc.wait();
+        drop(self.proc.kill());
+        drop(self.proc.wait());
     }
 }

--- a/boreal-parser/Cargo.toml
+++ b/boreal-parser/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["boreal", "yara", "parser"]
 categories = ["parser-implementations"]
 edition = "2021"
 # MSRV
-rust-version = "1.66"
+rust-version = "1.74"
 
 [dependencies]
 # Parsing library

--- a/boreal-parser/Cargo.toml
+++ b/boreal-parser/Cargo.toml
@@ -17,3 +17,6 @@ nom = "7.1"
 
 # Proper error reporting on parsing
 codespan-reporting = "0.11"
+
+[lints]
+workspace = true

--- a/boreal-parser/src/error.rs
+++ b/boreal-parser/src/error.rs
@@ -147,7 +147,10 @@ impl Error {
 
     fn from_nom_error_kind(position: usize, kind: NomErrorKind) -> Self {
         Self {
-            span: position..(position + 1),
+            span: Range {
+                start: position,
+                end: position + 1,
+            },
             kind: ErrorKind::NomError(kind),
         }
     }

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -93,34 +93,13 @@
 //! # Ok::<(), boreal_parser::error::Error>(())
 //! ```
 
-// Deny most of allowed by default lints from rustc.
-#![deny(explicit_outlives_requirements)]
-#![deny(keyword_idents)]
-#![deny(macro_use_extern_crate)]
-#![deny(missing_docs)]
-#![deny(non_ascii_idents)]
-#![deny(noop_method_call)]
-#![deny(rust_2021_compatibility)]
-#![deny(single_use_lifetimes)]
-#![deny(trivial_casts)]
-#![deny(trivial_numeric_casts)]
-#![deny(unsafe_code)]
-#![deny(unused_crate_dependencies)]
-#![deny(unused_extern_crates)]
-#![deny(unused_import_braces)]
-#![deny(unused_lifetimes)]
-#![deny(unused_qualifications)]
-#![deny(unused_results)]
 // Do the same for clippy
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
 // Allow some useless pedantic lints
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::range_plus_one)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::single_match_else)]
-#![allow(clippy::struct_field_names)]
-#![deny(clippy::cargo)]
+// #![allow(clippy::module_name_repetitions)]
+// #![allow(clippy::range_plus_one)]
+// #![allow(clippy::too_many_lines)]
+// #![allow(clippy::single_match_else)]
+// #![allow(clippy::struct_field_names)]
 
 // Parsing uses the [`nom`] crate, adapted for textual parsing.
 //

--- a/boreal-parser/src/lib.rs
+++ b/boreal-parser/src/lib.rs
@@ -93,14 +93,6 @@
 //! # Ok::<(), boreal_parser::error::Error>(())
 //! ```
 
-// Do the same for clippy
-// Allow some useless pedantic lints
-// #![allow(clippy::module_name_repetitions)]
-// #![allow(clippy::range_plus_one)]
-// #![allow(clippy::too_many_lines)]
-// #![allow(clippy::single_match_else)]
-// #![allow(clippy::struct_field_names)]
-
 // Parsing uses the [`nom`] crate, adapted for textual parsing.
 //
 // All of the parsing functions, unless otherwise indicated, depends on the

--- a/boreal-parser/src/regex.rs
+++ b/boreal-parser/src/regex.rs
@@ -599,6 +599,7 @@ struct Escaped {
     escaped: bool,
 }
 
+#[allow(variant_size_differences)]
 enum EscapedKind {
     Byte(u8),
     Char(char),

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["boreal", "yara", "string-matching", "scan"]
 categories = ["text-processing"]
 edition = "2021"
 # MSRV
-rust-version = "1.66"
+rust-version = "1.74"
 exclude = ["/tests"]
 
 [features]

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -120,5 +120,5 @@ yara = { version = "0.29", features = ["vendored"] }
 [package.metadata.docs.rs]
 features = ["authenticode", "memmap", "magic", "cuckoo"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+[lints]
+workspace = true

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -88,7 +88,7 @@ impl<'a> VarMatches<'a> {
             Err(idx) => idx,
         };
 
-        self.matches[var_index].get(start_idx).map_or(false, |mat| {
+        self.matches[var_index].get(start_idx).is_some_and(|mat| {
             let mat_offset = mat.offset.saturating_add(mat.base);
             mat_offset <= to
         })

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -35,23 +35,8 @@
 //! ```
 
 // Deny most of allowed by default lints from rustc.
-#![deny(explicit_outlives_requirements)]
-#![deny(keyword_idents)]
-#![deny(macro_use_extern_crate)]
-#![deny(non_ascii_idents)]
-#![deny(noop_method_call)]
-#![deny(rust_2021_compatibility)]
-#![deny(single_use_lifetimes)]
-#![deny(trivial_casts)]
-#![deny(trivial_numeric_casts)]
-#![deny(unused_crate_dependencies)]
-#![deny(unused_extern_crates)]
-#![deny(unused_import_braces)]
-#![deny(unused_lifetimes)]
-#![deny(unused_qualifications)]
-#![deny(unused_results)]
-#![deny(unsafe_op_in_unsafe_fn)]
 // Do the same for clippy
+#![allow(unsafe_code)]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::undocumented_unsafe_blocks)]
@@ -64,8 +49,6 @@
 #![allow(clippy::inline_always)]
 #![allow(clippy::struct_field_names)]
 #![allow(clippy::struct_excessive_bools)]
-#![allow(unsafe_code)]
-#![deny(missing_docs)]
 #![deny(clippy::cargo)]
 // Handled by cargo-deny
 #![allow(clippy::multiple_crate_versions)]

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -34,24 +34,7 @@
 //! # Ok::<(), boreal::compiler::AddRuleError>(())
 //! ```
 
-// Deny most of allowed by default lints from rustc.
-// Do the same for clippy
 #![allow(unsafe_code)]
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
-#![deny(clippy::undocumented_unsafe_blocks)]
-// Allow some useless pedantic lints
-#![allow(clippy::module_name_repetitions)]
-#![allow(clippy::unnested_or_patterns)]
-#![allow(clippy::match_same_arms)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::single_match_else)]
-#![allow(clippy::inline_always)]
-#![allow(clippy::struct_field_names)]
-#![allow(clippy::struct_excessive_bools)]
-#![deny(clippy::cargo)]
-// Handled by cargo-deny
-#![allow(clippy::multiple_crate_versions)]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 // Used in integration tests, not in the library.

--- a/boreal/src/matcher/literals.rs
+++ b/boreal/src/matcher/literals.rs
@@ -81,6 +81,7 @@ struct Extractor {
     dot_all: bool,
 }
 
+#[allow(variant_size_differences)]
 #[derive(Debug)]
 enum HirPartKind {
     Literal(u8),

--- a/boreal/src/module/pe.rs
+++ b/boreal/src/module/pe.rs
@@ -2095,7 +2095,7 @@ impl Pe {
                 export
                     .name
                     .as_ref()
-                    .map_or(false, |name| name.eq_ignore_ascii_case(&function_name))
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&function_name))
             }),
             Value::Integer(ordinal) => match usize::try_from(ordinal) {
                 Ok(ord) => data.exports.iter().any(|export| export.ordinal == ord),
@@ -2105,7 +2105,7 @@ impl Pe {
                 export
                     .name
                     .as_ref()
-                    .map_or(false, |name| function_name_regex.is_match(name))
+                    .is_some_and(|name| function_name_regex.is_match(name))
             }),
             _ => return None,
         };
@@ -2128,7 +2128,7 @@ impl Pe {
                 export
                     .name
                     .as_ref()
-                    .map_or(false, |name| name.eq_ignore_ascii_case(&function_name))
+                    .is_some_and(|name| name.eq_ignore_ascii_case(&function_name))
             })?,
             Value::Integer(ordinal) => {
                 let ordinal = usize::try_from(ordinal).ok()?;
@@ -2144,7 +2144,7 @@ impl Pe {
                 export
                     .name
                     .as_ref()
-                    .map_or(false, |name| function_name_regex.is_match(name))
+                    .is_some_and(|name| function_name_regex.is_match(name))
             })?,
             _ => return None,
         };

--- a/boreal/src/module/pe/signatures.rs
+++ b/boreal/src/module/pe/signatures.rs
@@ -196,7 +196,7 @@ fn add_signatures_from_content_info(
                 _ => false,
             };
         verified = verified
-            && signer_info.map_or(false, |info| {
+            && signer_info.is_some_and(|info| {
                 verify::verify_signer_info(info, &certificate_chain).unwrap_or(false)
             });
 
@@ -402,14 +402,14 @@ where
                 // Has a signer cert
                 !chain.0.is_empty() &&
                 // message digest matches
-                digest.map_or(false, check_digest) &&
+                digest.is_some_and(check_digest) &&
                 verify::verify_signer_info(info, certs).unwrap_or(false)
         )
         .into(),
     );
     #[cfg(not(feature = "authenticode-verify"))]
     let verified = {
-        let _f = check_digest;
+        drop(check_digest);
         Value::Undefined
     };
 

--- a/boreal/src/module/pe/signatures.rs
+++ b/boreal/src/module/pe/signatures.rs
@@ -409,7 +409,7 @@ where
     );
     #[cfg(not(feature = "authenticode-verify"))]
     let verified = {
-        let _ = check_digest;
+        let _f = check_digest;
         Value::Undefined
     };
 

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -75,7 +75,7 @@ impl ScanData<'_> {
     fn check_timeout(&mut self) -> bool {
         self.timeout_checker
             .as_mut()
-            .map_or(false, |checker| checker.check_timeout())
+            .is_some_and(|checker| checker.check_timeout())
     }
 }
 

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -785,7 +785,7 @@ impl ScanData<'_, '_> {
     pub(crate) fn check_timeout(&mut self) -> bool {
         self.timeout_checker
             .as_mut()
-            .map_or(false, TimeoutChecker::check_timeout)
+            .is_some_and(TimeoutChecker::check_timeout)
     }
 }
 

--- a/boreal/src/scanner/process/sys/linux.rs
+++ b/boreal/src/scanner/process/sys/linux.rs
@@ -135,7 +135,7 @@ impl LinuxProcessMemory {
         if self
             .current_region
             .as_mut()
-            .map_or(false, |line| line.update_to_next_chunk(params))
+            .is_some_and(|line| line.update_to_next_chunk(params))
         {
             return;
         }

--- a/boreal/src/scanner/process/sys/linux.rs
+++ b/boreal/src/scanner/process/sys/linux.rs
@@ -159,7 +159,7 @@ impl LinuxProcessMemory {
 
 impl FragmentedMemory for LinuxProcessMemory {
     fn reset(&mut self) {
-        let _ = self.maps_file.rewind();
+        let _r = self.maps_file.rewind();
     }
 
     fn next(&mut self, params: &MemoryParams) -> Option<RegionDescription> {

--- a/boreal/tests/it/error.rs
+++ b/boreal/tests/it/error.rs
@@ -29,7 +29,7 @@ fn test_invalid_files() {
         let mut compiler = if directives.without_yara {
             if cfg!(debug_assertions) {
                 let mut compiler = Compiler::new_without_yara();
-                let params = boreal::compiler::CompilerParams::default().max_condition_depth(15);
+                let params = CompilerParams::default().max_condition_depth(15);
                 compiler.set_params(params);
                 compiler
             } else {

--- a/boreal/tests/it/main.rs
+++ b/boreal/tests/it/main.rs
@@ -1,3 +1,8 @@
+#![allow(missing_docs)]
+#![allow(unused_results)]
+#![allow(unused_crate_dependencies)]
+#![allow(unsafe_code)]
+
 // contains tests imported from libyara
 mod libyara_compat;
 

--- a/boreal/tests/it/main.rs
+++ b/boreal/tests/it/main.rs
@@ -2,6 +2,7 @@
 #![allow(unused_results)]
 #![allow(unused_crate_dependencies)]
 #![allow(unsafe_code)]
+#![allow(clippy::pedantic)]
 
 // contains tests imported from libyara
 mod libyara_compat;

--- a/boreal/tests/it/process.rs
+++ b/boreal/tests/it/process.rs
@@ -406,7 +406,7 @@ impl BinHelper {
 
 impl Drop for BinHelper {
     fn drop(&mut self) {
-        let _ = self.proc.kill();
-        let _ = self.proc.wait();
+        drop(self.proc.kill());
+        drop(self.proc.wait());
     }
 }


### PR DESCRIPTION
This centralizes the configuration and avoids duplicating it in every crate.
A few changes are introduced due to new lints being configured.
In addition, this forces a MSRV bump to 1.74, which is still more than a year ago.