### PR TITLE
Add xor details in string matches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,9 +1392,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "yara"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd05a7a0913206818192765226ccc89557941c4700c6666047d415ea4db22dc2"
+checksum = "2860d5b9e61e482a7bb3481ae4375e9c551dc07afaf15c2172dd81009f01686c"
 dependencies = [
  "bitflags",
  "thiserror",

--- a/boreal-py/src/string_match_instance.rs
+++ b/boreal-py/src/string_match_instance.rs
@@ -13,7 +13,7 @@ pub struct StringMatchInstance {
     offset: usize,
 
     /// Matched data, might have been truncated if too long.
-    matched_data: Vec<u8>,
+    matched_data: Box<[u8]>,
 
     /// Length of the entire match.
     #[pyo3(get)]

--- a/boreal-py/src/string_match_instance.rs
+++ b/boreal-py/src/string_match_instance.rs
@@ -18,7 +18,10 @@ pub struct StringMatchInstance {
     /// Length of the entire match.
     #[pyo3(get)]
     matched_length: usize,
-    // TODO: missing xor_key
+
+    /// Xor key used in the match.
+    #[pyo3(get)]
+    xor_key: u8,
 }
 
 impl StringMatchInstance {
@@ -27,6 +30,7 @@ impl StringMatchInstance {
             offset: s.offset,
             matched_data: s.data,
             matched_length: s.length,
+            xor_key: s.xor_key,
         }
     }
 }
@@ -36,6 +40,10 @@ impl StringMatchInstance {
     #[getter]
     fn matched_data(&self) -> &[u8] {
         &self.matched_data
+    }
+
+    fn plaintext(&self) -> Vec<u8> {
+        self.matched_data.iter().map(|b| b ^ self.xor_key).collect()
     }
 
     fn __repr__(&self) -> String {

--- a/boreal-py/src/string_matches.rs
+++ b/boreal-py/src/string_matches.rs
@@ -17,6 +17,8 @@ pub struct StringMatches {
     /// List of matches for the string.
     #[pyo3(get)]
     instances: Vec<StringMatchInstance>,
+
+    has_xor_modifier: bool,
 }
 
 impl StringMatches {
@@ -29,12 +31,18 @@ impl StringMatches {
                 .into_iter()
                 .map(StringMatchInstance::new)
                 .collect(),
+            has_xor_modifier: s.has_xor_modifier,
         }
     }
 }
 
 #[pymethods]
 impl StringMatches {
+    /// Does the string have the xor modifier.
+    fn is_xor(&self) -> bool {
+        self.has_xor_modifier
+    }
+
     // TODO: missing is_xor
 
     fn __repr__(&self) -> &str {

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -208,10 +208,13 @@ rule my_rule {
     assert len(m.strings) == 2
     s0 = m.strings[0]
     s1 = m.strings[1]
+    assert s0.is_xor()
+    assert not s1.is_xor()
 
     assert len(s0.instances) == 2
     i0 = s0.instances[0]
     i1 = s0.instances[1]
+
     assert i0.xor_key == 0x02
     assert i0.matched_data == b"ccc"
     assert i0.plaintext() == b"aaa"

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -115,7 +115,7 @@ windows-sys = { version = "0.59", optional = true, features = [
 base64 = "0.22"
 glob = "0.3.1"
 tempfile = "3.12"
-yara = { version = "0.29", features = ["vendored"] }
+yara = { version = "0.30", features = ["vendored"] }
 
 [package.metadata.docs.rs]
 features = ["authenticode", "memmap", "magic", "cuckoo"]

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -69,6 +69,7 @@ pub(super) fn compile_variable(
                     ascii: modifiers.ascii,
                     nocase: modifiers.nocase,
                     dot_all,
+                    xor_start: None,
                 },
             )
             .map_err(VariableCompilationError::Regex)
@@ -81,6 +82,7 @@ pub(super) fn compile_variable(
                 ascii: modifiers.ascii,
                 nocase: modifiers.nocase,
                 dot_all: true,
+                xor_start: None,
             },
         )
         .map_err(VariableCompilationError::Regex),

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -120,7 +120,7 @@ pub struct StringMatch {
     /// The matched data.
     ///
     /// The length of this field is capped.
-    pub data: Vec<u8>,
+    pub data: Box<[u8]>,
 }
 
 impl StringMatch {
@@ -158,7 +158,7 @@ mod tests {
             base: 0,
             offset: 0,
             length: 0,
-            data: Vec::new(),
+            data: Box::new([]),
         });
     }
 }

--- a/boreal/src/evaluator/variable.rs
+++ b/boreal/src/evaluator/variable.rs
@@ -121,6 +121,12 @@ pub struct StringMatch {
     ///
     /// The length of this field is capped.
     pub data: Box<[u8]>,
+
+    /// The value of the xoring key that was used for the match.
+    ///
+    /// If the string had a xor modifier, this value indicates which value of the xory key
+    /// generated the match.
+    pub xor_key: u8,
 }
 
 impl StringMatch {
@@ -128,6 +134,7 @@ impl StringMatch {
         region: &Region,
         mat: std::ops::Range<usize>,
         match_max_length: usize,
+        xor_key: u8,
     ) -> Self {
         let length = mat.end - mat.start;
         let capped_length = std::cmp::min(length, match_max_length);
@@ -141,6 +148,7 @@ impl StringMatch {
                 .collect(),
             offset: mat.start,
             length,
+            xor_key,
         }
     }
 }
@@ -159,6 +167,7 @@ mod tests {
             offset: 0,
             length: 0,
             data: Box::new([]),
+            xor_key: 0,
         });
     }
 }

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -30,7 +30,7 @@ pub(crate) struct Matcher {
     kind: MatcherKind,
 
     /// Modifiers related to matching.
-    modifiers: Modifiers,
+    pub(crate) modifiers: Modifiers,
 }
 
 #[derive(Copy, Clone, Default, Debug)]

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1284,6 +1284,7 @@ fn build_matched_rule<'a>(
             .map(|(matches, var)| StringMatches {
                 name: &var.name,
                 matches,
+                has_xor_modifier: var.matcher.modifiers.xor_start.is_some(),
             })
             .collect(),
         matched,
@@ -1350,6 +1351,9 @@ pub struct StringMatches<'scanner> {
     /// for this variable, some potential matches will not
     /// be reported.
     pub matches: Vec<StringMatch>,
+
+    /// Does the string have a xor modifier.
+    pub has_xor_modifier: bool,
 }
 
 /// Error when defining a symbol's value in a [`Scanner`].
@@ -2020,6 +2024,7 @@ mod tests {
         test_type_traits_non_clonable(StringMatches {
             name: "a",
             matches: Vec::new(),
+            has_xor_modifier: false,
         });
         test_type_traits_non_clonable(DefineSymbolError::UnknownName);
         test_type_traits_non_clonable(ScanData {

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -366,7 +366,7 @@ impl Checker {
         for r in res.rules {
             for var in r.matches {
                 for mat in var.matches {
-                    if mat.data == expected_match {
+                    if &*mat.data == expected_match {
                         found = true;
                     }
                 }


### PR DESCRIPTION
Add details about the xor matching for strings:

- Add a xor_key value in StringMatch object
- Add the -X option in boreal-cli to print the xor key and the plaintext
- Add the missing details in boreal-py related to the xor key

The StringMatch object is also modified from a `Vec<u8>` to a `Box<[u8]>`: there is no need to keep the capability, and we can save one word (which is now used by the xor_key...).