### PR TITLE
WIP: Add python bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           cd boreal-py
           uv sync --dev
-          uv run pytest
+          uv run --config-setting "build-args=--features=cuckoo" pytest
 
     strategy:
       fail-fast: false
@@ -313,7 +313,7 @@ jobs:
 
           # And run the python bindings tests
           cd boreal-py
-          uv run --config-setting 'build-args=--profile=dev' pytest
+          uv run --config-setting 'build-args=--profile=dev --features=cuckoo' pytest
           cd ..
 
           # Finally, generate the report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           target: ${{matrix.target}}
 
+      - name: Install uv for the python bindings tests
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.25"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "boreal-py/pyproject.toml"
+
       - name: Build test helpers
         run: |
           cd boreal-test-helpers
@@ -62,6 +72,12 @@ jobs:
         run: |
           sudo apt install libjansson-dev
           cargo test --features magic,cuckoo --target=${{matrix.target}}
+
+      - name: Run python tests
+        run: |
+          cd boreal-py
+          uv sync --dev
+          uv run pytest
 
     strategy:
       fail-fast: false
@@ -103,6 +119,16 @@ jobs:
           echo "YARA_OPENSSL_DIR=${{ runner.workspace }}\\vcpkg\\installed\\${{ matrix.vcpkg_triplet }}" >> $GITHUB_ENV
           echo "YARA_CRYPTO_LIB=openssl" >> $GITHUB_ENV
 
+      - name: Install uv for the python bindings tests
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.25"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "boreal-py/pyproject.toml"
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{matrix.target}}
@@ -121,6 +147,12 @@ jobs:
         env:
           YARA_CRYPTO_LIB: openssl
         run: cargo test --features authenticode-verify --target=${{matrix.target}}
+
+      - name: Run python tests
+        run: |
+          cd boreal-py
+          uv sync --dev
+          uv run pytest
 
     strategy:
       fail-fast: false
@@ -157,6 +189,17 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install uv for the python bindings tests
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.25"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "boreal-py/pyproject.toml"
+
+
       - name: Build test helpers
         run: |
           cd boreal-test-helpers
@@ -181,6 +224,12 @@ jobs:
         # This is very suspect, and should be investigated and reported.
         run: |
           sudo cargo test -- --test-threads=1 --ignored
+
+      - name: Run python tests
+        run: |
+          cd boreal-py
+          uv sync --dev
+          sudo uv run pytest
 
     strategy:
       fail-fast: false
@@ -238,17 +287,35 @@ jobs:
       - name: Install dependencies
         run: sudo apt install libjansson-dev
 
+      - name: Install uv for the python bindings tests
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.5.25"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "boreal-py/pyproject.toml"
+
       - name: Generate code coverage
         run: |
           # Export cargo llvm-cov env stuff so that we can run "cargo test"
           # and have coverage
           source <(cargo llvm-cov show-env --export-prefix)
           cargo build -p boreal-test-helpers
+
           # Run the normal tests
           cargo test --features magic,authenticode-verify,cuckoo
+
           # And run the super user tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sudo -E" cargo \
             test --features magic,authenticode-verify,cuckoo -- --ignored
+
+          # And run the python bindings tests
+          cd boreal-py
+          uv run --config-setting 'build-args=--profile=dev' pytest
+          cd ..
+
           # Finally, generate the report
           cargo llvm-cov report --lcov --output-path lcov.info \
             --ignore-filename-regex boreal-test-helpers/src/main.rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,14 @@ jobs:
 
       - name: Install uv for the python bindings tests
         uses: astral-sh/setup-uv@v5
+        # There is no available python x86 for linux, so only run those on 64 bits.
+        if: ${{ matrix.build == 'linux' }}
         with:
           version: "0.5.25"
 
       - name: Set up Python
         uses: actions/setup-python@v5
+        if: ${{ matrix.build == 'linux' }}
         with:
           python-version-file: "boreal-py/pyproject.toml"
 
@@ -74,10 +77,11 @@ jobs:
           cargo test --features magic,cuckoo --target=${{matrix.target}}
 
       - name: Run python tests
+        if: ${{ matrix.build == 'linux' }}
         run: |
           cd boreal-py
           uv sync --dev
-          uv run --config-setting "build-args=--features=cuckoo" pytest
+          uv run --config-setting "build-args=--features=cuckoo --target=${{matrix.target}}" pytest
 
     strategy:
       fail-fast: false
@@ -127,6 +131,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
+          architecture: ${{matrix.architecture}}
           python-version-file: "boreal-py/pyproject.toml"
 
       - uses: dtolnay/rust-toolchain@stable
@@ -152,7 +157,7 @@ jobs:
         run: |
           cd boreal-py
           uv sync --dev
-          uv run pytest
+          uv run --config-setting "build-args=--target=${{matrix.target}}" pytest
 
     strategy:
       fail-fast: false
@@ -162,9 +167,11 @@ jobs:
           - build: windows
             vcpkg_triplet: x64-windows-static
             target: x86_64-pc-windows-msvc
+            architecture: x64
           - build: windows32
             vcpkg_triplet: x86-windows-static
             target: i686-pc-windows-msvc
