### PR TITLE
Add callback event when string reaches the match limit

### DIFF
--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -17,6 +17,7 @@ use ::boreal::compiler;
 mod module;
 mod rule;
 mod rule_match;
+mod rule_string;
 mod scanner;
 mod string_match_instance;
 mod string_matches;
@@ -33,6 +34,9 @@ const CALLBACK_MATCHES: u32 = 0x01;
 const CALLBACK_NON_MATCHES: u32 = 0x02;
 const CALLBACK_ALL: u32 = CALLBACK_MATCHES | CALLBACK_NON_MATCHES;
 
+// Same value as declared in yara, for compatibility.
+const CALLBACK_TOO_MANY_MATCHES: u32 = 6;
+
 #[pymodule]
 fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     let py = m.py();
@@ -48,6 +52,7 @@ fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("CALLBACK_MATCHES", CALLBACK_MATCHES)?;
     m.add("CALLBACK_NON_MATCHES", CALLBACK_NON_MATCHES)?;
     m.add("CALLBACK_ALL", CALLBACK_ALL)?;
+    m.add("CALLBACK_TOO_MANY_MATCHES", CALLBACK_TOO_MANY_MATCHES)?;
 
     m.add("AddRuleError", py.get_type::<AddRuleError>())?;
     m.add("ScanError", py.get_type::<scanner::ScanError>())?;

--- a/boreal-py/src/rule_string.rs
+++ b/boreal-py/src/rule_string.rs
@@ -1,0 +1,30 @@
+use pyo3::{prelude::*, types::PyString};
+
+use ::boreal::scanner::StringIdentifier;
+
+/// Identifier for a string
+// FIXME: this is a namedtuple in yara
+#[pyclass(frozen, module = "boreal")]
+pub struct RuleString {
+    /// Namespace of the rule containing the string.
+    #[pyo3(get)]
+    namespace: Py<PyString>,
+
+    /// Name of the rle containing the string.
+    #[pyo3(get)]
+    rule: Py<PyString>,
+
+    /// Name of the string.
+    #[pyo3(get)]
+    string: Py<PyString>,
+}
+
+impl RuleString {
+    pub fn new(py: Python, id: &StringIdentifier) -> Self {
+        Self {
+            namespace: PyString::new(py, id.rule_namespace.unwrap_or("default")).unbind(),
+            rule: PyString::new(py, id.rule_name).unbind(),
+            string: PyString::new(py, &format!("${}", id.string_name)).unbind(),
+        }
+    }
+}

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -94,7 +94,7 @@ pub(super) fn evaluate_expr(
             };
 
             let mut eval_ctx = EvalContext {
-                mem: &mut evaluator.scan_data.mem,
+                mem: evaluator.mem,
                 module_data: &evaluator.scan_data.module_values.data_map,
                 process_memory: evaluator.scan_data.params.process_memory,
             };
