### PR TITLE
feat: allow setting callback for console module in scanner

### DIFF
--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -45,7 +45,7 @@ use crate::memory::{Memory, Region};
 use crate::regex::Regex;
 
 mod console;
-pub use console::{Console, LogCallback};
+pub use console::{Console, ConsoleData, LogCallback};
 
 mod time;
 pub use time::Time;


### PR DESCRIPTION
This allows modifying the console module callback in the scanner. This will be useful for the python bindings where each match call can specify the console callback to use.