+            architecture: x86
 
   test-macos:
     name: Test ${{matrix.runner}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "boreal-py"
+version = "0.1.0"
+dependencies = [
+ "boreal",
+ "pyo3",
+]
+
+[[package]]
 name = "boreal-test-helpers"
 version = "0.0.1"
 dependencies = [
@@ -514,6 +522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +541,12 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -637,6 +657,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -778,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +865,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe09249128b3173d092de9523eaa75136bf7ba85e0d69eca241c7939c933cc"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd3927b5a78757a0d71aa9dff669f903b1eb64b54142a9bd9f757f8fde65fd7"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab6bb2102bd8f991e7749f130a70d05dd557613e39ed2deeee8e9ca0c4d548d"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91871864b353fd5ffcb3f91f2f703a22a9797c91b9ab497b1acac7b07ae509c7"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43abc3b80bc20f3facd86cd3c60beed58c3e2aa26213f3cda368de39c60a27e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1090,6 +1188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1264,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "boreal",
     "boreal-cli",
     "boreal-parser",
+    "boreal-py",
     "boreal-test-helpers",
 ]
 

--- a/boreal-py/Cargo.toml
+++ b/boreal-py/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "boreal-py"
+version = "0.1.0"
+description = "Python bindings to the boreal API"
+repository = "https://github.com/vthib/boreal"
+license = "MIT OR Apache-2.0"
+keywords = ["boreal", "yara", "string-matching", "scan", "python"]
+categories = ["api-bindings", "text-processing"]
+edition = "2021"
+# MSRV
+rust-version = "1.66"
+
+[lib]
+name = "boreal"
+crate-type = ["cdylib"]
+
+[dependencies]
+boreal = { path = "../boreal", version = "0.9.0" }
+
+pyo3 = { version = "0.23", features = ["abi3", "abi3-py311", "extension-module", "macros"] }
+
+[lints]
+workspace = true

--- a/boreal-py/Cargo.toml
+++ b/boreal-py/Cargo.toml
@@ -3,6 +3,7 @@ name = "boreal-py"
 version = "0.1.0"
 description = "Python bindings to the boreal API"
 repository = "https://github.com/vthib/boreal"
+readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["boreal", "yara", "string-matching", "scan", "python"]
 categories = ["api-bindings", "text-processing"]

--- a/boreal-py/Cargo.toml
+++ b/boreal-py/Cargo.toml
@@ -16,7 +16,7 @@ name = "boreal"
 crate-type = ["cdylib"]
 
 [features]
-default = ["cuckoo"]
+default = []
 
 cuckoo = ["boreal/cuckoo"]
 

--- a/boreal-py/Cargo.toml
+++ b/boreal-py/Cargo.toml
@@ -15,6 +15,11 @@ rust-version = "1.66"
 name = "boreal"
 crate-type = ["cdylib"]
 
+[features]
+default = ["cuckoo"]
+
+cuckoo = ["boreal/cuckoo"]
+
 [dependencies]
 boreal = { path = "../boreal", version = "0.9.0" }
 

--- a/boreal-py/README.md
+++ b/boreal-py/README.md
@@ -1,0 +1,3 @@
+Python bindings for the boreal library.
+
+TODO

--- a/boreal-py/pyproject.toml
+++ b/boreal-py/pyproject.toml
@@ -1,10 +1,8 @@
 [project]
 name = "boreal"
 version = "0.1.0"
-description = "Add your description here"
-authors = [
-    { name = "Vincent Thiberville", email = "vthib@pm.me" }
-]
+readme = "README.md"
+description = "TODO"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/boreal-py/pyproject.toml
+++ b/boreal-py/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "boreal"
+version = "0.1.0"
+description = "Add your description here"
+authors = [
+    { name = "Vincent Thiberville", email = "vthib@pm.me" }
+]
+requires-python = ">=3.11"
+dependencies = []
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.4",
+    "yara-python>=4.5.1",
+]
+
+[tool.uv]
+cache-keys = [{ file = "pyproject.toml" }, { file = "Cargo.toml" }, { file = "src/**/*" }]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--import-mode=importlib",
+]

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -1,0 +1,187 @@
+//! Python bindings for the boreal library.
+use std::collections::HashMap;
+
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyBytes, PyList, PyString};
+
+use ::boreal::scanner::{StringMatch, StringMatches};
+use ::boreal::{scanner::MatchedRule, Compiler, Scanner};
+use ::boreal::{Metadata, MetadataValue};
+
+#[pymodule]
+fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(compile, m)?)
+}
+
+#[pyfunction]
+#[pyo3(signature = (filepath=None, source=None))]
+fn compile(filepath: Option<&str>, source: Option<&str>) -> PyResult<PyScanner> {
+    let mut compiler = Compiler::new();
+    match (filepath, source) {
+        (Some(v), None) => compiler.add_rules_file(v),
+        (None, Some(v)) => compiler.add_rules_str(v),
+        _ => todo!(),
+    }
+    .unwrap();
+
+    Ok(PyScanner {
+        scanner: compiler.into_scanner(),
+    })
+}
+
+#[pyclass]
+struct PyScanner {
+    scanner: Scanner,
+}
+
+#[pymethods]
+impl PyScanner {
+    #[pyo3(signature = (filepath=None, data=None))]
+    fn r#match(
+        &self,
+        filepath: Option<&str>,
+        data: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Vec<PyMatch>> {
+        let res = match (filepath, data) {
+            (Some(filepath), None) => self.scanner.scan_file(filepath),
+            (None, Some(data)) => {
+                if let Ok(s) = data.downcast::<PyString>() {
+                    self.scanner.scan_mem(s.to_str()?.as_bytes())
+                } else if let Ok(s) = data.downcast::<PyBytes>() {
+                    self.scanner.scan_mem(s.as_bytes())
+                } else {
+                    todo!()
+                }
+            }
+            _ => todo!(),
+        };
+
+        match res {
+            Ok(v) => Python::with_gil(|py| {
+                v.matched_rules
+                    .into_iter()
+                    .map(|v| PyMatch::new(py, &self.scanner, v))
+                    .collect::<Result<_, _>>()
+            }),
+            // TODO: fix difference
+            Err((err, _)) => Err(PyValueError::new_err(format!("{err}"))),
+        }
+    }
+}
+
+#[pyclass]
+struct PyMatch {
+    /// Name of the matching rule
+    #[pyo3(get)]
+    rule: Py<PyString>,
+
+    /// Namespace of the matching rule
+    #[pyo3(get)]
+    namespace: Py<PyString>,
+
+    /// List of tags associated to the rule
+    #[pyo3(get)]
+    tags: Py<PyList>,
+
+    /// Dictionary with metadata associated to the rule
+    #[pyo3(get)]
+    meta: HashMap<String, Py<PyAny>>,
+
+    /// Tuple with offsets and strings that matched the file
+    #[pyo3(get)]
+    strings: Vec<PyStringMatches>,
+}
+
+impl PyMatch {
+    fn new(py: Python, scanner: &Scanner, rule: MatchedRule) -> Result<Self, PyErr> {
+        Ok(Self {
+            rule: rule.name.into_pyobject(py)?.unbind(),
+            namespace: rule
+                .namespace
+                .unwrap_or_default()
+                .into_pyobject(py)?
+                .unbind(),
+            meta: rule
+                .metadatas
+                .iter()
+                .map(|m| convert_metadata(py, scanner, m))
+                .collect::<Result<_, _>>()?,
+            tags: PyList::new(py, rule.tags)?.unbind(),
+            strings: rule.matches.into_iter().map(PyStringMatches::new).collect(),
+        })
+    }
+}
+
+fn convert_metadata(
+    py: Python,
+    scanner: &Scanner,
+    metadata: &Metadata,
+) -> Result<(String, Py<PyAny>), PyErr> {
+    let name = scanner.get_string_symbol(metadata.name).to_string();
+    let value = match metadata.value {
+        // XXX: Yara forces a string conversion here, losing data in the
+        // process. Prefer using the right type here.
+        // TODO: add a yara compat mode?
+        MetadataValue::Bytes(v) => scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?,
+        MetadataValue::Integer(v) => v.into_pyobject(py)?.into_any(),
+        MetadataValue::Boolean(v) => PyBool::new(py, v).to_owned().into_any(),
+    };
+    Ok((name, value.unbind()))
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct PyStringMatches {
+    /// Name of the matching string.
+    #[pyo3(get)]
+    identifier: String,
+
+    /// List of matches for the string.
+    #[pyo3(get)]
+    instances: Vec<PyStringMatch>,
+    // TODO: missing flags
+}
+
+impl PyStringMatches {
+    fn new(s: StringMatches) -> Self {
+        Self {
+            identifier: format!("${}", &s.name),
+            instances: s.matches.into_iter().map(PyStringMatch::new).collect(),
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Clone)]
+struct PyStringMatch {
+    /// Offset of the match.
+    #[pyo3(get)]
+    offset: usize,
+
+    /// Matched data, might have been truncated if too long.
+    matched_data: Vec<u8>,
+
+    /// Length of the entire match.
+    #[pyo3(get)]
+    matched_length: usize,
+    // TODO: missing xor_key
+}
+
+impl PyStringMatch {
+    fn new(s: StringMatch) -> Self {
+        Self {
+            offset: s.offset,
+            matched_data: s.data,
+            matched_length: s.length,
+        }
+    }
+}
+
+#[pymethods]
+impl PyStringMatch {
+    #[getter]
+    fn matched_data(self_: PyRef<'_, Self>) -> PyResult<Bound<'_, PyBytes>> {
+        Ok(PyBytes::new(self_.py(), &self_.matched_data))
+    }
+}

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -21,6 +21,8 @@ fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(compile, m)?)?;
 
     m.add("AddRuleError", m.py().get_type::<AddRuleError>())?;
+    m.add("ScanError", m.py().get_type::<scanner::ScanError>())?;
+    m.add("TimeoutError", m.py().get_type::<scanner::TimeoutError>())?;
 
     Ok(())
 }
@@ -38,7 +40,7 @@ fn compile(
     externals: Option<&Bound<'_, PyDict>>,
     includes: bool,
     error_on_warning: bool,
-) -> PyResult<scanner::PyScanner> {
+) -> PyResult<scanner::Scanner> {
     let mut compiler = compiler::Compiler::new();
     compiler.set_params(
         compiler::CompilerParams::default()
@@ -127,7 +129,7 @@ fn compile(
         _ => return Err(PyTypeError::new_err("invalid arguments passed")),
     }
 
-    Ok(scanner::PyScanner {
+    Ok(scanner::Scanner {
         scanner: compiler.into_scanner(),
         warnings,
     })

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -1,7 +1,10 @@
 //! Python bindings for the boreal library.
+use pyo3::exceptions::{PyException, PyTypeError};
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use pyo3::{create_exception, intern};
 
-use ::boreal::Compiler;
+use ::boreal::compiler;
 
 // TODO: all clone impls should be efficient...
 // TODO: should all pyclasses have names and be exposed in the module?
@@ -11,23 +14,148 @@ mod scanner;
 mod string_match_instance;
 mod string_matches;
 
+create_exception!(boreal, AddRuleError, PyException, "error when adding rules");
+
 #[pymodule]
 fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(compile, m)?)
+    m.add_function(wrap_pyfunction!(compile, m)?)?;
+
+    m.add("AddRuleError", m.py().get_type::<AddRuleError>())?;
+
+    Ok(())
 }
 
+// TODO: add strict_escape?
 #[pyfunction]
-#[pyo3(signature = (filepath=None, source=None))]
-fn compile(filepath: Option<&str>, source: Option<&str>) -> PyResult<scanner::PyScanner> {
-    let mut compiler = Compiler::new();
-    match (filepath, source) {
-        (Some(v), None) => compiler.add_rules_file(v),
-        (None, Some(v)) => compiler.add_rules_str(v),
-        _ => todo!(),
+#[pyo3(signature = (filepath=None, source=None, file=None, filepaths=None, sources=None, externals=None, includes=true, error_on_warning=false))]
+#[allow(clippy::too_many_arguments)]
+fn compile(
+    filepath: Option<&str>,
+    source: Option<&str>,
+    file: Option<&Bound<'_, PyAny>>,
+    filepaths: Option<&Bound<'_, PyDict>>,
+    sources: Option<&Bound<'_, PyDict>>,
+    externals: Option<&Bound<'_, PyDict>>,
+    includes: bool,
+    error_on_warning: bool,
+) -> PyResult<scanner::PyScanner> {
+    let mut compiler = compiler::Compiler::new();
+    compiler.set_params(
+        compiler::CompilerParams::default()
+            .disable_includes(!includes)
+            .fail_on_warnings(error_on_warning),
+    );
+    if let Some(externals) = externals {
+        add_externals(&mut compiler, externals)?;
     }
-    .unwrap();
+
+    let mut warnings = Vec::new();
+
+    match (filepath, source, file, filepaths, sources) {
+        (Some(filepath), None, None, None, None) => {
+            let res = compiler
+                .add_rules_file(filepath)
+                // TODO: contents
+                .map_err(|err| convert_compiler_error(&err, filepath, ""))
+                .map_err(AddRuleError::new_err)?;
+            warnings = res
+                .warnings()
+                .map(|err| convert_compiler_error(err, filepath, ""))
+                .collect();
+        }
+        (None, Some(source), None, None, None) => {
+            let res = compiler
+                .add_rules_str(source)
+                .map_err(|err| convert_compiler_error(&err, "source", source))
+                .map_err(AddRuleError::new_err)?;
+            warnings = res
+                .warnings()
+                .map(|err| convert_compiler_error(err, "source", source))
+                .collect();
+        }
+        (None, None, Some(file), None, None) => {
+            // Read the file into a string
+            let res = file.call_method0(intern!(file.py(), "read"))?;
+            let contents: &str = res.extract()?;
+
+            let res = compiler
+                .add_rules_str(contents)
+                .map_err(|err| convert_compiler_error(&err, "file", contents))
+                .map_err(AddRuleError::new_err)?;
+            warnings = res
+                .warnings()
+                .map(|err| convert_compiler_error(err, "file", contents))
+                .collect();
+        }
+        (None, None, None, Some(filepaths), None) => {
+            for (key, value) in filepaths {
+                let namespace: &str = key.extract().map_err(|_| {
+                    PyTypeError::new_err("keys of the `filepaths` argument must be strings")
+                })?;
+                let filepath: &str = value.extract().map_err(|_| {
+                    PyTypeError::new_err("values of the `filepaths` argument must be strings")
+                })?;
+                let res = compiler
+                    .add_rules_file_in_namespace(filepath, namespace)
+                    // TODO: contents
+                    .map_err(|err| convert_compiler_error(&err, filepath, ""))
+                    .map_err(AddRuleError::new_err)?;
+                warnings.extend(
+                    res.warnings()
+                        .map(|err| convert_compiler_error(err, filepath, "")),
+                );
+            }
+        }
+        (None, None, None, None, Some(sources)) => {
+            for (key, value) in sources {
+                let namespace: &str = key.extract().map_err(|_| {
+                    PyTypeError::new_err("keys of the `sources` argument must be strings")
+                })?;
+                let source: &str = value.extract().map_err(|_| {
+                    PyTypeError::new_err("values of the `sources` argument must be strings")
+                })?;
+                let res = compiler
+                    .add_rules_str_in_namespace(source, namespace)
+                    .map_err(|err| convert_compiler_error(&err, namespace, source))
+                    .map_err(AddRuleError::new_err)?;
+                warnings.extend(
+                    res.warnings()
+                        .map(|err| convert_compiler_error(err, namespace, source)),
+                );
+            }
+        }
+        _ => return Err(PyTypeError::new_err("invalid arguments passed")),
+    }
 
     Ok(scanner::PyScanner {
         scanner: compiler.into_scanner(),
+        warnings,
     })
+}
+
+fn convert_compiler_error(err: &compiler::AddRuleError, input_name: &str, input: &str) -> String {
+    err.to_short_description(input_name, input)
+}
+
+fn add_externals(compiler: &mut compiler::Compiler, externals: &Bound<'_, PyDict>) -> PyResult<()> {
+    for (key, value) in externals {
+        let name: &str = key.extract()?;
+
+        if let Ok(v) = value.extract::<bool>() {
+            let _r = compiler.define_symbol(name, v);
+        } else if let Ok(v) = value.extract::<i64>() {
+            let _r = compiler.define_symbol(name, v);
+        } else if let Ok(v) = value.extract::<f64>() {
+            let _r = compiler.define_symbol(name, v);
+        } else if let Ok(v) = value.extract::<&str>() {
+            let _r = compiler.define_symbol(name, v);
+        } else if let Ok(v) = value.extract::<&[u8]>() {
+            let _r = compiler.define_symbol(name, v);
+        } else {
+            return Err(PyTypeError::new_err(
+                "invalid type for the external value, must be a boolean, integer, float or string",
+            ));
+        }
+    }
+    Ok(())
 }

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -14,6 +14,7 @@ use ::boreal::compiler;
 // TODO: should all pyclasses have names and be exposed in the module?
 // TODO: check GIL handling in all functions (especially match)
 
+mod rule;
 mod rule_match;
 mod scanner;
 mod string_match_instance;
@@ -155,10 +156,7 @@ fn compile(
         _ => return Err(PyTypeError::new_err("invalid arguments passed")),
     }
 
-    Ok(scanner::Scanner {
-        scanner: compiler.into_scanner(),
-        warnings,
-    })
+    Ok(scanner::Scanner::new(compiler.into_scanner(), warnings))
 }
 
 fn convert_compiler_error(err: &compiler::AddRuleError, input_name: &str, input: &str) -> String {

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -1,18 +1,15 @@
 //! Python bindings for the boreal library.
-use std::collections::HashMap;
-use std::hash::{DefaultHasher, Hash, Hasher};
-
-use pyo3::basic::CompareOp;
-use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyList, PyString};
 
-use ::boreal::scanner;
-use ::boreal::{Compiler, Scanner};
-use ::boreal::{Metadata, MetadataValue};
+use ::boreal::Compiler;
 
 // TODO: all clone impls should be efficient...
 // TODO: should all pyclasses have names and be exposed in the module?
+
+mod rule_match;
+mod scanner;
+mod string_match_instance;
+mod string_matches;
 
 #[pymodule]
 fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -21,7 +18,7 @@ fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[pyfunction]
 #[pyo3(signature = (filepath=None, source=None))]
-fn compile(filepath: Option<&str>, source: Option<&str>) -> PyResult<PyScanner> {
+fn compile(filepath: Option<&str>, source: Option<&str>) -> PyResult<scanner::PyScanner> {
     let mut compiler = Compiler::new();
     match (filepath, source) {
         (Some(v), None) => compiler.add_rules_file(v),
@@ -30,221 +27,7 @@ fn compile(filepath: Option<&str>, source: Option<&str>) -> PyResult<PyScanner> 
     }
     .unwrap();
 
-    Ok(PyScanner {
+    Ok(scanner::PyScanner {
         scanner: compiler.into_scanner(),
     })
-}
-
-#[pyclass]
-struct PyScanner {
-    scanner: Scanner,
-}
-
-#[pymethods]
-impl PyScanner {
-    #[pyo3(signature = (filepath=None, data=None))]
-    fn r#match(
-        &self,
-        filepath: Option<&str>,
-        data: Option<&Bound<'_, PyAny>>,
-    ) -> PyResult<Vec<Match>> {
-        let res = match (filepath, data) {
-            (Some(filepath), None) => self.scanner.scan_file(filepath),
-            (None, Some(data)) => {
-                if let Ok(s) = data.downcast::<PyString>() {
-                    self.scanner.scan_mem(s.to_str()?.as_bytes())
-                } else if let Ok(s) = data.downcast::<PyBytes>() {
-                    self.scanner.scan_mem(s.as_bytes())
-                } else {
-                    todo!()
-                }
-            }
-            _ => todo!(),
-        };
-
-        match res {
-            Ok(v) => Python::with_gil(|py| {
-                v.matched_rules
-                    .into_iter()
-                    .map(|v| Match::new(py, &self.scanner, v))
-                    .collect::<Result<_, _>>()
-            }),
-            // TODO: fix difference
-            Err((err, _)) => Err(PyValueError::new_err(format!("{err}"))),
-        }
-    }
-}
-
-/// A matching rule
-#[pyclass(frozen)]
-struct Match {
-    /// Name of the matching rule
-    #[pyo3(get)]
-    rule: String,
-
-    /// Namespace of the matching rule
-    #[pyo3(get)]
-    namespace: String,
-
-    /// List of tags associated to the rule
-    #[pyo3(get)]
-    tags: Py<PyList>,
-
-    /// Dictionary with metadata associated to the rule
-    #[pyo3(get)]
-    meta: HashMap<String, Py<PyAny>>,
-
-    /// Tuple with offsets and strings that matched the file
-    #[pyo3(get)]
-    strings: Vec<StringMatches>,
-}
-
-#[pymethods]
-impl Match {
-    fn __repr__(&self) -> &str {
-        &self.rule
-    }
-
-    fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
-        let a = (&self.rule, &self.namespace);
-        let b = (&other.rule, &other.namespace);
-        match op {
-            CompareOp::Eq => a == b,
-            CompareOp::Ne => a != b,
-            CompareOp::Le => a <= b,
-            CompareOp::Lt => a < b,
-            CompareOp::Gt => a > b,
-            CompareOp::Ge => a >= b,
-        }
-    }
-
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.rule.hash(&mut hasher);
-        self.namespace.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
-impl Match {
-    fn new(py: Python, scanner: &Scanner, rule: scanner::MatchedRule) -> Result<Self, PyErr> {
-        Ok(Self {
-            rule: rule.name.to_string(),
-            namespace: rule.namespace.unwrap_or_default().to_string(),
-            meta: rule
-                .metadatas
-                .iter()
-                .map(|m| convert_metadata(py, scanner, m))
-                .collect::<Result<_, _>>()?,
-            tags: PyList::new(py, rule.tags)?.unbind(),
-            strings: rule.matches.into_iter().map(StringMatches::new).collect(),
-        })
-    }
-}
-
-fn convert_metadata(
-    py: Python,
-    scanner: &Scanner,
-    metadata: &Metadata,
-) -> Result<(String, Py<PyAny>), PyErr> {
-    let name = scanner.get_string_symbol(metadata.name).to_string();
-    let value = match metadata.value {
-        // XXX: Yara forces a string conversion here, losing data in the
-        // process. Prefer using the right type here.
-        // TODO: add a yara compat mode?
-        MetadataValue::Bytes(v) => scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?,
-        MetadataValue::Integer(v) => v.into_pyobject(py)?.into_any(),
-        MetadataValue::Boolean(v) => PyBool::new(py, v).to_owned().into_any(),
-    };
-    Ok((name, value.unbind()))
-}
-
-/// List of match instances of a YARA string
-#[pyclass(frozen)]
-#[derive(Clone)]
-struct StringMatches {
-    /// Name of the matching string.
-    #[pyo3(get)]
-    identifier: String,
-
-    /// List of matches for the string.
-    #[pyo3(get)]
-    instances: Vec<StringMatchInstance>,
-}
-
-impl StringMatches {
-    fn new(s: scanner::StringMatches) -> Self {
-        Self {
-            identifier: format!("${}", &s.name),
-            instances: s
-                .matches
-                .into_iter()
-                .map(StringMatchInstance::new)
-                .collect(),
-        }
-    }
-}
-
-#[pymethods]
-impl StringMatches {
-    // TODO: missing is_xor
-
-    fn __repr__(&self) -> &str {
-        &self.identifier
-    }
-
-    // XXX: the yara impl is to hash on the identifier only.
-    // TODO: when not in yara compat mode, we should probably avoid this...
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.identifier.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
-/// Match instance of a YARA string
-#[pyclass(frozen)]
-#[derive(Clone)]
-struct StringMatchInstance {
-    /// Offset of the match.
-    #[pyo3(get)]
-    offset: usize,
-
-    /// Matched data, might have been truncated if too long.
-    matched_data: Vec<u8>,
-
-    /// Length of the entire match.
-    #[pyo3(get)]
-    matched_length: usize,
-    // TODO: missing xor_key
-}
-
-impl StringMatchInstance {
-    fn new(s: scanner::StringMatch) -> Self {
-        Self {
-            offset: s.offset,
-            matched_data: s.data,
-            matched_length: s.length,
-        }
-    }
-}
-
-#[pymethods]
-impl StringMatchInstance {
-    #[getter]
-    fn matched_data(&self) -> &[u8] {
-        &self.matched_data
-    }
-
-    fn __repr__(&self) -> String {
-        String::from_utf8_lossy(&self.matched_data).to_string()
-    }
-
-    // XXX: the yara impl is to hash on the data only.
-    // TODO: when not in yara compat mode, we should probably avoid this...
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.matched_data.hash(&mut hasher);
-        hasher.finish()
-    }
 }

--- a/boreal-py/src/rule.rs
+++ b/boreal-py/src/rule.rs
@@ -1,0 +1,73 @@
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyList};
+
+use ::boreal::scanner;
+use ::boreal::{Metadata, MetadataValue};
+
+/// A matching rule
+#[pyclass(frozen)]
+pub struct Rule {
+    /// Name of the rule
+    #[pyo3(get)]
+    identifier: String,
+
+    /// Namespace of the rule
+    #[pyo3(get)]
+    namespace: String,
+
+    /// List of tags associated with the rule
+    #[pyo3(get)]
+    tags: Py<PyList>,
+
+    /// Dictionary with metadata associated with the rule
+    #[pyo3(get)]
+    meta: HashMap<String, Py<PyAny>>,
+
+    /// Is the rule global
+    #[pyo3(get)]
+    is_global: bool,
+
+    /// Is the rule private
+    #[pyo3(get)]
+    is_private: bool,
+}
+
+impl Rule {
+    pub fn new(
+        py: Python,
+        scanner: &scanner::Scanner,
+        rule: &scanner::RuleDetails,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            identifier: rule.name.to_owned(),
+            namespace: rule.namespace.unwrap_or_default().to_string(),
+            meta: rule
+                .metadatas
+                .iter()
+                .map(|m| convert_metadata(py, scanner, m))
+                .collect::<Result<_, _>>()?,
+            tags: PyList::new(py, rule.tags)?.unbind(),
+            is_global: rule.is_global,
+            is_private: rule.is_private,
+        })
+    }
+}
+
+pub fn convert_metadata(
+    py: Python,
+    scanner: &scanner::Scanner,
+    metadata: &Metadata,
+) -> Result<(String, Py<PyAny>), PyErr> {
+    let name = scanner.get_string_symbol(metadata.name).to_string();
+    let value = match metadata.value {
+        // XXX: Yara forces a string conversion here, losing data in the
+        // process. Prefer using the right type here.
+        // TODO: add a yara compat mode?
+        MetadataValue::Bytes(v) => scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?,
+        MetadataValue::Integer(v) => v.into_pyobject(py)?.into_any(),
+        MetadataValue::Boolean(v) => PyBool::new(py, v).to_owned().into_any(),
+    };
+    Ok((name, value.unbind()))
+}

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use pyo3::basic::CompareOp;
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyList};
+
+use ::boreal::scanner;
+use ::boreal::{Metadata, MetadataValue};
+
+use crate::string_matches::StringMatches;
+
+/// A matching rule
+#[pyclass(frozen)]
+pub struct Match {
+    /// Name of the matching rule
+    #[pyo3(get)]
+    rule: String,
+
+    /// Namespace of the matching rule
+    #[pyo3(get)]
+    namespace: String,
+
+    /// List of tags associated to the rule
+    #[pyo3(get)]
+    tags: Py<PyList>,
+
+    /// Dictionary with metadata associated to the rule
+    #[pyo3(get)]
+    meta: HashMap<String, Py<PyAny>>,
+
+    /// Tuple with offsets and strings that matched the file
+    #[pyo3(get)]
+    strings: Vec<StringMatches>,
+}
+
+#[pymethods]
+impl Match {
+    fn __repr__(&self) -> &str {
+        &self.rule
+    }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> bool {
+        let a = (&self.rule, &self.namespace);
+        let b = (&other.rule, &other.namespace);
+        match op {
+            CompareOp::Eq => a == b,
+            CompareOp::Ne => a != b,
+            CompareOp::Le => a <= b,
+            CompareOp::Lt => a < b,
+            CompareOp::Gt => a > b,
+            CompareOp::Ge => a >= b,
+        }
+    }
+
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.rule.hash(&mut hasher);
+        self.namespace.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl Match {
+    pub fn new(
+        py: Python,
+        scanner: &scanner::Scanner,
+        rule: scanner::MatchedRule,
+    ) -> Result<Self, PyErr> {
+        Ok(Self {
+            rule: rule.name.to_string(),
+            namespace: rule.namespace.unwrap_or_default().to_string(),
+            meta: rule
+                .metadatas
+                .iter()
+                .map(|m| convert_metadata(py, scanner, m))
+                .collect::<Result<_, _>>()?,
+            tags: PyList::new(py, rule.tags)?.unbind(),
+            strings: rule.matches.into_iter().map(StringMatches::new).collect(),
+        })
+    }
+}
+
+fn convert_metadata(
+    py: Python,
+    scanner: &scanner::Scanner,
+    metadata: &Metadata,
+) -> Result<(String, Py<PyAny>), PyErr> {
+    let name = scanner.get_string_symbol(metadata.name).to_string();
+    let value = match metadata.value {
+        // XXX: Yara forces a string conversion here, losing data in the
+        // process. Prefer using the right type here.
+        // TODO: add a yara compat mode?
+        MetadataValue::Bytes(v) => scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?,
+        MetadataValue::Integer(v) => v.into_pyobject(py)?.into_any(),
+        MetadataValue::Boolean(v) => PyBool::new(py, v).to_owned().into_any(),
+    };
+    Ok((name, value.unbind()))
+}

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -3,11 +3,11 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 
 use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyList};
+use pyo3::types::PyList;
 
 use ::boreal::scanner;
-use ::boreal::{Metadata, MetadataValue};
 
+use crate::rule::convert_metadata;
 use crate::string_matches::StringMatches;
 
 /// A matching rule
@@ -79,21 +79,4 @@ impl Match {
             strings: rule.matches.into_iter().map(StringMatches::new).collect(),
         })
     }