@@ -110,7 +110,7 @@ pub(super) fn evaluate_expr(
                 .map(expr_value_to_module_value)
                 .collect();
             let mut eval_ctx = EvalContext {
-                mem: &mut evaluator.scan_data.mem,
+                mem: evaluator.mem,
                 module_data: &evaluator.scan_data.module_values.data_map,
                 process_memory: evaluator.scan_data.params.process_memory,
             };

--- a/boreal/src/evaluator/read_integer.rs
+++ b/boreal/src/evaluator/read_integer.rs
@@ -26,7 +26,7 @@ pub(super) fn evaluate_read_integer(
 
     let mem = addr
         .checked_add(length)
-        .and_then(|end| evaluator.scan_data.mem.get_contiguous(addr, end))
+        .and_then(|end| evaluator.mem.get_contiguous(addr, end))
         .ok_or(PoisonKind::Undefined)?;
 
     match ty {

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder, AhoCorasickKind};
 
-use super::{ScanError, ScanParams, StringMatch};
+use super::{ScanData, ScanError, StringMatch};
 use crate::atoms::pick_atom_in_literal;
 use crate::compiler::variable::Variable;
 use crate::compiler::CompilerProfile;
@@ -47,36 +47,6 @@ struct LiteralInfo {
 
     /// Left and right offset for the slice picked in the Aho-Corasick.
     slice_offset: (usize, usize),
-}
-
-/// Context related to a scan.
-///
-/// Mostly used simply to factorize variables used during the AC scan.
-#[derive(Debug)]
-pub struct ScanData<'a> {
-    /// Object used to check if the scan times out.
-    pub timeout_checker: Option<&'a mut crate::timeout::TimeoutChecker>,
-
-    #[cfg(feature = "profiling")]
-    /// Statistics related to the scan.
-    pub statistics: Option<&'a mut crate::statistics::Evaluation>,
-
-    /// List of variables to scan.
-    ///
-    /// This is the same variables, in the same order, as when building the
-    /// [`AcScan`] object.
-    pub variables: &'a [Variable],
-
-    /// Max number of matches for a given string.
-    pub params: &'a ScanParams,
-}
-
-impl ScanData<'_> {
-    fn check_timeout(&mut self) -> bool {
-        self.timeout_checker
-            .as_mut()
-            .is_some_and(|checker| checker.check_timeout())
-    }
 }
 
 impl AcScan {
@@ -149,6 +119,7 @@ impl AcScan {
     pub(super) fn scan_region(
         &self,
         region: &Region,
+        variables: &[Variable],
         scan_data: &mut ScanData,
         matches: &mut [Vec<StringMatch>],
     ) -> Result<(), ScanError> {
@@ -163,7 +134,7 @@ impl AcScan {
             if scan_data.check_timeout() {
                 return Err(ScanError::Timeout);
             }
-            self.handle_possible_match(region, &mat, scan_data, matches);
+            self.handle_possible_match(region, variables, &mat, scan_data, matches);
         }
 
         if !self.non_handled_var_indexes.is_empty() {
@@ -172,7 +143,7 @@ impl AcScan {
 
             // For every "raw" variable, scan the memory for this variable.
             for variable_index in &self.non_handled_var_indexes {
-                let var = &scan_data.variables[*variable_index].matcher;
+                let var = &variables[*variable_index].matcher;
 
                 scan_single_variable(region, var, scan_data, &mut matches[*variable_index]);
             }
@@ -189,6 +160,7 @@ impl AcScan {
     fn handle_possible_match(
         &self,
         region: &Region,
+        variables: &[Variable],
         mat: &aho_corasick::Match,
         scan_data: &mut ScanData,
         matches: &mut [Vec<StringMatch>],
@@ -199,7 +171,7 @@ impl AcScan {
                 literal_index,
                 slice_offset: (start_offset, end_offset),
             } = *literal_info;
-            let var = &scan_data.variables[variable_index].matcher;
+            let var = &variables[variable_index].matcher;
 
             #[cfg(feature = "profiling")]
             if let Some(stats) = scan_data.statistics.as_mut() {
@@ -324,13 +296,6 @@ mod tests {
             variable_index: 0,
             literal_index: 0,
             slice_offset: (0, 0),
-        });
-        test_type_traits_non_clonable(ScanData {
-            variables: &[],
-            #[cfg(feature = "profiling")]
-            statistics: None,
-            timeout_checker: None,
-            params: &ScanParams::default(),
         });
     }
 }

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -911,19 +911,13 @@ impl Inner {
         #[cfg(feature = "profiling")]
         let start = std::time::Instant::now();
 
-        let mut ac_scan_data = ac_scan::ScanData {
-            timeout_checker: scan_data.timeout_checker.as_mut(),
-            #[cfg(feature = "profiling")]
-            statistics: scan_data.statistics.as_mut(),
-            variables: &self.variables,
-            params: scan_data.params,
-        };
         match mem {
             Memory::Direct(mem) => {
                 // Scan the memory for all variables occurences.
                 self.ac_scan.scan_region(
                     &Region { start: 0, mem },
-                    &mut ac_scan_data,
+                    &self.variables,
+                    scan_data,
                     &mut matches,
                 )?;
             }
@@ -938,12 +932,12 @@ impl Inner {
                     };
 
                     #[cfg(feature = "profiling")]
-                    if let Some(stats) = ac_scan_data.statistics.as_mut() {
+                    if let Some(stats) = scan_data.statistics.as_mut() {
                         stats.fetch_memory_duration += start_fetch.elapsed();
                     }
 
                     self.ac_scan
-                        .scan_region(&region, &mut ac_scan_data, &mut matches)?;
+                        .scan_region(&region, &self.variables, scan_data, &mut matches)?;
 
                     // Also, compute the value for the entrypoint expression. Since
                     // we fetch each region here, this is much cheaper that refetching

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -500,6 +500,9 @@ impl CallbackEvents {
     /// the `profiling` feature must have been enabled during compilation.
     pub const SCAN_STATISTICS: CallbackEvents = CallbackEvents(0b0000_1000);
 
+    /// Enables the [`crate::scanner::ScanEvent::StringReachedMatchLimit`] events.
+    pub const STRING_REACHED_MATCH_LIMIT: CallbackEvents = CallbackEvents(0b0001_0000);
+
     /// Return an empty bitflag
     #[must_use]
     pub fn empty() -> Self {


### PR DESCRIPTION
Add a new callback for when a string reaches the match limit. This is handled both in boreal-cli and in boreal-py mirroring how it is handled in yara.

Handling in boreal required a little rework which ends up cleaning the scanner/ac_scan.rs module. Generating the right event when the limit is reached requires iterating over all the rules which isn't ideal, but should be fine in practice.