### PR TITLE
Add yara compatibility mode in boreal-py

### DIFF
--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -55,6 +55,10 @@ fn boreal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("CALLBACK_TOO_MANY_MATCHES", CALLBACK_TOO_MANY_MATCHES)?;
 
     m.add("AddRuleError", py.get_type::<AddRuleError>())?;
+    // Add an alias for SyntaxError: this provides compatibility
+    // with code using yara.
+    m.add("SyntaxError", py.get_type::<AddRuleError>())?;
+
     m.add("ScanError", py.get_type::<scanner::ScanError>())?;
     m.add("TimeoutError", py.get_type::<scanner::TimeoutError>())?;
 

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -68,7 +68,7 @@ impl Match {
     ) -> Result<Self, PyErr> {
         Ok(Self {
             rule: rule.name.to_string(),
-            namespace: rule.namespace.unwrap_or_default().to_string(),
+            namespace: rule.namespace.unwrap_or("default").to_string(),
             meta: rule
                 .metadatas
                 .iter()

--- a/boreal-py/tests/test_api.py
+++ b/boreal-py/tests/test_api.py
@@ -2,8 +2,8 @@ import pytest
 from .utils import MODULES
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_modules(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_modules(module):
     modules = module.modules
 
     assert type(modules) is list
@@ -12,15 +12,15 @@ def test_modules(module, is_yara):
     assert 'console' in modules
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_version(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_version(module):
     assert type(module.__version__) is str
 
 
 # Test is marked as to be run last because it modifies a global config
 # that impacts other tests.
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_run_last_set_config_max_strings_per_rule(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_run_last_set_config_max_strings_per_rule(module):
     module.set_config(max_strings_per_rule=2)
 
     with pytest.raises(module.SyntaxError):
@@ -38,8 +38,8 @@ def test_run_last_set_config_max_strings_per_rule(module, is_yara):
 
 # Test is marked as to be run last because it modifies a global config
 # that impacts other tests.
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_run_last_set_config_max_match_data(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_run_last_set_config_max_match_data(module):
     module.set_config(max_match_data=3)
 
     rules = module.compile(source="""
@@ -55,7 +55,7 @@ def test_run_last_set_config_max_match_data(module, is_yara):
     assert s.matched_data == b"123"
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_run_last_set_config_stack_size(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_run_last_set_config_stack_size(module):
     # Just check isetting stack_size doesn't fail
     module.set_config(stack_size=10_000)

--- a/boreal-py/tests/test_api.py
+++ b/boreal-py/tests/test_api.py
@@ -23,11 +23,7 @@ def test_version(module, is_yara):
 def test_run_last_set_config_max_strings_per_rule(module, is_yara):
     module.set_config(max_strings_per_rule=2)
 
-    if is_yara:
-        exctype = module.SyntaxError
-    else:
-        exctype = module.AddRuleError
-    with pytest.raises(exctype):
+    with pytest.raises(module.SyntaxError):
         module.compile(source="""
     rule a {
         strings:

--- a/boreal-py/tests/test_compile.py
+++ b/boreal-py/tests/test_compile.py
@@ -2,11 +2,11 @@ import boreal
 import pytest
 import tempfile
 import yara
-from .utils import MODULES
+from .utils import MODULES, MODULES_DISTINCT
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_filepath(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_filepath(module):
     # Do not use NamedTemporaryFile, yara seems to get permission denied
     # issues on those type of files.
     with tempfile.TemporaryDirectory() as fd:
@@ -27,8 +27,8 @@ def test_compile_filepath(module, is_yara):
         assert matches[0].rule == 'a'
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_source(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_source(module):
     # Source specifies the string directly
     rules = module.compile(source='rule a { condition: true }')
     matches = rules.match(data='')
@@ -36,8 +36,8 @@ def test_compile_source(module, is_yara):
     assert matches[0].rule == 'a'
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_file(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_file(module):
     with tempfile.TemporaryDirectory() as fd:
         path = f"{fd}/file"
         with open(path, "w") as f:
@@ -50,8 +50,8 @@ def test_compile_file(module, is_yara):
         assert matches[0].rule == 'a'
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_filepaths(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_filepaths(module):
     # filepaths allows specifying namespaces
     with tempfile.TemporaryDirectory() as fd:
         path1 = f"{fd}/file1"
@@ -73,8 +73,8 @@ def test_compile_filepaths(module, is_yara):
         assert matches[1].namespace == 'ns2'
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_sources(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_sources(module):
     # sources allows specifying namespaces
     rules = module.compile(sources={
         'ns1': 'rule a { condition: true }',
@@ -88,7 +88,7 @@ def test_compile_sources(module, is_yara):
     assert matches[1].namespace == 'ns2'
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
+@pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)
 def test_compile_externals(module, is_yara):
     externals = {
         'b': True,
@@ -117,8 +117,8 @@ rule a {
         assert len(matches) == 1
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_includes(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_includes(module):
     # By default, includes are allowed
     with tempfile.TemporaryDirectory() as fd:
         path = f"{fd}/file"
@@ -139,7 +139,7 @@ rule b {{ condition: true }}
             module.compile(source=source, includes=False)
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
+@pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)
 def test_compile_warnings(module, is_yara):
     # By default, warnings do not make the compilation fail
     source = """rule a { condition: "foo" }"""
@@ -161,8 +161,8 @@ def test_compile_warnings(module, is_yara):
         module.compile(source=source, error_on_warning=True)
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_warnings_contexts(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_warnings_contexts(module):
     # Test warnings are correctly handled in all the different contexts
     source1 = """rule a { condition: "foo" }"""
     source2 = """rule b { condition: "b" }"""
@@ -200,8 +200,8 @@ def test_compile_warnings_contexts(module, is_yara):
         assert "boolean" in rules.warnings[1]
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_errors_invalid_arguments(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_errors_invalid_arguments(module):
     # Cannot specify multiple sources
     with pytest.raises(TypeError):
         module.compile(source="", sources={})
@@ -223,7 +223,7 @@ def test_compile_errors_invalid_arguments(module, is_yara):
         module.compile()
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
+@pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)
 def test_compile_errors_invalid_types(module, is_yara):
     with pytest.raises(TypeError):
         module.compile(filepath=1)
@@ -257,8 +257,8 @@ def test_compile_errors_invalid_types(module, is_yara):
         module.compile(source=source, externals={ 'a': [1] })
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES)
-def test_compile_errors_compilation(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_compile_errors_compilation(module):
     with tempfile.TemporaryDirectory() as fd:
         path = f"{fd}/file"
         with open(path, "w") as f:

--- a/boreal-py/tests/test_compile.py
+++ b/boreal-py/tests/test_compile.py
@@ -241,7 +241,7 @@ def test_compile_errors_invalid_types(module, is_yara):
         module.compile(sources=1)
     with pytest.raises(TypeError):
         module.compile(filepaths=1)
-    # FIXME: yara segfaults on this on Windows
+    # segfaults in yaran on Windows: https://github.com/VirusTotal/yara-python/pull/269
     if not is_yara:
         with pytest.raises(AttributeError):
             module.compile(file='str')
@@ -257,9 +257,10 @@ def test_compile_errors_invalid_types(module, is_yara):
         module.compile(filepaths={ 'a': 1 })
 
     source = 'rule a { condition: true }'
-    # FIXME: difference here between boreal and yara
-    # with pytest.raises(TypeError):
-    #     module.compile(source=source, externals={ 1: 'a' })
+    # Broken in yara: https://github.com/VirusTotal/yara-python/pull/270
+    if not is_yara:
+        with pytest.raises(TypeError):
+            module.compile(source=source, externals={ 1: 'a' })
     with pytest.raises(TypeError):
         module.compile(source=source, externals={ 'a': [1] })
 

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -412,7 +412,7 @@ rule b { condition: false }
 
     r = matches[0]
     assert r.rule == "a"
-    assert r.namespace == ("default" if is_yara else "")
+    assert r.namespace == "default"
     assert r.tags == ["tag1", "tag2"]
     assert r.meta == {
         's': 'str' if is_yara else b'str',
@@ -423,7 +423,7 @@ rule b { condition: false }
     r = callback_rules[0]
     assert r['matches']
     assert r['rule'] == "a"
-    assert r['namespace'] == ("default" if is_yara else "")
+    assert r['namespace'] == "default"
     assert r['tags'] == ["tag1", "tag2"]
     assert r['meta'] == {
         's': 'str' if is_yara else b'str',

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -161,7 +161,7 @@ def test_match_invalid_types(module, is_yara):
     with pytest.raises(TypeError):
         rules.match()
 
-    # FIXME: this makes yara segfault...
+    # Broken in yara: https://github.com/VirusTotal/yara-python/pull/270
     if not is_yara:
         with pytest.raises(TypeError):
             rules.match(data='', externals={ 1: 'a' })
@@ -220,12 +220,7 @@ rule a {
         )
 }""")
 
-    if is_yara:
-        exctype = yara.TimeoutError
-    else:
-        exctype = boreal.TimeoutError
-
-    with pytest.raises(exctype):
+    with pytest.raises(module.TimeoutError):
         # Unfortunately, we cannot go below 1 second as this is the smallest timeout value
         # in the yara api
         rules.match(data='', timeout=1)
@@ -500,7 +495,7 @@ rule a { condition: true }
     def modules_callback(v):
         nonlocal received_values
         received_values.append(v)
-        return boreal.CALLBACK_CONTINUE
+        return module.CALLBACK_CONTINUE
 
     rules.match('../boreal/tests/assets/libyara/data/mtxex.dll', modules_callback=modules_callback)
 
@@ -544,7 +539,7 @@ rule a { condition: true }
     def modules_callback(v):
         nonlocal received_values
         received_values.append(v)
-        return boreal.CALLBACK_ABORT
+        return module.CALLBACK_ABORT
 
     rules.match(data='', modules_callback=modules_callback)
 

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -1,8 +1,8 @@
 import pytest
-from .utils import MODULES
+from .utils import MODULES, MODULES_DISTINCT
 
 
-@pytest.mark.parametrize("module,is_yara", MODULES)
+@pytest.mark.parametrize("module,is_yara", MODULES_DISTINCT)
 def test_match(module, is_yara):
     """Test all properties related to the Match object"""
 
@@ -110,8 +110,8 @@ rule r3 { condition: true }
     assert not (r2_m0 > m0)
 
 
-@pytest.mark.parametrize("module,is_yara", MODULES)
-def test_string_matches(module, is_yara):
+@pytest.mark.parametrize("module", MODULES)
+def test_string_matches(module):
     """Test all properties related to the StringMatches object"""
     rule = module.compile(source="""
 rule foo {
@@ -147,7 +147,7 @@ rule foo {
     assert hash(s0) == hash(s1)
 
 
-@pytest.mark.parametrize("module,is_yara", MODULES)
+@pytest.mark.parametrize("module,is_yara", MODULES_DISTINCT)
 def test_string_match(module, is_yara):
     """Test all properties related to the StringMatch object"""
     rule = module.compile(source="""
@@ -191,8 +191,8 @@ rule foo {
     assert hash(i0) == hash(i3)
 
 
-@pytest.mark.parametrize("module,is_yara", MODULES)
-def test_string_match_instance_xor_key(module, is_yara):
+@pytest.mark.parametrize("module", MODULES)
+def test_string_match_instance_xor_key(module):
     rule = module.compile(source="""
 rule my_rule {
     strings:

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -10,8 +10,7 @@ def test_match(module, is_yara):
     rule = module.compile(source="rule a { condition: true }")
     matches = rule.match(data='')
     assert len(matches) == 1
-    # FIXME
-    assert matches[0].namespace == ('default' if is_yara else '')
+    assert matches[0].namespace == 'default'
 
     # Check with multiple namespaces
     source = """

--- a/boreal-py/tests/utils.py
+++ b/boreal-py/tests/utils.py
@@ -1,9 +1,16 @@
 import boreal
 import yara
 
-
 MODULES = [boreal, yara]
 MODULES_DISTINCT = [
     (boreal, False),
     (yara, True),
 ]
+
+
+class YaraCompatibilityMode:
+    def __enter__(self):
+        boreal.set_config(yara_compatibility=True)
+
+    def __exit__(self, *args):
+        boreal.set_config(yara_compatibility=False)

--- a/boreal-py/tests/utils.py
+++ b/boreal-py/tests/utils.py
@@ -2,7 +2,8 @@ import boreal
 import yara
 
 
-MODULES = [
+MODULES = [boreal, yara]
+MODULES_DISTINCT = [
     (boreal, False),
     (yara, True),
 ]


### PR DESCRIPTION
- Clean up some comments and tests
- Add a yara compatibility mode to ensure full compat while providing better defaults if disabled
- Handle fast mode in match method