-}
-
-fn convert_metadata(
-    py: Python,
-    scanner: &scanner::Scanner,
-    metadata: &Metadata,
-) -> Result<(String, Py<PyAny>), PyErr> {
-    let name = scanner.get_string_symbol(metadata.name).to_string();
-    let value = match metadata.value {
-        // XXX: Yara forces a string conversion here, losing data in the
-        // process. Prefer using the right type here.
-        // TODO: add a yara compat mode?
-        MetadataValue::Bytes(v) => scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?,
-        MetadataValue::Integer(v) => v.into_pyobject(py)?.into_any(),
-        MetadataValue::Boolean(v) => PyBool::new(py, v).to_owned().into_any(),
-    };
-    Ok((name, value.unbind()))
 }

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use pyo3::basic::CompareOp;
 use pyo3::prelude::*;
-use pyo3::types::PyList;
+use pyo3::types::{IntoPyDict, PyDict, PyList};
 
 use ::boreal::scanner;
 
@@ -27,7 +26,7 @@ pub struct Match {
 
     /// Dictionary with metadata associated to the rule
     #[pyo3(get)]
-    meta: HashMap<String, Py<PyAny>>,
+    meta: Py<PyDict>,
 
     /// Tuple with offsets and strings that matched the file
     #[pyo3(get)]
@@ -74,7 +73,9 @@ impl Match {
                 .metadatas
                 .iter()
                 .map(|m| convert_metadata(py, scanner, m))
-                .collect::<Result<_, _>>()?,
+                .collect::<Result<Vec<_>, _>>()?
+                .into_py_dict(py)?
+                .unbind(),
             tags: PyList::new(py, rule.tags)?.unbind(),
             strings: rule.matches.into_iter().map(StringMatches::new).collect(),
         })

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -190,6 +190,7 @@ fn set_modules_data(
     scanner: &mut scanner::Scanner,
     modules_data: &Bound<'_, PyDict>,
 ) -> PyResult<()> {
+    #[allow(clippy::never_loop)]
     for (key, value) in modules_data {
         let name: &str = key.extract()?;
 
@@ -217,10 +218,16 @@ fn set_modules_data(
                 continue;
             }
         }
+        #[cfg(not(feature = "cuckoo"))]
+        // Suppress unused var warnings
+        {
+            let _ = scanner;
+            let _v = value;
+        }
 
-        return Err(PyTypeError::new_err(
+        return Err(PyTypeError::new_err(format!(
             "cannot set data for unknown module `{name}`",
-        ));
+        )));
     }
 
     Ok(())

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -1,0 +1,47 @@
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyBytes, PyString};
+
+use ::boreal::Scanner;
+
+use crate::rule_match::Match;
+
+#[pyclass]
+pub struct PyScanner {
+    pub scanner: Scanner,
+}
+
+#[pymethods]
+impl PyScanner {
+    #[pyo3(signature = (filepath=None, data=None))]
+    fn r#match(
+        &self,
+        filepath: Option<&str>,
+        data: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Vec<Match>> {
+        let res = match (filepath, data) {
+            (Some(filepath), None) => self.scanner.scan_file(filepath),
+            (None, Some(data)) => {
+                if let Ok(s) = data.downcast::<PyString>() {
+                    self.scanner.scan_mem(s.to_str()?.as_bytes())
+                } else if let Ok(s) = data.downcast::<PyBytes>() {
+                    self.scanner.scan_mem(s.as_bytes())
+                } else {
+                    todo!()
+                }
+            }
+            _ => todo!(),
+        };
+
+        match res {
+            Ok(v) => Python::with_gil(|py| {
+                v.matched_rules
+                    .into_iter()
+                    .map(|v| Match::new(py, &self.scanner, v))
+                    .collect::<Result<_, _>>()
+            }),
+            // TODO: fix difference
+            Err((err, _)) => Err(PyValueError::new_err(format!("{err}"))),
+        }
+    }
+}

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -9,6 +9,8 @@ use crate::rule_match::Match;
 #[pyclass]
 pub struct PyScanner {
     pub scanner: Scanner,
+    #[pyo3(get)]
+    pub warnings: Vec<String>,
 }
 
 #[pymethods]

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -1,49 +1,138 @@
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyString};
+use std::time::Duration;
 
