### PR TITLE
Add some more CLI options in boreal-cli

### DIFF
--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1329,6 +1329,33 @@ fn test_scan_list() {
     }
 }
 
+#[test]
+fn test_negate() {
+    let rule_file = test_file(
+        br#"
+rule a { condition: true }
+rule b { condition: false }
+rule c { condition: true }
+rule d { condition: false }
+"#,
+    );
+
+    let input = test_file(b"");
+    // Not matching
+    cmd()
+        .arg("-n")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!(
+            "b {}\nd {}\n",
+            input.path().display(),
+            input.path().display()
+        ))
+        .stderr("")
+        .success();
+}
+
 // Copied in `boreal/tests/it/utils.rs`. Not trivial to share, and won't be
 // modified too frequently.
 struct BinHelper {

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -499,6 +499,12 @@ impl CallbackEvents {
     /// The [`ScanParams::compute_statistics`] parameter must be set to true, and
     /// the `profiling` feature must have been enabled during compilation.
     pub const SCAN_STATISTICS: CallbackEvents = CallbackEvents(0b0000_1000);
+
+    /// Return an empty bitflag
+    #[must_use]
+    pub fn empty() -> Self {
+        Self(0)
+    }
 }
 
 impl std::ops::BitOr for CallbackEvents {


### PR DESCRIPTION
Add some options that exists in yara cli but not in boreal:

- `-n/--negate` to print non matching rules. This is now possible thanks to the `include_non_matching_rules` parameter in boreal.
- `-c/--count` to print the number of rules.
- `-l/--max-rules` to limit the number of matching rules, also possible now that the callback API is available.