### PR TITLE
Add ability to list non matched rules in results

### DIFF
--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -64,7 +64,7 @@ impl Match {
     pub fn new(
         py: Python,
         scanner: &scanner::Scanner,
-        rule: scanner::MatchedRule,
+        rule: scanner::EvaluatedRule,
     ) -> Result<Self, PyErr> {
         Ok(Self {
             rule: rule.name.to_string(),

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! // Use this object to scan strings or files.
 //! let res = scanner.scan_mem(b"<\0t\0m\0p\0.\0d\0a\0t\0>\0").unwrap();
-//! assert!(res.matched_rules.iter().any(|rule| rule.name == "example"));
+//! assert!(res.rules.iter().any(|rule| rule.name == "example"));
 //!
 //! # Ok::<(), boreal::compiler::AddRuleError>(())
 //! ```

--- a/boreal/src/module/cuckoo.rs
+++ b/boreal/src/module/cuckoo.rs
@@ -26,7 +26,7 @@ use super::{EvalContext, Module, ModuleData, StaticValue, Type, Value};
 /// scanner.set_module_data::<Cuckoo>(cuckoo_data);
 ///
 /// let result = scanner.scan_mem(b"").unwrap();
-/// assert_eq!(result.matched_rules.len(), 1);
+/// assert_eq!(result.rules.len(), 1);
 /// ```
 #[derive(Debug)]
 pub struct Cuckoo;

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -383,7 +383,7 @@ impl std::fmt::Debug for ModuleDataMap<'_> {
 /// scanner.set_module_data::<Bar>(BarUserData { value: 3 });
 ///
 /// let result = scanner.scan_mem(b"").unwrap();
-/// assert_eq!(result.matched_rules.len(), 1);
+/// assert_eq!(result.rules.len(), 1);
 /// ```
 pub trait ModuleData: Module {
     /// Private Data to associate with the module.

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -483,16 +483,22 @@ pub struct CallbackEvents(pub(crate) u32);
 
 impl CallbackEvents {
     /// Enables the [`crate::scanner::ScanEvent::RuleMatch`] events.
-    pub const RULE_MATCH: CallbackEvents = CallbackEvents(0b0001);
+    pub const RULE_MATCH: CallbackEvents = CallbackEvents(0b0000_0001);
+
+    /// Enables the [`crate::scanner::ScanEvent::RuleNoMatch`] events.
+    ///
+    /// The [`ScanParams::include_not_matched_rules`] parameter must also be set to true
+    /// to received those events.
+    pub const RULE_NO_MATCH: CallbackEvents = CallbackEvents(0b0000_0010);
 
     /// Enables the [`crate::scanner::ScanEvent::ModuleImport`] events.
-    pub const MODULE_IMPORT: CallbackEvents = CallbackEvents(0b0010);
+    pub const MODULE_IMPORT: CallbackEvents = CallbackEvents(0b0000_0100);
 
     /// Enables the [`crate::scanner::ScanEvent::ScanStatistics`] events.
     ///
     /// The [`ScanParams::compute_statistics`] parameter must be set to true, and
     /// the `profiling` feature must have been enabled during compilation.
-    pub const SCAN_STATISTICS: CallbackEvents = CallbackEvents(0b0100);
+    pub const SCAN_STATISTICS: CallbackEvents = CallbackEvents(0b0000_1000);
 }
 
 impl std::ops::BitOr for CallbackEvents {
@@ -583,14 +589,14 @@ mod tests {
         let a = CallbackEvents::RULE_MATCH;
         let b = CallbackEvents::MODULE_IMPORT;
 
-        assert_eq!(a | b, CallbackEvents(0b11));
-        assert_eq!(a & b, CallbackEvents(0b00));
+        assert_eq!(a | b, CallbackEvents(0b101));
+        assert_eq!(a & b, CallbackEvents(0b000));
 
         let mut c = a;
         c |= b;
-        assert_eq!(c, CallbackEvents(0b11));
+        assert_eq!(c, CallbackEvents(0b101));
         assert_eq!(c & a, CallbackEvents(0b01));
         c &= b;
-        assert_eq!(c, CallbackEvents(0b10));
+        assert_eq!(c, CallbackEvents(0b100));
     }
 }

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -27,12 +27,12 @@ rule bar {
     let file = tempfile::NamedTempFile::new().unwrap();
     file.as_file().write_all(b"zyxabcxy").unwrap();
     let result = scanner.scan_file(file.path()).unwrap();
-    assert_eq!(result.matched_rules.len(), 1);
+    assert_eq!(result.rules.len(), 1);
 
     file.as_file().rewind().unwrap();
     file.as_file().write_all(b"zyxacxby").unwrap();
     let result = scanner.scan_file(file.path()).unwrap();
-    assert_eq!(result.matched_rules.len(), 0);
+    assert_eq!(result.rules.len(), 0);
 }
 
 // An import is reused in the same namespace

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -256,7 +256,7 @@ impl Checker {
     #[track_caller]
     pub fn check_count(&mut self, mem: &[u8], count: usize) {
         let res = self.scan_mem(mem);
-        assert_eq!(res.matched_rules.len(), count, "test failed for boreal",);
+        assert_eq!(res.rules.len(), count, "test failed for boreal",);
 
         if let Some(rules) = &self.yara_rules {
             let len = rules.scan_mem(mem, 1).unwrap().len();
@@ -298,7 +298,7 @@ impl Checker {
 
         let scan_res = self.scan_mem(mem);
         let mut res: Vec<String> = scan_res
-            .matched_rules
+            .rules
             .iter()
             .map(|v| {
                 if let Some(ns) = &v.namespace {
@@ -355,7 +355,7 @@ impl Checker {
     #[track_caller]
     pub fn check_boreal(&mut self, mem: &[u8], expected_res: bool) {
         let res = self.scan_mem(mem);
-        let res = !res.matched_rules.is_empty();
+        let res = !res.rules.is_empty();
         assert_eq!(res, expected_res, "test failed for boreal");
     }
 
@@ -363,7 +363,7 @@ impl Checker {
     pub fn check_str_has_match(&mut self, mem: &[u8], expected_match: &[u8]) {
         let res = self.scan_mem(mem);
         let mut found = false;
-        for r in res.matched_rules {
+        for r in res.rules {
             for var in r.matches {
                 for mat in var.matches {
                     if mat.data == expected_match {
@@ -401,7 +401,7 @@ impl Checker {
             .scanner
             .scan_fragmented(FragmentedSlices::new(regions))
             .unwrap();
-        let res = !res.matched_rules.is_empty();
+        let res = !res.rules.is_empty();
         assert_eq!(res, expected_res, "test failed for boreal");
 
         if let Some(rules) = &self.yara_rules {
@@ -472,7 +472,7 @@ impl Checker {
                 v
             }
         };
-        let res = !res.matched_rules.is_empty();
+        let res = !res.rules.is_empty();
         assert_eq!(res, expected_res, "test failed for boreal");
 
         if let Some(rules) = &self.yara_rules {
@@ -635,7 +635,7 @@ impl Scanner<'_> {
     #[track_caller]
     pub fn check_boreal(&self, mem: &[u8], expected_res: bool) {
         let res = self.scanner.scan_mem(mem).unwrap();
-        let res = !res.matched_rules.is_empty();
+        let res = !res.rules.is_empty();
         assert_eq!(res, expected_res, "test failed for boreal");
     }
 
@@ -700,7 +700,7 @@ pub fn check_warnings(rule: &str, expected_warnings: &[&str]) {
 pub type FullMatches<'a> = Vec<(String, Vec<(&'a str, Vec<(&'a [u8], usize, usize)>)>)>;
 
 pub fn get_boreal_full_matches<'a>(res: &'a ScanResult<'a>) -> FullMatches<'a> {
-    res.matched_rules
+    res.rules
         .iter()
         .map(|v| {
             let rule_name = if let Some(ns) = &v.namespace {


### PR DESCRIPTION
- Add a scan param to add non matched rules in results
- Rename MatchedRule to EvaluatedRule for clarity since it can now be a non matched rule
- Add a matched bool in this object
- Add a callback scan event for non matched rules and the relevant callback event bitflag
- Fix boreal-py which_callbacks parameter to allow non matched rules as well

I still quite fail to see the purpose of this feature... it's added to provide feature parity with YARA, especially in boreal-py.