-use ::boreal::Scanner;
+use pyo3::create_exception;
+use pyo3::exceptions::{PyException, PyTypeError};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use ::boreal::scanner;
 
 use crate::rule_match::Match;
 
+create_exception!(boreal, ScanError, PyException, "error when scanning");
+create_exception!(boreal, TimeoutError, PyException, "scan timed out");
+
 #[pyclass]
-pub struct PyScanner {
-    pub scanner: Scanner,
+pub struct Scanner {
+    pub scanner: scanner::Scanner,
     #[pyo3(get)]
     pub warnings: Vec<String>,
 }
 
 #[pymethods]
-impl PyScanner {
-    #[pyo3(signature = (filepath=None, data=None))]
+impl Scanner {
+    #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (
+        filepath=None,
+        data=None,
+        pid=None,
+        externals=None,
+        callback=None,
+        fast=false,
+        timeout=None,
+        modules_data=None,
+        modules_callback=None,
+        warnings_callback=None,
+        which_callbacks=None,
+        console_callback=None,
+    ))]
     fn r#match(
         &self,
         filepath: Option<&str>,
         data: Option<&Bound<'_, PyAny>>,
+        pid: Option<u32>,
+        externals: Option<&Bound<'_, PyDict>>,
+        callback: Option<&Bound<'_, PyAny>>,
+        fast: bool,
+        timeout: Option<u64>,
+        modules_data: Option<&Bound<'_, PyDict>>,
+        modules_callback: Option<&Bound<'_, PyAny>>,
+        warnings_callback: Option<&Bound<'_, PyAny>>,
+        which_callbacks: Option<&Bound<'_, PyAny>>,
+        console_callback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Vec<Match>> {
-        let res = match (filepath, data) {
-            (Some(filepath), None) => self.scanner.scan_file(filepath),
-            (None, Some(data)) => {
-                if let Ok(s) = data.downcast::<PyString>() {
-                    self.scanner.scan_mem(s.to_str()?.as_bytes())
-                } else if let Ok(s) = data.downcast::<PyBytes>() {
-                    self.scanner.scan_mem(s.as_bytes())
+        let mut scanner = self.scanner.clone();
+
+        if let Some(externals) = externals {
+            set_externals(&mut scanner, externals)?;
+        }
+
+        if let Some(timeout) = timeout {
+            scanner.set_scan_params(
+                scanner::ScanParams::default().timeout_duration(Some(Duration::from_secs(timeout))),
+            );
+        }
+
+        // TODO
+        {
+            let _ = callback;
+            let _ = fast;
+            let _ = modules_data;
+            let _ = modules_callback;
+            let _ = warnings_callback;
+            let _ = which_callbacks;
+            let _ = console_callback;
+        }
+
+        let res = match (filepath, data, pid) {
+            (Some(filepath), None, None) => scanner.scan_file(filepath),
+            (None, Some(data), None) => {
+                if let Ok(s) = data.extract::<&[u8]>() {
+                    scanner.scan_mem(s)
+                } else if let Ok(s) = data.extract::<&str>() {
+                    scanner.scan_mem(s.as_bytes())
                 } else {
-                    todo!()
+                    return Err(PyTypeError::new_err(
+                        "data must be a string or a bytestring",
+                    ));
                 }
             }
-            _ => todo!(),
+            (None, None, Some(pid)) => scanner.scan_process(pid),
+            _ => {
+                return Err(PyTypeError::new_err(
+                    "one of filepath, data or pid must be passed",
+                ))
+            }
         };
 
         match res {
             Ok(v) => Python::with_gil(|py| {
                 v.matched_rules
                     .into_iter()
-                    .map(|v| Match::new(py, &self.scanner, v))
+                    .map(|v| Match::new(py, &scanner, v))
                     .collect::<Result<_, _>>()
             }),
-            // TODO: fix difference
-            Err((err, _)) => Err(PyValueError::new_err(format!("{err}"))),
+            Err((err, _)) => match err {
+                scanner::ScanError::Timeout => Err(TimeoutError::new_err("")),
+                _ => Err(ScanError::new_err(format!("{err}"))),
+            },
         }
     }
+}
+
+fn set_externals(scanner: &mut scanner::Scanner, externals: &Bound<'_, PyDict>) -> PyResult<()> {
+    for (key, value) in externals {
+        let name: &str = key.extract()?;
+
+        let res = if let Ok(v) = value.extract::<bool>() {
+            scanner.define_symbol(name, v)
+        } else if let Ok(v) = value.extract::<i64>() {
+            scanner.define_symbol(name, v)
+        } else if let Ok(v) = value.extract::<f64>() {
+            scanner.define_symbol(name, v)
+        } else if let Ok(v) = value.extract::<&str>() {
+            scanner.define_symbol(name, v)
+        } else if let Ok(v) = value.extract::<&[u8]>() {
+            scanner.define_symbol(name, v)
+        } else {
+            return Err(PyTypeError::new_err(
+                "invalid type for the external value, must be a boolean, integer, float or string",
+            ));
+        };
+
+        // the error is ignored as is done in YARA: this avoids aborting the scan for an
+        // overfit dictionary.
+        drop(res);
+    }
+    Ok(())
 }

--- a/boreal-py/src/string_match_instance.rs
+++ b/boreal-py/src/string_match_instance.rs
@@ -1,0 +1,52 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use pyo3::prelude::*;
+
+use ::boreal::scanner;
+
+/// Match instance of a YARA string
+#[pyclass(frozen)]
+#[derive(Clone)]
+pub struct StringMatchInstance {
+    /// Offset of the match.
+    #[pyo3(get)]
+    offset: usize,
+
+    /// Matched data, might have been truncated if too long.
+    matched_data: Vec<u8>,
+
+    /// Length of the entire match.
+    #[pyo3(get)]
+    matched_length: usize,
+    // TODO: missing xor_key
+}
+
+impl StringMatchInstance {
+    pub fn new(s: scanner::StringMatch) -> Self {
+        Self {
+            offset: s.offset,
+            matched_data: s.data,
+            matched_length: s.length,
+        }
+    }
+}
+
+#[pymethods]
+impl StringMatchInstance {
+    #[getter]
+    fn matched_data(&self) -> &[u8] {
+        &self.matched_data
+    }
+
+    fn __repr__(&self) -> String {
+        String::from_utf8_lossy(&self.matched_data).to_string()
+    }
+
+    // XXX: the yara impl is to hash on the data only.
+    // TODO: when not in yara compat mode, we should probably avoid this...
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.matched_data.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/boreal-py/src/string_matches.rs
+++ b/boreal-py/src/string_matches.rs
@@ -1,0 +1,50 @@
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use pyo3::prelude::*;
+
+use ::boreal::scanner;
+
+use crate::string_match_instance::StringMatchInstance;
+
+/// List of match instances of a YARA string
+#[pyclass(frozen)]
+#[derive(Clone)]
+pub struct StringMatches {
+    /// Name of the matching string.
+    #[pyo3(get)]
+    identifier: String,
+
+    /// List of matches for the string.
+    #[pyo3(get)]
+    instances: Vec<StringMatchInstance>,
+}
+
+impl StringMatches {
+    pub fn new(s: scanner::StringMatches) -> Self {
+        Self {
+            identifier: format!("${}", &s.name),
+            instances: s
+                .matches
+                .into_iter()
+                .map(StringMatchInstance::new)
+                .collect(),
+        }
+    }
+}
+
+#[pymethods]
+impl StringMatches {
+    // TODO: missing is_xor
+
+    fn __repr__(&self) -> &str {
+        &self.identifier
+    }
+
+    // XXX: the yara impl is to hash on the identifier only.
+    // TODO: when not in yara compat mode, we should probably avoid this...
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.identifier.hash(&mut hasher);
+        hasher.finish()
+    }
+}

--- a/boreal-py/tests/test_compile.py
+++ b/boreal-py/tests/test_compile.py
@@ -1,0 +1,279 @@
+import boreal
+import pytest
+import tempfile
+import yara
+
+
+MODULES = [
+    (boreal, False),
+    (yara, True),
+]
+
+
+def compile_exc_type(is_yara):
+    if is_yara:
+        return yara.SyntaxError
+    else:
+        return boreal.AddRuleError
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_filepath(module, is_yara):
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(b'rule a { condition: true }')
+        fp.flush()
+
+        # By default, it uses filepath
+        rules = module.compile(fp.name)
+        matches = rules.match(data='')
+        assert len(matches) == 1
+        assert matches[0].rule == 'a'
+
+        # Can also be specified
+        rules = module.compile(filepath=fp.name)
+        matches = rules.match(data='')
+        assert len(matches) == 1
+        assert matches[0].rule == 'a'
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_source(module, is_yara):
+    # Source specifies the string directly
+    rules = module.compile(source='rule a { condition: true }')
+    matches = rules.match(data='')
+    assert len(matches) == 1
+    assert matches[0].rule == 'a'
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_file(module, is_yara):
+    with tempfile.TemporaryFile() as fp:
+        fp.write(b'rule a { condition: true }')
+        fp.flush()
+        fp.seek(0)
+
+        rules = module.compile(file=fp)
+        matches = rules.match(data='')
+        assert len(matches) == 1
+        assert matches[0].rule == 'a'
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_filepaths(module, is_yara):
+    # filepaths allows specifying namespaces
+    with tempfile.NamedTemporaryFile() as fp1, tempfile.NamedTemporaryFile() as fp2:
+        fp1.write(b'rule a { condition: true }')
+        fp1.flush()
+        fp2.write(b'rule b { condition: true }')
+        fp2.flush()
+
+        rules = module.compile(filepaths={
+            'ns1': fp1.name,
+            'ns2': fp2.name
+        })
+        matches = rules.match(data='')
+        assert len(matches) == 2
+        assert matches[0].rule == 'a'
+        assert matches[0].namespace ==  'ns1'
+        assert matches[1].rule == 'b'
+        assert matches[1].namespace == 'ns2'
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_sources(module, is_yara):
+    # sources allows specifying namespaces
+    rules = module.compile(sources={
+        'ns1': 'rule a { condition: true }',
+        'ns2': 'rule b { condition: true }',
+    })
+    matches = rules.match(data='')
+    assert len(matches) == 2
+    assert matches[0].rule == 'a'
+    assert matches[0].namespace ==  'ns1'
+    assert matches[1].rule == 'b'
+    assert matches[1].namespace == 'ns2'
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_externals(module, is_yara):
+    externals = {
+        'b': True,
+        's': 'foo',
+        'i': -12,
+        'f': 34.5,
+    }
+    rules = module.compile(externals=externals, source="""
+rule a {
+    condition:
+        b and s == "foo" and i == -12 and f == 34.5
+}""")
+    matches = rules.match(data='')
+    assert len(matches) == 1
+
+    # boreal also accepts byte-string, while yara does not
+    if is_yara:
+        with pytest.raises(TypeError):
+            module.compile(externals={ 's': b'foo' }, source="rule a { condition: true }")
+    else:
+        rules = module.compile(
+            externals={ 's': b'f\xFFo' },
+            source="""rule a { condition: s == "f\\xFFo" }"""
+        )
+        matches = rules.match(data='')
+        assert len(matches) == 1
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_includes(module, is_yara):
+    # By default, includes are allowed
+    with tempfile.NamedTemporaryFile() as fp1:
+        fp1.write(b"rule a { condition: true }")
+        fp1.flush()
+
+        source = """
+include "{path}"
+
+rule b {{ condition: true }}
+        """.format(path=fp1.name)
+        rules = module.compile(source=source)
+        matches = rules.match(data='')
+        assert len(matches) == 2
+
+        # But they can be disabled
+        exctype = compile_exc_type(is_yara)
+        with pytest.raises(exctype):
+            module.compile(source=source, includes=False)
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_warnings(module, is_yara):
+    # By default, warnings do not make the compilation fail
+    source = """rule a { condition: "foo" }"""
+    rules = module.compile(source=source)
+    matches = rules.match(data="")
+    assert len(matches) == 1
+
+    # warnings can be found in the rules objects
+    assert len(rules.warnings) == 1
+    assert "boolean" in rules.warnings[0]
+
+    # error_on_warning can modify this
+    if is_yara:
+        # Yara uses a different exception for warnings turned into errors.
+        exctype = yara.WarningError
+    else:
+        exctype = boreal.AddRuleError
+    with pytest.raises(exctype):
+        module.compile(source=source, error_on_warning=True)
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_warnings_contexts(module, is_yara):
+    # Test warnings are correctly handled in all the different contexts
+    source1 = """rule a { condition: "foo" }"""
+    source2 = """rule b { condition: "b" }"""
+
+    rules = module.compile(source=source1 + source2)
+    assert len(rules.warnings) == 2
+    assert "boolean" in rules.warnings[0]
+    assert "boolean" in rules.warnings[1]
+
+    rules = module.compile(sources={ 'ns1': source1, 'ns2': source2 })
+    assert len(rules.warnings) == 2
+    assert "boolean" in rules.warnings[0]
+    assert "boolean" in rules.warnings[1]
+
+    with tempfile.NamedTemporaryFile() as fp1, tempfile.NamedTemporaryFile() as fp2:
+        fp1.write(source1.encode())
+        fp1.flush()
+        fp1.seek(0)
+        fp2.write(source2.encode())
+        fp2.flush()
+        fp2.seek(0)
+
+        rules = module.compile(filepath=fp1.name)
+        assert len(rules.warnings) == 1
+        assert "boolean" in rules.warnings[0]
+
+        rules = module.compile(file=fp1)
+        assert len(rules.warnings) == 1
+        assert "boolean" in rules.warnings[0]
+
+        rules = module.compile(filepaths={ 'ns1': fp1.name, 'ns2': fp2.name })
+        assert len(rules.warnings) == 2
+        assert "boolean" in rules.warnings[0]
+        assert "boolean" in rules.warnings[1]
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_errors_invalid_arguments(module, is_yara):
+    # Cannot specify multiple sources
+    with pytest.raises(TypeError):
+        module.compile(source="", sources={})
+    with pytest.raises(TypeError):
+        module.compile(filepath="", sources={})
+    with pytest.raises(TypeError):
+        module.compile(filepaths={}, sources={})
+    with tempfile.NamedTemporaryFile() as fp:
+        with pytest.raises(TypeError):
+            module.compile(file=fp, sources={})
+    with pytest.raises(TypeError):
+        module.compile(source={}, filepaths={})
+
+    with pytest.raises(TypeError):
+        module.compile()
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_errors_invalid_types(module, is_yara):
+    with pytest.raises(TypeError):
+        module.compile(filepath=1)
+    with pytest.raises(TypeError):
+        module.compile(source=1)
+    with pytest.raises(TypeError):
+        module.compile(sources=1)
+    with pytest.raises(TypeError):
+        module.compile(filepaths=1)
+    # FIXME: yara segfaults on this on Windows
+    if not is_yara:
+        with pytest.raises(AttributeError):
+            module.compile(file='str')
+
+    with pytest.raises(TypeError):
+        module.compile(sources={ 1: 'a' })
+    with pytest.raises(TypeError):
+        module.compile(sources={ 'a': 1 })
+
+    with pytest.raises(TypeError):
+        module.compile(filepaths={ 1: 'a' })
+    with pytest.raises(TypeError):
+        module.compile(filepaths={ 'a': 1 })
+
+    source = 'rule a { condition: true }'
+    # FIXME: difference here between boreal and yara
+    # with pytest.raises(TypeError):
+    #     module.compile(source=source, externals={ 1: 'a' })
+    with pytest.raises(TypeError):
+        module.compile(source=source, externals={ 'a': [1] })
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_compile_errors_compilation(module, is_yara):
+    exctype = compile_exc_type(is_yara)
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(b'rule')
+        fp.flush()
+        fp.seek(0)
+
+        with pytest.raises(exctype):
+            module.compile(filepath=fp.name)
+        with pytest.raises(exctype):
+            module.compile(filepaths={ 'ns': fp.name })
+        with pytest.raises(exctype):
+            module.compile(file=fp)
+
+    with pytest.raises(exctype):
+        module.compile(source='rule')
+    with pytest.raises(exctype):
+        module.compile(sources={ 'ns': 'rule' })

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -245,3 +245,19 @@ rule a {
     captured = capsys.readouterr()
     assert captured.out == "override <i am a log>\n"
     assert captured.err == ""
+
+
+# TODO: find a way to compile yara python with cuckoo?
+def test_match_modules_data():
+    rules = boreal.compile(source="""
+import "cuckoo"
+
+rule a {
+    condition:
+        cuckoo.network.host(/bcd/) == 1
+}""")
+
+    matches = rules.match(data='', modules_data={
+        'cuckoo': '{ "network": { "hosts": ["abcde"] } }'
+    })
+    assert len(matches) == 1

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -1,0 +1,57 @@
+import boreal
+import pytest
+import yara
+
+
+MODULES = [
+    (boreal, False),
+    (yara, True),
+]
+
+
+RULE = """
+rule foo: bar baz {
+    meta:
+        s = "a\\nz"
+        b = true
+        v = -11
+    strings:
+        $ = "fgj"
+        $a = /l.{1,2}n/
+    condition:
+        any of them
+}
+"""
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
+def test_match(module, is_yara):
+    rule = module.compile(source=RULE)
+    matches = rule.match(data='abcdefgjiklmnoprstuvwxyzlmmn')
+    assert len(matches) == 1
+    assert matches[0].rule == 'foo'
+    # FIXME: difference between yara and boreal
+    # assert matches[0].namespace == ''
+    assert matches[0].tags == ['bar', 'baz']
+    assert matches[0].meta == {
+        # XXX yara forces a string type, losing information.
+        's': 'a\nz' if is_yara else b'a\nz',
+        'b': True,
+        'v': -11
+    }
+
+    m = matches[0]
+    assert len(m.strings) == 2
+    assert m.strings[0].identifier == '$'
+    assert len(m.strings[0].instances) == 1
+    assert m.strings[0].instances[0].offset == 5
+    assert m.strings[0].instances[0].matched_length == 3
+    assert m.strings[0].instances[0].matched_data == b'fgj'
+
+    assert m.strings[1].identifier == '$a'
+    assert len(m.strings[1].instances) == 2
+    assert m.strings[1].instances[0].offset == 10
+    assert m.strings[1].instances[0].matched_length == 3
+    assert m.strings[1].instances[0].matched_data == b'lmn'
+    assert m.strings[1].instances[1].offset == 24
+    assert m.strings[1].instances[1].matched_length == 4
+    assert m.strings[1].instances[1].matched_data == b'lmmn'

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -58,6 +58,43 @@ def test_match(module, is_yara):
 
 
 @pytest.mark.parametrize("module,is_yara", MODULES)
+def test_string_matches(module, is_yara):
+    """Test all properties related to the StringMatches object"""
+    rule = module.compile(source="""
+rule foo {
+    strings:
+        $ = "a"
+        $ = "b"
+        $c = "c"
+    condition:
+        any of them
+}""")
+    matches = rule.match(data=b'abca')
+    assert len(matches) == 1
+    m = matches[0]
+    assert len(m.strings) == 3
+    s0 = m.strings[0]
+    s1 = m.strings[1]
+    s2 = m.strings[2]
+
+    # check standard getters: identifier, instances
+    assert s0.identifier == '$'
+    assert len(s0.instances) == 2
+    assert s1.identifier == '$'
+    assert len(s1.instances) == 1
+    assert s2.identifier == '$c'
+    assert len(s2.instances) == 1
+
+    # check special method __repr__
+    assert s0.__repr__() == '$'
+    assert s1.__repr__() == '$'
+    assert s2.__repr__() == '$c'
+
+    # Check that the hash depends only on the identifier
+    assert hash(s0) == hash(s1)
+
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
 def test_string_match(module, is_yara):
     """Test all properties related to the StringMatch object"""
     rule = module.compile(source="""

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -9,54 +9,6 @@ MODULES = [
 ]
 
 
-RULE = """
-rule foo: bar baz {
-    meta:
-        s = "a\\nz"
-        b = true
-        v = -11
-    strings:
-        $ = "fgj"
-        $a = /l.{1,2}n/
-    condition:
-        any of them
-}
-"""
-
-@pytest.mark.parametrize("module,is_yara", MODULES)
-def test_overall(module, is_yara):
-    rule = module.compile(source=RULE)
-    matches = rule.match(data='abcdefgjiklmnoprstuvwxyzlmmn')
-    assert len(matches) == 1
-    assert matches[0].rule == 'foo'
-    # FIXME: difference between yara and boreal
-    # assert matches[0].namespace == ''
-    assert matches[0].tags == ['bar', 'baz']
-    assert matches[0].meta == {
-        # XXX yara forces a string type, losing information.
-        's': 'a\nz' if is_yara else b'a\nz',
-        'b': True,
-        'v': -11
-    }
-
-    m = matches[0]
-    assert len(m.strings) == 2
-    assert m.strings[0].identifier == '$'
-    assert len(m.strings[0].instances) == 1
-    assert m.strings[0].instances[0].offset == 5
-    assert m.strings[0].instances[0].matched_length == 3
-    assert m.strings[0].instances[0].matched_data == b'fgj'
-
-    assert m.strings[1].identifier == '$a'
-    assert len(m.strings[1].instances) == 2
-    assert m.strings[1].instances[0].offset == 10
-    assert m.strings[1].instances[0].matched_length == 3
-    assert m.strings[1].instances[0].matched_data == b'lmn'
-    assert m.strings[1].instances[1].offset == 24
-    assert m.strings[1].instances[1].matched_length == 4
-    assert m.strings[1].instances[1].matched_data == b'lmmn'
-
-
 @pytest.mark.parametrize("module,is_yara", MODULES)
 def test_match(module, is_yara):
     """Test all properties related to the Match object"""

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -223,3 +223,25 @@ rule a {
         # Unfortunately, we cannot go below 1 second as this is the smallest timeout value
         # in the yara api
         rules.match(data='', timeout=1)
+
+
+@pytest.mark.parametrize('module,is_yara', MODULES)
+def test_match_console_log(module, is_yara, capsys):
+    rules = module.compile(source="""
+import "console"
+
+rule a {
+    condition:
+        console.log("i am a log") and true
+}""")
+
+    rules.match(data='')
+    captured = capsys.readouterr()
+    assert captured.out == "i am a log\n"
+    assert captured.err == ""
+
+    # Can override the callback
+    rules.match(data='', console_callback=lambda log: print(f"override <{log}>"))
+    captured = capsys.readouterr()
+    assert captured.out == "override <i am a log>\n"
+    assert captured.err == ""

--- a/boreal-py/tests/test_match.py
+++ b/boreal-py/tests/test_match.py
@@ -55,3 +55,47 @@ def test_match(module, is_yara):
     assert m.strings[1].instances[1].offset == 24
     assert m.strings[1].instances[1].matched_length == 4
     assert m.strings[1].instances[1].matched_data == b'lmmn'
+
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
+def test_string_match(module, is_yara):
+    """Test all properties related to the StringMatch object"""
+    rule = module.compile(source="""
+rule foo {
+    strings:
+        $ = /<.{1,3}>/
+    condition:
+        any of them
+}""")
+    matches = rule.match(data=b'<a> <\td> <\x00\xFF\xFB> <a>')
+    assert len(matches) == 1
+    m = matches[0]
+    assert len(m.strings) == 1
+    s = m.strings[0]
+    assert len(s.instances) == 4
+    i0 = s.instances[0]
+    i1 = s.instances[1]
+    i2 = s.instances[2]
+    i3 = s.instances[3]
+
+    # check standard getters: offset, matched_data, matched_length
+    assert i0.offset == 0
+    assert i0.matched_length == 3
+    assert i0.matched_data == b'<a>'
+    assert i1.offset == 4
+    assert i1.matched_length == 4
+    assert i1.matched_data == b'<\td>'
+    assert i2.offset == 9
+    assert i2.matched_length == 5
+    assert i2.matched_data == b'<\x00\xFF\xFB>'
+
+    # TODO: missing xor_key and plaintext
+
+    # check special method __repr__
+    assert i0.__repr__() == '<a>'
+    assert i1.__repr__() == '<\td>'
+    # TODO: difference here, should we care about it?
+    assert i2.__repr__() == '<\x00\\xff\\xfb>' if is_yara else '<\x00\uFFFD\uFFFD>'
+
+    # Check that the hash depends only on the matched_data
+    assert hash(i0) == hash(i3)

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -174,6 +174,9 @@ def test_match_invalid_types(module, is_yara):
     with pytest.raises(TypeError):
         rules.match(data='', externals={ 'a': [1] })
 
+    with pytest.raises(TypeError):
+        rules.match(data='', console_callback=1)
+
 
 @pytest.mark.parametrize('module,is_yara', MODULES)
 def test_match_externals_unknown(module, is_yara):
@@ -265,6 +268,20 @@ rule a {
         'cuckoo': '{ "network": { "hosts": ["abcde"] } }'
     })
     assert len(matches) == 1
+
+
+def test_match_modules_data_errors():
+    rules = get_rules(boreal)
+
+    # YARA does not reject this, as the list is not checked.
+    with pytest.raises(TypeError):
+        rules.match(data="", modules_data={ 'unknown': 1 })
+
+    if 'cuckoo' in boreal.available_modules():
+        with pytest.raises(TypeError):
+            rules.match(data="", modules_data={ 'cuckoo': 1 })
+        with pytest.raises(TypeError):
+            rules.match(data="", modules_data={ 'cuckoo': "invalid json" })
 
 
 @pytest.mark.parametrize('module,is_yara', MODULES)

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -249,6 +249,10 @@ rule a {
 
 # TODO: find a way to compile yara python with cuckoo?
 def test_match_modules_data():
+    # Test only works if the cuckoo module is present
+    if 'cuckoo' not in boreal.available_modules():
+        return
+
     rules = boreal.compile(source="""
 import "cuckoo"
 

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -1,0 +1,199 @@
+import boreal
+import pytest
+import yara
+
+
+MODULES = [
+    (boreal, False),
+    (yara, True),
+]
+
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
+def test_match(module, is_yara):
+    """Test all properties related to the Match object"""
+
+    # Check default namespace
+    rule = module.compile(source="rule a { condition: true }")
+    matches = rule.match(data='')
+    assert len(matches) == 1
+    # FIXME
+    assert matches[0].namespace == ('default' if is_yara else '')
+
+    # Check with multiple namespaces
+    source = """
+rule r1: bar baz {
+    meta:
+        s = "a\\nz"
+        b = true
+        v = -11
+    condition:
+        true
+}
+
+rule r2: quux { condition: false }
+rule r3 { condition: true }
+"""
+
+    rules = module.compile(sources={
+        'ns1': source,
+        'ns2': source,
+    })
+    rules2 = module.compile(sources={
+        'ns1': 'rule r1 { condition: true }',
+        'ns2': 'rule r1 { condition: true }',
+    })
+    matches = rules.match(data='')
+    assert len(matches) == 4
+    m0 = matches[0]
+    m1 = matches[1]
+    m2 = matches[2]
+    m3 = matches[3]
+
+    matches2 = rules2.match(data='')
+    assert len(matches2) == 2
+    r2_m0 = matches2[0]
+    r2_m1 = matches2[1]
+
+    assert m0.rule == 'r1'
+    assert m0.namespace == 'ns1'
+    assert m0.tags == ['bar', 'baz']
+    assert m0.meta == {
+        # XXX yara forces a string type, losing information.
+        's': 'a\nz' if is_yara else b'a\nz',
+        'b': True,
+        'v': -11
+    }
+
+    assert m1.rule == 'r3'
+    assert m1.namespace == 'ns1'
+
+    assert m2.rule == 'r1'
+    assert m2.namespace == 'ns2'
+
+    assert m3.rule == 'r3'
+    assert m3.namespace == 'ns2'
+
+    # check special method __repr__
+    assert m0.__repr__() == 'r1'
+    assert m1.__repr__() == 'r3'
+    assert m2.__repr__() == 'r1'
+    assert m3.__repr__() == 'r3'
+    assert r2_m0.__repr__() == 'r1'
+    assert r2_m1.__repr__() == 'r1'
+
+    assert hash(m0) != hash(m1) # rule name differs
+    assert hash(m0) != hash(m2) # namespace name differs
+    assert hash(m0) == hash(r2_m0) # same name and namespace
+    assert hash(m0) != hash(r2_m1)
+
+    # check richcmp impl
+    # eq
+    assert not (m0 == m1)
+    assert not (m0 == m2)
+    assert m0 == r2_m0
+    # ne
+    assert (m0 != m1)
+    assert (m0 != m2)
+    assert not (m0 != r2_m0)
+    # <=
+    assert m0 <= m1
+    assert not (m1 <= m2)
+    assert m0 <= m2
+    assert m0 <= r2_m0
+    # <
+    assert m0 < m1
+    assert not (m1 < m2)
+    assert m0 < m2
+    assert not (m0 < r2_m0)
+    # >=
+    assert m1 >= m0
+    assert not (m2 >= m1)
+    assert m2 >= m0
+    assert r2_m0 >= m0
+    # >
+    assert m1 > m0
+    assert not (m2 > m1)
+    assert m2 > m0
+    assert not (r2_m0 > m0)
+
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
+def test_string_matches(module, is_yara):
+    """Test all properties related to the StringMatches object"""
+    rule = module.compile(source="""
+rule foo {
+    strings:
+        $ = "a"
+        $ = "b"
+        $c = "c"
+    condition:
+        any of them
+}""")
+    matches = rule.match(data=b'abca')
+    assert len(matches) == 1
+    m = matches[0]
+    assert len(m.strings) == 3
+    s0 = m.strings[0]
+    s1 = m.strings[1]
+    s2 = m.strings[2]
+
+    # check standard getters: identifier, instances
+    assert s0.identifier == '$'
+    assert len(s0.instances) == 2
+    assert s1.identifier == '$'
+    assert len(s1.instances) == 1
+    assert s2.identifier == '$c'
+    assert len(s2.instances) == 1
+
+    # check special method __repr__
+    assert s0.__repr__() == '$'
+    assert s1.__repr__() == '$'
+    assert s2.__repr__() == '$c'
+
+    # Check that the hash depends only on the identifier
+    assert hash(s0) == hash(s1)
+
+
+@pytest.mark.parametrize("module,is_yara", MODULES)
+def test_string_match(module, is_yara):
+    """Test all properties related to the StringMatch object"""
+    rule = module.compile(source="""
+rule foo {
+    strings:
+        $ = /<.{1,3}>/
+    condition:
+        any of them
+}""")
+    matches = rule.match(data=b'<a> <\td> <\x00\xFF\xFB> <a>')
+    assert len(matches) == 1
+    m = matches[0]
+    assert len(m.strings) == 1
+    s = m.strings[0]
+    assert len(s.instances) == 4
+    i0 = s.instances[0]
+    i1 = s.instances[1]
+    i2 = s.instances[2]
+    i3 = s.instances[3]
+
+    # check standard getters: offset, matched_data, matched_length
+    assert i0.offset == 0
+    assert i0.matched_length == 3
+    assert i0.matched_data == b'<a>'
+    assert i1.offset == 4
+    assert i1.matched_length == 4
+    assert i1.matched_data == b'<\td>'
+    assert i2.offset == 9
+    assert i2.matched_length == 5
+    assert i2.matched_data == b'<\x00\xFF\xFB>'
+
+    # TODO: missing xor_key and plaintext
+
+    # check special method __repr__
+    assert i0.__repr__() == '<a>'
+    assert i1.__repr__() == '<\td>'
+    # TODO: difference here, should we care about it?
+    assert i2.__repr__() == '<\x00\\xff\\xfb>' if is_yara else '<\x00\uFFFD\uFFFD>'
+
+    # Check that the hash depends only on the matched_data
+    assert hash(i0) == hash(i3)

--- a/boreal-py/uv.lock
+++ b/boreal-py/uv.lock
@@ -1,0 +1,100 @@
+version = 1
+requires-python = ">=3.11"
+
+[[package]]
+name = "boreal"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "yara-python" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3.4" },
+    { name = "yara-python", specifier = ">=4.5.1" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
+]
+
+[[package]]
+name = "yara-python"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/3a/0d2970e76215ab7a835ebf06ba0015f98a9d8e11b9969e60f1ca63f04ba5/yara_python-4.5.1.tar.gz", hash = "sha256:52ab24422b021ae648be3de25090cbf9e6c6caa20488f498860d07f7be397930", size = 550202 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/78/f5e1751e27b61a8a265043f238db7c72bd64bdd0ec5169f5dbdcbc7601fa/yara_python-4.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3044359876921e26370f7b646d84a65681811df577be7d4d09c7de21b33d9130", size = 414527 },
+    { url = "https://files.pythonhosted.org/packages/93/f1/088b2dfb5cc8f1bd1bbba6195179fe5d52ca0174d4c899ac6b2cfca834d7/yara_python-4.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:49ad70b6b65ed1c591c3bfb3d5d6da0fc6a73b1f979604feead450f348ad67c4", size = 2061616 },
+    { url = "https://files.pythonhosted.org/packages/f7/91/ed1c827ce0b650953344ab0da9fda9006211e740f05eb367ae60fa79cdb1/yara_python-4.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5a6a185d2ec8fbbffa89d0f7949b84f76860d0e3a74192825dbf53d6a5069b83", size = 2243210 },
+    { url = "https://files.pythonhosted.org/packages/60/6d/77578b1d924666d766b16fa125c93394ba48856177dc8ed1f988174390a3/yara_python-4.5.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2560dd27f63cdb395d9d77d6a74d1f0d6b7aa0ea18394f44d650e5abb6e377a3", size = 2321636 },
+    { url = "https://files.pythonhosted.org/packages/30/bb/05182e1276fc11f45f782a045a96d4a9672eada3122fc935c4603c2db477/yara_python-4.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:471e4070bf7e3b9b132f1c0134d1172d9dae353b04f2fce9bc31431ae785595e", size = 2326006 },
+    { url = "https://files.pythonhosted.org/packages/f3/b4/8cda7f39558d852bd42dc513dbe6ac89a49fe5153b3f174e4dfc108ced6d/yara_python-4.5.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f533848781f0e46e44eda77055eae4ec934cf56c1f473e787704f1a348e90094", size = 1954845 },
+    { url = "https://files.pythonhosted.org/packages/af/b3/f6036ad67b26b94e6bc1a49d10fdc78577588abee806569c0385531199e3/yara_python-4.5.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:3aaf259ed162d2de5db70ae1ba057307efdeb7f4697d74cc5b3313caa7647923", size = 2008589 },
+    { url = "https://files.pythonhosted.org/packages/b8/d0/39b6deb57698a3d6d84d6b099632dd47a73016f3178f5a77736c16890e7a/yara_python-4.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:90374acc38086447a668580a9aecceb11964f08deb05bfaced6f43e9e67955a1", size = 2058872 },
+    { url = "https://files.pythonhosted.org/packages/07/fd/9db15a6216d4ac5f6f76f5e8e27785c38235856fe7686b362f0fbe2cdf7a/yara_python-4.5.1-cp311-cp311-win32.whl", hash = "sha256:721422a14d18a81d75397df51481f5b5f3ab8d0a5220087e5306570877cab4e4", size = 1336639 },
+    { url = "https://files.pythonhosted.org/packages/a7/fa/475113ec92e9c685bbccea3ce65cabd96367e7023fa0357c6a1082da1358/yara_python-4.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:dac13dc77a5f21c119104ae4e6ad837589eace0505e9daf38af0bd2d4ccd7cfa", size = 1683833 },
+    { url = "https://files.pythonhosted.org/packages/68/69/847b0699c64beaea8de549ef806064420df54cf58e94fcd2f651d9963b7a/yara_python-4.5.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:7eb27c1cd2f6f93f68e23e676ede28357c1fc8b9ec7deefe86f2cfef4abd877c", size = 414622 },
+    { url = "https://files.pythonhosted.org/packages/97/57/8cdb21d9c5fe049885cce8fdad02a79200533ffe64bb3a2f9c90affac274/yara_python-4.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4c7ac7c1ae5e25bd5bf67ce752ac82568c2cdc157c9af50ba28d7cbab4421175", size = 2061769 },
+    { url = "https://files.pythonhosted.org/packages/41/14/af54ca86186aa265a4c722324f1f0aca8dd5fdef59ff9c9a81c8679bc3ed/yara_python-4.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77011bed905f3786755da7de7ba9082790db654a241e13746fa3fc325b9ad966", size = 2245644 },
+    { url = "https://files.pythonhosted.org/packages/20/60/7fe2cf48d8478774b15d049eccf5f7a76b40d0dc158d500c836d4e4a0e63/yara_python-4.5.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ddedd9bfcfc37ffddceefd9dbf9bbba137c979b3effc9c1e9aeb08d77c6858c", size = 2324557 },
+    { url = "https://files.pythonhosted.org/packages/b1/cd/1a6a0b8d70cb4b117d6aeb3e62b41ab85ab46717a15c74aa615e2beeb4fa/yara_python-4.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3431154fac7f41b4657edad91632717b5f1bab5be4ed6ce28d6e17e441d5c947", size = 2328876 },
+    { url = "https://files.pythonhosted.org/packages/b0/24/6027b35f4cea11537d6f0b8a5119933f405eb806c27f3c288e086b6e4f76/yara_python-4.5.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7d5dc091235ded00b30f04a51d70e08352e44976122f8d45e63d25e96eae27d9", size = 1957556 },
+    { url = "https://files.pythonhosted.org/packages/92/65/5414dcd86e5564608054200a70b94e44bc350dc10cf634c26b8ff473b1f8/yara_python-4.5.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:97d30a483d195e6b695f072086cf1234317a650727844bac7bf85cf98dd960a3", size = 2011059 },
+    { url = "https://files.pythonhosted.org/packages/aa/8f/11785bb3256151b8584e27557ea7747b54cf3a28e0f12980555458734a8e/yara_python-4.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bb65c17657b4cdbe5adee7a6e617ee05e214e8afdbc82b195885354a72a16476", size = 2061924 },
+    { url = "https://files.pythonhosted.org/packages/d8/f4/409a8e77e915748135c8f4d5a04392c4b86f034f6e89986d3198788b754e/yara_python-4.5.1-cp312-cp312-win32.whl", hash = "sha256:4f368d057e0865278444c948a65802f7c92008a1b59bf629bdc9efa1b0120a22", size = 1336853 },
+    { url = "https://files.pythonhosted.org/packages/f5/2e/27063ad99728a3146159f7a6a202d9959a0c938ba34e5e17ce9b29763348/yara_python-4.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ccd73466d7ad1a50cd06f38fdb7a023fee87dd185d3fcf67cc5c55d82cc34dd", size = 1684095 },
+]

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,7 @@ ignore = [
 allow = [
     "MIT",
     "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
     "BSD-3-Clause",
     "Unicode-3.0",
     "ISC",


### PR DESCRIPTION
Add a new crate to expose python bindings. This will attempt to match the yara API as much as possible to ease migration.

Most of the bindings have been implemented. A few features are missing in boreal to be able to match the yara API, and a few things need to be fixed. This will be done in following PRs.