### PR TITLE
Add serialization implementation on Scanner object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,11 +312,11 @@ jobs:
           cargo build -p boreal-test-helpers
 
           # Run the normal tests
-          cargo test --features magic,authenticode-verify,cuckoo
+          cargo test --features magic,authenticode-verify,cuckoo,serialize
 
           # And run the super user tests
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="sudo -E" cargo \
-            test --features magic,authenticode-verify,cuckoo -- --ignored
+            test --features magic,authenticode-verify,cuckoo,serialize -- --ignored
 
           # And run the python bindings tests
           cd boreal-py
@@ -380,7 +380,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kind: [none, hash, object, process, hash_object, authenticode, authenticode_verify, all]
+        kind: [none, hash, object, process, hash_object, authenticode, authenticode_verify, serialize, all]
         include:
           - kind: none
             features: "--no-default-features"
@@ -402,6 +402,9 @@ jobs:
             boreal_cli: false
           - kind: authenticode_verify
             features: "--no-default-features --features=hash,object,authenticode,authenticode-verify"
+            boreal_cli: false
+          - kind: serialize
+            features: "--no-default-features --features=serialize"
             boreal_cli: false
           - kind: all
             features: "--all-features"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "aho-corasick",
  "base64",
  "boreal-parser",
+ "borsh",
  "codespan-reporting",
  "const-oid",
  "crc32fast",
@@ -210,6 +211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5430e3be710b68d984d1391c854eb431a9d548640711faa54eecb1df93db91cc"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bstr"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +259,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clang-sys"

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -47,7 +47,14 @@ process = ["dep:libc", "dep:windows-sys", "dep:mach2"]
 # Enables computation of statistics during scanning.
 profiling = []
 
-# Enables serialization and deserialization of rules
+# Enables serialization and deserialization of the scanner object.
+#
+# See `Scanner::to_bytes` and `Scanner::from_bytes_unchecked`.
+# Note that in order for a scanner to be serialized, it requires storing data
+# that is not required otherwise. This means that enabling this feature will
+# make the Scanner object that a bit more memory than if the feature is disabled.
+# This is marginal, but it is thus recommended to avoid enabling this feature
+# if not needed.
 serialize = ["dep:borsh"]
 
 [dependencies]

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.74"
 exclude = ["/tests"]
 
 [features]
-default = ["hash", "object", "memmap", "process", "authenticode", "serialize"]
+default = ["hash", "object", "memmap", "process", "authenticode"]
 
 # Enables the "hash" module.
 hash = ["dep:md-5", "dep:sha1", "dep:sha2", "dep:crc32fast", "dep:tlsh2"]

--- a/boreal/Cargo.toml
+++ b/boreal/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.74"
 exclude = ["/tests"]
 
 [features]
-default = ["hash", "object", "memmap", "process", "authenticode"]
+default = ["hash", "object", "memmap", "process", "authenticode", "serialize"]
 
 # Enables the "hash" module.
 hash = ["dep:md-5", "dep:sha1", "dep:sha2", "dep:crc32fast", "dep:tlsh2"]
@@ -46,6 +46,9 @@ process = ["dep:libc", "dep:windows-sys", "dep:mach2"]
 
 # Enables computation of statistics during scanning.
 profiling = []
+
+# Enables serialization and deserialization of rules
+serialize = ["dep:borsh"]
 
 [dependencies]
 boreal-parser = { path = "../boreal-parser", version = "0.6.0" }
@@ -90,6 +93,9 @@ magic = { version = "0.16", optional = true }
 
 # "cuckoo" feature
 serde_json = { version = "1.0", optional = true }
+
+# "serialize" feature
+borsh = { version = "1.5.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { version = "0.2", optional = true }

--- a/boreal/src/bytes_pool.rs
+++ b/boreal/src/bytes_pool.rs
@@ -138,6 +138,61 @@ impl BytesPoolBuilder {
     }
 }
 
+#[cfg(feature = "serialize")]
+mod wire {
+    use std::io;
+
+    use borsh::{BorshDeserialize as BD, BorshSerialize};
+
+    use super::{BytesPool, BytesSymbol, StringSymbol};
+
+    impl BorshSerialize for BytesPool {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.buffer.serialize(writer)
+        }
+    }
+
+    impl BD for BytesPool {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            Ok(Self {
+                buffer: BD::deserialize_reader(reader)?,
+            })
+        }
+    }
+
+    impl BorshSerialize for StringSymbol {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.from.serialize(writer)?;
+            self.to.serialize(writer)?;
+            Ok(())
+        }
+    }
+
+    impl BD for StringSymbol {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let from = BD::deserialize_reader(reader)?;
+            let to = BD::deserialize_reader(reader)?;
+            Ok(Self { from, to })
+        }
+    }
+
+    impl BorshSerialize for BytesSymbol {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.from.serialize(writer)?;
+            self.to.serialize(writer)?;
+            Ok(())
+        }
+    }
+
+    impl BD for BytesSymbol {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let from = BD::deserialize_reader(reader)?;
+            let to = BD::deserialize_reader(reader)?;
+            Ok(Self { from, to })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test_helpers::{test_type_traits, test_type_traits_non_clonable};

--- a/boreal/src/bytes_pool.rs
+++ b/boreal/src/bytes_pool.rs
@@ -142,25 +142,25 @@ impl BytesPoolBuilder {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::{BytesPool, BytesSymbol, StringSymbol};
 
-    impl BorshSerialize for BytesPool {
+    impl Serialize for BytesPool {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.buffer.serialize(writer)
         }
     }
 
-    impl BD for BytesPool {
+    impl DS for BytesPool {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
             Ok(Self {
-                buffer: BD::deserialize_reader(reader)?,
+                buffer: DS::deserialize_reader(reader)?,
             })
         }
     }
 
-    impl BorshSerialize for StringSymbol {
+    impl Serialize for StringSymbol {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.from.serialize(writer)?;
             self.to.serialize(writer)?;
@@ -168,15 +168,15 @@ mod wire {
         }
     }
 
-    impl BD for StringSymbol {
+    impl DS for StringSymbol {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let from = BD::deserialize_reader(reader)?;
-            let to = BD::deserialize_reader(reader)?;
+            let from = DS::deserialize_reader(reader)?;
+            let to = DS::deserialize_reader(reader)?;
             Ok(Self { from, to })
         }
     }
 
-    impl BorshSerialize for BytesSymbol {
+    impl Serialize for BytesSymbol {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.from.serialize(writer)?;
             self.to.serialize(writer)?;
@@ -184,10 +184,10 @@ mod wire {
         }
     }
 
-    impl BD for BytesSymbol {
+    impl DS for BytesSymbol {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let from = BD::deserialize_reader(reader)?;
-            let to = BD::deserialize_reader(reader)?;
+            let from = DS::deserialize_reader(reader)?;
+            let to = DS::deserialize_reader(reader)?;
             Ok(Self { from, to })
         }
     }

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -1343,14 +1343,14 @@ mod wire {
     use std::io;
 
     use boreal_parser::expression::ReadIntegerType;
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use crate::wire::DeserializeContext;
 
     use super::module::ModuleExpression;
     use super::{Expression, ForIterator, ForSelection, RuleSet, VariableIndex, VariableSet};
 
-    impl BorshSerialize for Expression {
+    impl Serialize for Expression {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Filesize => {
@@ -1630,7 +1630,7 @@ mod wire {
         ctx: &DeserializeContext,
         reader: &mut R,
     ) -> io::Result<Vec<Expression>> {
-        let len: usize = BD::deserialize_reader(reader)?;
+        let len: usize = DS::deserialize_reader(reader)?;
         let mut exprs = Vec::with_capacity(len);
         for _ in 0..len {
             exprs.push(deserialize_expr(ctx, reader)?);
@@ -1642,12 +1642,12 @@ mod wire {
         ctx: &DeserializeContext,
         reader: &mut R,
     ) -> io::Result<Expression> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         Ok(match discriminant {
             0 => Expression::Filesize,
             1 => Expression::Entrypoint,
             2 => {
-                let discriminant: u8 = BD::deserialize_reader(reader)?;
+                let discriminant: u8 = DS::deserialize_reader(reader)?;
                 let ty = match discriminant {
                     0 => ReadIntegerType::Int8,
                     1 => ReadIntegerType::Uint8,
@@ -1674,11 +1674,11 @@ mod wire {
                     addr: Box::new(addr),
                 }
             }
-            3 => Expression::Integer(BD::deserialize_reader(reader)?),
-            4 => Expression::Double(BD::deserialize_reader(reader)?),
-            5 => Expression::Count(BD::deserialize_reader(reader)?),
+            3 => Expression::Integer(DS::deserialize_reader(reader)?),
+            4 => Expression::Double(DS::deserialize_reader(reader)?),
+            5 => Expression::Count(DS::deserialize_reader(reader)?),
             6 => {
-                let variable_index = BD::deserialize_reader(reader)?;
+                let variable_index = DS::deserialize_reader(reader)?;
                 let from = Box::new(deserialize_expr(ctx, reader)?);
                 let to = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::CountInRange {
@@ -1688,7 +1688,7 @@ mod wire {
                 }
             }
             7 => {
-                let variable_index = BD::deserialize_reader(reader)?;
+                let variable_index = DS::deserialize_reader(reader)?;
                 let occurence_number = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::Offset {
                     variable_index,
@@ -1696,7 +1696,7 @@ mod wire {
                 }
             }
             8 => {
-                let variable_index = BD::deserialize_reader(reader)?;
+                let variable_index = DS::deserialize_reader(reader)?;
                 let occurence_number = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::Length {
                     variable_index,
@@ -1776,8 +1776,8 @@ mod wire {
             24 => {
                 let left = Box::new(deserialize_expr(ctx, reader)?);
                 let right = Box::new(deserialize_expr(ctx, reader)?);
-                let less_than = BD::deserialize_reader(reader)?;
-                let can_be_equal = BD::deserialize_reader(reader)?;
+                let less_than = DS::deserialize_reader(reader)?;
+                let can_be_equal = DS::deserialize_reader(reader)?;
                 Expression::Cmp {
                     left,
                     right,
@@ -1798,7 +1798,7 @@ mod wire {
             27 => {
                 let haystack = Box::new(deserialize_expr(ctx, reader)?);
                 let needle = Box::new(deserialize_expr(ctx, reader)?);
-                let case_insensitive = BD::deserialize_reader(reader)?;
+                let case_insensitive = DS::deserialize_reader(reader)?;
                 Expression::Contains {
                     haystack,
                     needle,
@@ -1808,7 +1808,7 @@ mod wire {
             28 => {
                 let expr = Box::new(deserialize_expr(ctx, reader)?);
                 let prefix = Box::new(deserialize_expr(ctx, reader)?);
-                let case_insensitive = BD::deserialize_reader(reader)?;
+                let case_insensitive = DS::deserialize_reader(reader)?;
                 Expression::StartsWith {
                     expr,
                     prefix,
@@ -1818,7 +1818,7 @@ mod wire {
             29 => {
                 let expr = Box::new(deserialize_expr(ctx, reader)?);
                 let suffix = Box::new(deserialize_expr(ctx, reader)?);
-                let case_insensitive = BD::deserialize_reader(reader)?;
+                let case_insensitive = DS::deserialize_reader(reader)?;
                 Expression::EndsWith {
                     expr,
                     suffix,
@@ -1832,14 +1832,14 @@ mod wire {
             }
             31 => {
                 let expr = Box::new(deserialize_expr(ctx, reader)?);
-                let regex = BD::deserialize_reader(reader)?;
+                let regex = DS::deserialize_reader(reader)?;
                 Expression::Matches(expr, regex)
             }
             32 => Expression::Defined(Box::new(deserialize_expr(ctx, reader)?)),
-            33 => Expression::Boolean(BD::deserialize_reader(reader)?),
-            34 => Expression::Variable(BD::deserialize_reader(reader)?),
+            33 => Expression::Boolean(DS::deserialize_reader(reader)?),
+            34 => Expression::Variable(DS::deserialize_reader(reader)?),
             35 => {
-                let variable_index = BD::deserialize_reader(reader)?;
+                let variable_index = DS::deserialize_reader(reader)?;
                 let offset = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::VariableAt {
                     variable_index,
@@ -1847,7 +1847,7 @@ mod wire {
                 }
             }
             36 => {
-                let variable_index = BD::deserialize_reader(reader)?;
+                let variable_index = DS::deserialize_reader(reader)?;
                 let from = Box::new(deserialize_expr(ctx, reader)?);
                 let to = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::VariableIn {
@@ -1858,7 +1858,7 @@ mod wire {
             }
             37 => {
                 let selection = deserialize_for_selection(ctx, reader)?;
-                let set = BD::deserialize_reader(reader)?;
+                let set = DS::deserialize_reader(reader)?;
                 let body = Box::new(deserialize_expr(ctx, reader)?);
                 Expression::For {
                     selection,
@@ -1878,14 +1878,14 @@ mod wire {
             }
             39 => {
                 let selection = deserialize_for_selection(ctx, reader)?;
-                let set = BD::deserialize_reader(reader)?;
+                let set = DS::deserialize_reader(reader)?;
                 Expression::ForRules { selection, set }
             }
             40 => Expression::Module(ModuleExpression::deserialize(ctx, reader)?),
-            41 => Expression::Rule(BD::deserialize_reader(reader)?),
-            42 => Expression::ExternalSymbol(BD::deserialize_reader(reader)?),
-            43 => Expression::Bytes(BD::deserialize_reader(reader)?),
-            44 => Expression::Regex(BD::deserialize_reader(reader)?),
+            41 => Expression::Rule(DS::deserialize_reader(reader)?),
+            42 => Expression::ExternalSymbol(DS::deserialize_reader(reader)?),
+            43 => Expression::Bytes(DS::deserialize_reader(reader)?),
+            44 => Expression::Regex(DS::deserialize_reader(reader)?),
             v => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -1895,7 +1895,7 @@ mod wire {
         })
     }
 
-    impl BorshSerialize for ForSelection {
+    impl Serialize for ForSelection {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Any => 0_u8.serialize(writer)?,
@@ -1915,14 +1915,14 @@ mod wire {
         ctx: &DeserializeContext,
         reader: &mut R,
     ) -> io::Result<ForSelection> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         match discriminant {
             0 => Ok(ForSelection::Any),
             1 => Ok(ForSelection::All),
             2 => Ok(ForSelection::None),
             3 => {
                 let expr = Box::new(deserialize_expr(ctx, reader)?);
-                let as_percent = BD::deserialize_reader(reader)?;
+                let as_percent = DS::deserialize_reader(reader)?;
                 Ok(ForSelection::Expr { expr, as_percent })
             }
             v => Err(io::Error::new(
@@ -1932,7 +1932,7 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for ForIterator {
+    impl Serialize for ForIterator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::ModuleIterator(module_expr) => {
@@ -1957,7 +1957,7 @@ mod wire {
         ctx: &DeserializeContext,
         reader: &mut R,
     ) -> io::Result<ForIterator> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         match discriminant {
             0 => {
                 let module_expr = ModuleExpression::deserialize(ctx, reader)?;
@@ -1979,7 +1979,7 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for RuleSet {
+    impl Serialize for RuleSet {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.elements.serialize(writer)?;
             self.already_matched.serialize(writer)?;
@@ -1987,10 +1987,10 @@ mod wire {
         }
     }
 
-    impl BD for RuleSet {
+    impl DS for RuleSet {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let elements = BD::deserialize_reader(reader)?;
-            let already_matched = BD::deserialize_reader(reader)?;
+            let elements = DS::deserialize_reader(reader)?;
+            let already_matched = DS::deserialize_reader(reader)?;
             Ok(Self {
                 elements,
                 already_matched,
@@ -1998,29 +1998,29 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for VariableSet {
+    impl Serialize for VariableSet {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.elements.serialize(writer)?;
             Ok(())
         }
     }
 
-    impl BD for VariableSet {
+    impl DS for VariableSet {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let elements = BD::deserialize_reader(reader)?;
+            let elements = DS::deserialize_reader(reader)?;
             Ok(Self { elements })
         }
     }
 
-    impl BorshSerialize for VariableIndex {
+    impl Serialize for VariableIndex {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.0.serialize(writer)
         }
     }
 
-    impl BD for VariableIndex {
+    impl DS for VariableIndex {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            Ok(Self(BD::deserialize_reader(reader)?))
+            Ok(Self(DS::deserialize_reader(reader)?))
         }
     }
 }

--- a/boreal/src/compiler/external_symbol.rs
+++ b/boreal/src/compiler/external_symbol.rs
@@ -89,11 +89,11 @@ impl_into_bytes!(&str);
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::ExternalValue;
 
-    impl BorshSerialize for ExternalValue {
+    impl Serialize for ExternalValue {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Integer(v) => {
@@ -117,14 +117,14 @@ mod wire {
         }
     }
 
-    impl BD for ExternalValue {
+    impl DS for ExternalValue {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let discriminant: u8 = BD::deserialize_reader(reader)?;
+            let discriminant: u8 = DS::deserialize_reader(reader)?;
             match discriminant {
-                0 => Ok(ExternalValue::Integer(BD::deserialize_reader(reader)?)),
-                1 => Ok(ExternalValue::Float(BD::deserialize_reader(reader)?)),
-                2 => Ok(ExternalValue::Bytes(BD::deserialize_reader(reader)?)),
-                3 => Ok(ExternalValue::Boolean(BD::deserialize_reader(reader)?)),
+                0 => Ok(ExternalValue::Integer(DS::deserialize_reader(reader)?)),
+                1 => Ok(ExternalValue::Float(DS::deserialize_reader(reader)?)),
+                2 => Ok(ExternalValue::Bytes(DS::deserialize_reader(reader)?)),
+                3 => Ok(ExternalValue::Boolean(DS::deserialize_reader(reader)?)),
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("invalid discriminant when deserializing an external value: {v}"),

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -144,7 +144,7 @@ pub enum IteratorType {
     Dictionary(ValueType),
 }
 
-pub(crate) fn compile_module<M: ModuleTrait>(module: &M) -> Module {
+pub(crate) fn compile_module(module: &dyn ModuleTrait) -> Module {
     Module {
         name: module.get_name(),
         static_values: module.get_static_values(),

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -339,14 +339,14 @@ pub(super) struct CompiledRule {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use crate::compiler::expression::Expression;
     use crate::wire::DeserializeContext;
 
     use super::{Metadata, MetadataValue, Rule};
 
-    impl BorshSerialize for Rule {
+    impl Serialize for Rule {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.name.serialize(writer)?;
             self.namespace_index.serialize(writer)?;
@@ -363,12 +363,12 @@ mod wire {
         ctx: &DeserializeContext,
         reader: &mut R,
     ) -> io::Result<Rule> {
-        let name = BD::deserialize_reader(reader)?;
-        let namespace_index = BD::deserialize_reader(reader)?;
-        let nb_variables = BD::deserialize_reader(reader)?;
-        let is_private = BD::deserialize_reader(reader)?;
-        let tags = BD::deserialize_reader(reader)?;
-        let metadatas = BD::deserialize_reader(reader)?;
+        let name = DS::deserialize_reader(reader)?;
+        let namespace_index = DS::deserialize_reader(reader)?;
+        let nb_variables = DS::deserialize_reader(reader)?;
+        let is_private = DS::deserialize_reader(reader)?;
+        let tags = DS::deserialize_reader(reader)?;
+        let metadatas = DS::deserialize_reader(reader)?;
         let condition = Expression::deserialize(ctx, reader)?;
         Ok(Rule {
             name,
@@ -381,7 +381,7 @@ mod wire {
         })
     }
 
-    impl BorshSerialize for Metadata {
+    impl Serialize for Metadata {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.name.serialize(writer)?;
             self.value.serialize(writer)?;
@@ -389,15 +389,15 @@ mod wire {
         }
     }
 
-    impl BD for Metadata {
+    impl DS for Metadata {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let name = BD::deserialize_reader(reader)?;
-            let value = BD::deserialize_reader(reader)?;
+            let name = DS::deserialize_reader(reader)?;
+            let value = DS::deserialize_reader(reader)?;
             Ok(Self { name, value })
         }
     }
 
-    impl BorshSerialize for MetadataValue {
+    impl Serialize for MetadataValue {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Bytes(s) => {
@@ -417,13 +417,13 @@ mod wire {
         }
     }
 
-    impl BD for MetadataValue {
+    impl DS for MetadataValue {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let discriminant: u8 = BD::deserialize_reader(reader)?;
+            let discriminant: u8 = DS::deserialize_reader(reader)?;
             match discriminant {
-                0 => Ok(Self::Bytes(BD::deserialize_reader(reader)?)),
-                1 => Ok(Self::Integer(BD::deserialize_reader(reader)?)),
-                2 => Ok(Self::Boolean(BD::deserialize_reader(reader)?)),
+                0 => Ok(Self::Bytes(DS::deserialize_reader(reader)?)),
+                1 => Ok(Self::Integer(DS::deserialize_reader(reader)?)),
+                2 => Ok(Self::Boolean(DS::deserialize_reader(reader)?)),
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("invalid discriminant when deserializing a metadata value: {v}"),

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -149,6 +149,37 @@ impl std::fmt::Display for VariableCompilationError {
     }
 }
 
+#[cfg(feature = "serialize")]
+mod wire {
+    use std::io;
+
+    use borsh::{BorshDeserialize as BD, BorshSerialize};
+
+    use super::Variable;
+
+    impl BorshSerialize for Variable {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.name.serialize(writer)?;
+            self.is_private.serialize(writer)?;
+            self.matcher.serialize(writer)?;
+            Ok(())
+        }
+    }
+
+    impl BD for Variable {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let name = BD::deserialize_reader(reader)?;
+            let is_private = BD::deserialize_reader(reader)?;
+            let matcher = BD::deserialize_reader(reader)?;
+            Ok(Self {
+                name,
+                is_private,
+                matcher,
+            })
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -153,11 +153,11 @@ impl std::fmt::Display for VariableCompilationError {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::Variable;
 
-    impl BorshSerialize for Variable {
+    impl Serialize for Variable {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.name.serialize(writer)?;
             self.is_private.serialize(writer)?;
@@ -166,11 +166,11 @@ mod wire {
         }
     }
 
-    impl BD for Variable {
+    impl DS for Variable {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let name = BD::deserialize_reader(reader)?;
-            let is_private = BD::deserialize_reader(reader)?;
-            let matcher = BD::deserialize_reader(reader)?;
+            let name = DS::deserialize_reader(reader)?;
+            let is_private = DS::deserialize_reader(reader)?;
+            let matcher = DS::deserialize_reader(reader)?;
             Ok(Self {
                 name,
                 is_private,

--- a/boreal/src/evaluator/module.rs
+++ b/boreal/src/evaluator/module.rs
@@ -100,7 +100,7 @@ pub(super) fn evaluate_expr(
             };
             evaluate_ops(&mut eval_ctx, value, ops, expressions)
         }
-        ModuleExpressionKind::StaticFunction { fun } => {
+        ModuleExpressionKind::StaticFunction { fun, .. } => {
             let Some(ValueOperation::FunctionCall(nb_arguments)) = ops.next() else {
                 return Err(PoisonKind::Undefined);
             };

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -72,6 +72,8 @@ pub mod scanner;
 pub use scanner::Scanner;
 pub mod statistics;
 mod timeout;
+#[cfg(feature = "serialize")]
+mod wire;
 
 #[cfg(test)]
 mod test_helpers;

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -448,7 +448,7 @@ fn string_to_wide(s: &[u8]) -> Vec<u8> {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use crate::matcher::Modifiers;
 
@@ -456,7 +456,7 @@ mod wire {
     use super::validator::Validator;
     use super::{Matcher, MatcherKind};
 
-    impl BorshSerialize for Matcher {
+    impl Serialize for Matcher {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.literals.serialize(writer)?;
             self.modifiers.serialize(writer)?;
@@ -465,10 +465,10 @@ mod wire {
         }
     }
 
-    impl BD for Matcher {
+    impl DS for Matcher {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let literals = BD::deserialize_reader(reader)?;
-            let modifiers = BD::deserialize_reader(reader)?;
+            let literals = DS::deserialize_reader(reader)?;
+            let modifiers = DS::deserialize_reader(reader)?;
             let kind = deserialize_matcher_kind(modifiers, reader)?;
             Ok(Self {
                 literals,
@@ -478,7 +478,7 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for MatcherKind {
+    impl Serialize for MatcherKind {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Literals => {
@@ -501,7 +501,7 @@ mod wire {
         modifiers: Modifiers,
         reader: &mut R,
     ) -> io::Result<MatcherKind> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         match discriminant {
             0 => Ok(MatcherKind::Literals),
             1 => {
@@ -519,7 +519,7 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for Modifiers {
+    impl Serialize for Modifiers {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.fullword.serialize(writer)?;
             self.wide.serialize(writer)?;
@@ -531,14 +531,14 @@ mod wire {
         }
     }
 
-    impl BD for Modifiers {
+    impl DS for Modifiers {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let fullword = BD::deserialize_reader(reader)?;
-            let wide = BD::deserialize_reader(reader)?;
-            let ascii = BD::deserialize_reader(reader)?;
-            let nocase = BD::deserialize_reader(reader)?;
-            let dot_all = BD::deserialize_reader(reader)?;
-            let xor_start = BD::deserialize_reader(reader)?;
+            let fullword = DS::deserialize_reader(reader)?;
+            let wide = DS::deserialize_reader(reader)?;
+            let ascii = DS::deserialize_reader(reader)?;
+            let nocase = DS::deserialize_reader(reader)?;
+            let dot_all = DS::deserialize_reader(reader)?;
+            let xor_start = DS::deserialize_reader(reader)?;
             Ok(Self {
                 fullword,
                 wide,

--- a/boreal/src/matcher/raw.rs
+++ b/boreal/src/matcher/raw.rs
@@ -175,14 +175,14 @@ fn unwide(mem: &[u8]) -> Vec<u8> {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use crate::matcher::Modifiers;
     use crate::regex::Regex;
 
     use super::RawMatcher;
 
-    impl BorshSerialize for RawMatcher {
+    impl Serialize for RawMatcher {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.exprs[0].serialize(writer)?;
             self.exprs[1].serialize(writer)?;
@@ -198,10 +198,10 @@ mod wire {
         modifiers: Modifiers,
         reader: &mut R,
     ) -> io::Result<RawMatcher> {
-        let expr1: String = BD::deserialize_reader(reader)?;
-        let expr2: String = BD::deserialize_reader(reader)?;
+        let expr1: String = DS::deserialize_reader(reader)?;
+        let expr2: String = DS::deserialize_reader(reader)?;
 
-        let non_wide_expr: Option<String> = BD::deserialize_reader(reader)?;
+        let non_wide_expr: Option<String> = DS::deserialize_reader(reader)?;
         let non_wide_regex = match non_wide_expr {
             Some(expr) => Some(
                 Regex::from_string(expr.clone(), modifiers.nocase, modifiers.dot_all).map_err(

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -242,13 +242,13 @@ impl std::fmt::Display for HalfValidator {
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use crate::matcher::Modifiers;
 
     use super::{dfa, HalfValidator, Validator};
 
-    impl BorshSerialize for Validator {
+    impl Serialize for Validator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Validator::NonGreedy { forward, reverse } => {
@@ -270,7 +270,7 @@ mod wire {
         modifiers: Modifiers,
         reader: &mut R,
     ) -> io::Result<Validator> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         match discriminant {
             0 => {
                 let forward = deserialize_half_validator(modifiers, false, reader)?;
@@ -312,10 +312,10 @@ mod wire {
         reverse: bool,
         reader: &mut R,
     ) -> io::Result<Option<HalfValidator>> {
-        let discriminant: u8 = BD::deserialize_reader(reader)?;
+        let discriminant: u8 = DS::deserialize_reader(reader)?;
         match discriminant {
             0 => Ok(None),
-            1 => Ok(Some(HalfValidator::Simple(BD::deserialize_reader(reader)?))),
+            1 => Ok(Some(HalfValidator::Simple(DS::deserialize_reader(reader)?))),
             2 => {
                 let dfa = dfa::DfaValidator::deserialize(modifiers, reverse, reader)?;
                 Ok(Some(HalfValidator::Dfa(dfa)))

--- a/boreal/src/matcher/validator/dfa.rs
+++ b/boreal/src/matcher/validator/dfa.rs
@@ -323,14 +323,14 @@ fn build_dfa(
 mod wire {
     use std::{io, sync::Arc};
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
     use regex_automata::util::pool::Pool;
 
     use crate::matcher::Modifiers;
 
     use super::{build_dfa, DfaValidator, PoolCreateFn};
 
-    impl BorshSerialize for DfaValidator {
+    impl Serialize for DfaValidator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.exprs[0].serialize(writer)?;
             self.exprs[1].serialize(writer)?;
@@ -344,9 +344,9 @@ mod wire {
         reverse: bool,
         reader: &mut R,
     ) -> io::Result<DfaValidator> {
-        let expr1: String = BD::deserialize_reader(reader)?;
-        let expr2: String = BD::deserialize_reader(reader)?;
-        let use_custom_wide_runner = BD::deserialize_reader(reader)?;
+        let expr1: String = DS::deserialize_reader(reader)?;
+        let expr2: String = DS::deserialize_reader(reader)?;
+        let use_custom_wide_runner = DS::deserialize_reader(reader)?;
 
         let dfa = Arc::new(
             build_dfa(&expr1, &expr2, modifiers, reverse).map_err(|err| {

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -198,11 +198,11 @@ fn add_hir_to_simple_nodes(
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::{SimpleNode, SimpleValidator};
 
-    impl BorshSerialize for SimpleValidator {
+    impl Serialize for SimpleValidator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.nodes.serialize(writer)?;
             self.length.serialize(writer)?;
@@ -210,16 +210,16 @@ mod wire {
         }
     }
 
-    impl BD for SimpleValidator {
+    impl DS for SimpleValidator {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let nodes = BD::deserialize_reader(reader)?;
-            let length = BD::deserialize_reader(reader)?;
+            let nodes = DS::deserialize_reader(reader)?;
+            let length = DS::deserialize_reader(reader)?;
 
             Ok(Self { nodes, length })
         }
     }
 
-    impl BorshSerialize for SimpleNode {
+    impl Serialize for SimpleNode {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             match self {
                 Self::Byte(b) => {
@@ -249,22 +249,22 @@ mod wire {
         }
     }
 
-    impl BD for SimpleNode {
+    impl DS for SimpleNode {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let discriminant: u8 = BD::deserialize_reader(reader)?;
+            let discriminant: u8 = DS::deserialize_reader(reader)?;
             match discriminant {
-                0 => Ok(Self::Byte(BD::deserialize_reader(reader)?)),
+                0 => Ok(Self::Byte(DS::deserialize_reader(reader)?)),
                 1 => {
-                    let value = BD::deserialize_reader(reader)?;
-                    let mask = BD::deserialize_reader(reader)?;
+                    let value = DS::deserialize_reader(reader)?;
+                    let mask = DS::deserialize_reader(reader)?;
                     Ok(Self::Mask { value, mask })
                 }
                 2 => {
-                    let value = BD::deserialize_reader(reader)?;
-                    let mask = BD::deserialize_reader(reader)?;
+                    let value = DS::deserialize_reader(reader)?;
+                    let mask = DS::deserialize_reader(reader)?;
                     Ok(Self::NegatedMask { value, mask })
                 }
-                3 => Ok(Self::Jump(BD::deserialize_reader(reader)?)),
+                3 => Ok(Self::Jump(DS::deserialize_reader(reader)?)),
                 4 => Ok(Self::Dot),
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -447,6 +447,32 @@ impl<'scanner> ModuleDataMap<'scanner> {
     }
 }
 
+pub(crate) fn add_default_modules<F: FnMut(Box<dyn Module>)>(mut cb: F) {
+    cb(Box::new(Time));
+    cb(Box::new(Math));
+    cb(Box::new(String_));
+
+    #[cfg(feature = "hash")]
+    cb(Box::new(Hash));
+
+    #[cfg(feature = "object")]
+    cb(Box::new(Pe));
+    #[cfg(feature = "object")]
+    cb(Box::new(Elf));
+    #[cfg(feature = "object")]
+    cb(Box::new(MachO));
+    #[cfg(feature = "object")]
+    cb(Box::new(Dotnet));
+    #[cfg(feature = "object")]
+    cb(Box::new(Dex));
+
+    #[cfg(feature = "magic")]
+    cb(Box::new(Magic));
+
+    #[cfg(feature = "cuckoo")]
+    cb(Box::new(Cuckoo));
+}
+
 /// A value bound to an identifier.
 ///
 /// This object represents an immediately resolvable value for an identifier.

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -544,6 +544,8 @@ impl std::fmt::Debug for Value {
     }
 }
 
+pub(crate) type StaticFunction = fn(&mut EvalContext, Vec<Value>) -> Option<Value>;
+
 /// A static value provided by a module at compilation time.
 ///
 /// This is similar to [`Value`], but without some compounds values that require evaluation
@@ -564,7 +566,7 @@ pub enum StaticValue {
     /// A function, see [`Value::Function`].
     Function {
         /// The function to call.
-        fun: fn(&mut EvalContext, Vec<Value>) -> Option<Value>,
+        fun: StaticFunction,
 
         /// Types of arguments for the function.
         ///

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -321,11 +321,11 @@ impl std::error::Error for Error {}
 mod wire {
     use std::io;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::Regex;
 
-    impl BorshSerialize for Regex {
+    impl Serialize for Regex {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.case_insensitive.serialize(writer)?;
             self.dot_all.serialize(writer)?;
@@ -334,11 +334,11 @@ mod wire {
         }
     }
 
-    impl BD for Regex {
+    impl DS for Regex {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let case_insensitive = BD::deserialize_reader(reader)?;
-            let dot_all = BD::deserialize_reader(reader)?;
-            let expr = BD::deserialize_reader(reader)?;
+            let case_insensitive = DS::deserialize_reader(reader)?;
+            let dot_all = DS::deserialize_reader(reader)?;
+            let expr = DS::deserialize_reader(reader)?;
             Regex::from_string(expr, case_insensitive, dot_all).map_err(|err| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1468,38 +1468,11 @@ mod wire {
 
     impl Default for DeserializeParams {
         fn default() -> Self {
-            fn add_module<M: Module + 'static>(
-                modules: &mut HashMap<&'static str, Box<dyn Module>>,
-                module: M,
-            ) {
-                let _r = modules.insert(module.get_name(), Box::new(module));
-            }
-
             let mut modules = HashMap::new();
 
-            add_module(&mut modules, crate::module::Time);
-            add_module(&mut modules, crate::module::Math);
-            add_module(&mut modules, crate::module::String_);
-
-            #[cfg(feature = "hash")]
-            add_module(&mut modules, crate::module::Hash);
-
-            #[cfg(feature = "object")]
-            add_module(&mut modules, crate::module::Pe);
-            #[cfg(feature = "object")]
-            add_module(&mut modules, crate::module::Elf);
-            #[cfg(feature = "object")]
-            add_module(&mut modules, crate::module::MachO);
-            #[cfg(feature = "object")]
-            add_module(&mut modules, crate::module::Dotnet);
-            #[cfg(feature = "object")]
-            add_module(&mut modules, crate::module::Dex);
-
-            #[cfg(feature = "magic")]
-            add_module(&mut modules, crate::module::Magic);
-
-            #[cfg(feature = "cuckoo")]
-            add_module(&mut modules, crate::module::Cuckoo);
+            crate::module::add_default_modules(|module| {
+                let _r = modules.insert(module.get_name(), module);
+            });
 
             Self { modules }
         }

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -543,11 +543,11 @@ mod wire {
     use std::io;
     use std::time::Duration;
 
-    use borsh::{BorshDeserialize as BD, BorshSerialize};
+    use crate::wire::{Deserialize as DS, Serialize};
 
     use super::{CallbackEvents, FragmentedScanMode, ScanParams};
 
-    impl BorshSerialize for ScanParams {
+    impl Serialize for ScanParams {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.compute_full_matches.serialize(writer)?;
             self.match_max_length.serialize(writer)?;
@@ -566,19 +566,19 @@ mod wire {
         }
     }
 
-    impl BD for ScanParams {
+    impl DS for ScanParams {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let compute_full_matches = BD::deserialize_reader(reader)?;
-            let match_max_length = BD::deserialize_reader(reader)?;
-            let string_max_nb_matches = BD::deserialize_reader(reader)?;
-            let timeout_duration: Option<u64> = BD::deserialize_reader(reader)?;
-            let compute_statistics = BD::deserialize_reader(reader)?;
-            let fragmented_scan_mode = BD::deserialize_reader(reader)?;
-            let process_memory = BD::deserialize_reader(reader)?;
-            let max_fetched_region_size = BD::deserialize_reader(reader)?;
-            let memory_chunk_size = BD::deserialize_reader(reader)?;
-            let callback_events = BD::deserialize_reader(reader)?;
-            let include_not_matched_rules = BD::deserialize_reader(reader)?;
+            let compute_full_matches = DS::deserialize_reader(reader)?;
+            let match_max_length = DS::deserialize_reader(reader)?;
+            let string_max_nb_matches = DS::deserialize_reader(reader)?;
+            let timeout_duration: Option<u64> = DS::deserialize_reader(reader)?;
+            let compute_statistics = DS::deserialize_reader(reader)?;
+            let fragmented_scan_mode = DS::deserialize_reader(reader)?;
+            let process_memory = DS::deserialize_reader(reader)?;
+            let max_fetched_region_size = DS::deserialize_reader(reader)?;
+            let memory_chunk_size = DS::deserialize_reader(reader)?;
+            let callback_events = DS::deserialize_reader(reader)?;
+            let include_not_matched_rules = DS::deserialize_reader(reader)?;
             Ok(Self {
                 compute_full_matches,
                 match_max_length,
@@ -595,7 +595,7 @@ mod wire {
         }
     }
 
-    impl BorshSerialize for FragmentedScanMode {
+    impl Serialize for FragmentedScanMode {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.modules_dynamic_values.serialize(writer)?;
             self.can_refetch_regions.serialize(writer)?;
@@ -603,10 +603,10 @@ mod wire {
         }
     }
 
-    impl BD for FragmentedScanMode {
+    impl DS for FragmentedScanMode {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let modules_dynamic_values = BD::deserialize_reader(reader)?;
-            let can_refetch_regions = BD::deserialize_reader(reader)?;
+            let modules_dynamic_values = DS::deserialize_reader(reader)?;
+            let can_refetch_regions = DS::deserialize_reader(reader)?;
             Ok(Self {
                 modules_dynamic_values,
                 can_refetch_regions,

--- a/boreal/src/wire.rs
+++ b/boreal/src/wire.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+use borsh::{BorshDeserialize as BD, BorshSerialize};
+
+use crate::module::StaticValue;
+
+const VERSION: u32 = 0;
+
+pub(crate) struct DeserializeContext {
+    pub(crate) modules_static_values: Vec<StaticValue>,
+}
+
+pub(crate) fn serialize_header<W: io::Write>(kind: [u8; 4], writer: &mut W) -> io::Result<()> {
+    let magic: [u8; 12] = *b"boreal_wire_";
+    magic.serialize(writer)?;
+    kind.serialize(writer)?;
+    VERSION.serialize(writer)?;
+    Ok(())
+}
+
+pub(super) fn deserialize_header<R: io::Read>(
+    expected_kind: [u8; 4],
+    reader: &mut R,
+) -> io::Result<()> {
+    let magic: [u8; 12] = BD::deserialize_reader(reader)?;
+    if &magic != b"boreal_wire_" {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid magic: {:x?}", &magic),
+        ));
+    }
+    let kind: [u8; 4] = BD::deserialize_reader(reader)?;
+    if kind != expected_kind {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid kind: {:x?}", &kind),
+        ));
+    }
+    let version: u32 = BD::deserialize_reader(reader)?;
+    if version != VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unknown version {version}"),
+        ));
+    }
+    Ok(())
+}

--- a/boreal/src/wire.rs
+++ b/boreal/src/wire.rs
@@ -1,6 +1,7 @@
 use std::io;
 
-use borsh::{BorshDeserialize as BD, BorshSerialize};
+pub use borsh::BorshDeserialize as Deserialize;
+pub use borsh::BorshSerialize as Serialize;
 
 use crate::module::StaticValue;
 
@@ -22,21 +23,21 @@ pub(super) fn deserialize_header<R: io::Read>(
     expected_kind: [u8; 4],
     reader: &mut R,
 ) -> io::Result<()> {
-    let magic: [u8; 12] = BD::deserialize_reader(reader)?;
+    let magic: [u8; 12] = Deserialize::deserialize_reader(reader)?;
     if &magic != b"boreal_wire_" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid magic: {:x?}", &magic),
         ));
     }
-    let kind: [u8; 4] = BD::deserialize_reader(reader)?;
+    let kind: [u8; 4] = Deserialize::deserialize_reader(reader)?;
     if kind != expected_kind {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid kind: {:x?}", &kind),
         ));
     }
-    let version: u32 = BD::deserialize_reader(reader)?;
+    let version: u32 = Deserialize::deserialize_reader(reader)?;
     if version != VERSION {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,

--- a/boreal/src/wire.rs
+++ b/boreal/src/wire.rs
@@ -1,3 +1,39 @@
+//! Serialization and deserialization routines.
+//!
+//! This module defines the different serialization and deserialization traits and methods
+//! used throughout the crate, and exposed through the [`crate::Scanner::to_bytes`] and
+//! [`crate::Scanner::from_bytes_unchecked`] methods.
+//!
+//! # Architecture
+//!
+//! The `borsh` library is used to provide ser/deser implementations for all std types.
+//! This library provides some good safe defaults and is very simple.
+//!
+//! All ser/deser implementations follow this design:
+//!
+//! - The derive methods are *not* used, for several reasons:
+//!
+//!   - Making those methods explicit guarantees that a innocuous change in an object
+//!     does not break serialization.
+//!   - This allows testing the serialization of those objects more thoroughly
+//!   - derive implementations uses proc macros which are slow and bring more, unneeded,
+//!     dependencies.
+//!
+//! - Use of the `Deserialize` trait is made through explicit types. This ensures that
+//!   changing the type of a field, which means a break in the serialization format,
+//!   forces a change in those routines. This makes the break explicit. That is,
+//!   do not do `Deserialize::deserialize_reader(reader)`, but do
+//!   `String::deserialize_reader(reader)`.
+//!
+//! - A few objects needs additional data to deserialize properly. In that case, the object
+//!   implements the Serialize trait normally, but exposes a `deserialize` method that takes
+//!   this additional data instead of implementing the Deserialize trait.
+//!
+//! - A few objects requires storing additional data in the Scanner in order to be able to
+//!   be serialized and deserialized properly. In that case, those additional datas are
+//!   conditioned through the use of the `serialize` feature, to ensure that if this
+//!   feature is enabled, those useless fields are not stored and do not increase the RAM
+//!   usage of the scanner.
 use std::io;
 
 pub use borsh::BorshDeserialize as Deserialize;

--- a/boreal/src/wire.rs
+++ b/boreal/src/wire.rs
@@ -7,6 +7,7 @@ use crate::module::StaticValue;
 
 const VERSION: u32 = 0;
 
+#[derive(Default)]
 pub(crate) struct DeserializeContext {
     pub(crate) modules_static_values: Vec<StaticValue>,
 }
@@ -23,21 +24,21 @@ pub(super) fn deserialize_header<R: io::Read>(
     expected_kind: [u8; 4],
     reader: &mut R,
 ) -> io::Result<()> {
-    let magic: [u8; 12] = Deserialize::deserialize_reader(reader)?;
+    let magic = <[u8; 12]>::deserialize_reader(reader)?;
     if &magic != b"boreal_wire_" {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid magic: {:x?}", &magic),
         ));
     }
-    let kind: [u8; 4] = Deserialize::deserialize_reader(reader)?;
+    let kind = <[u8; 4]>::deserialize_reader(reader)?;
     if kind != expected_kind {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("invalid kind: {:x?}", &kind),
         ));
     }
-    let version: u32 = Deserialize::deserialize_reader(reader)?;
+    let version = u32::deserialize_reader(reader)?;
     if version != VERSION {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -45,4 +46,95 @@ pub(super) fn deserialize_header<R: io::Read>(
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::fmt::Debug;
+
+    use super::*;
+
+    // Test that a round trip through serialization yields the same object.
+    //
+    // The second parameter is a list of offsets at which if the serialized buffer
+    // is truncated, the serialization will fail. This is useful to test proper error
+    // propagation when failing to deserialize each field.
+    #[track_caller]
+    pub(crate) fn test_round_trip<T: Serialize + Deserialize + PartialEq + Debug>(
+        v: &T,
+        truncate_offset_errors: &[usize],
+    ) {
+        test_round_trip_custom_deser(
+            v,
+            |reader| T::deserialize_reader(reader),
+            truncate_offset_errors,
+        );
+    }
+
+    #[track_caller]
+    pub(crate) fn test_round_trip_custom_deser<T, F>(
+        v: &T,
+        deser: F,
+        truncate_offset_errors: &[usize],
+    ) where
+        T: Serialize + PartialEq + Debug,
+        F: Fn(&mut io::Cursor<&[u8]>) -> io::Result<T>,
+    {
+        for offset in truncate_offset_errors {
+            let mut buf = vec![0_u8; *offset];
+            let mut s: &mut [u8] = &mut buf[..];
+            assert!(v.serialize(&mut s).is_err());
+        }
+
+        let mut buf = Vec::new();
+        v.serialize(&mut buf).unwrap();
+
+        for offset in truncate_offset_errors {
+            let mut cursor = io::Cursor::new(&buf[..*offset]);
+            assert!((deser)(&mut cursor).is_err());
+        }
+
+        let mut cursor = io::Cursor::new(&*buf);
+        let v2 = (deser)(&mut cursor).unwrap();
+        assert_eq!(v, &v2);
+    }
+
+    pub(crate) fn test_invalid_deserialization<T: Deserialize>(mut buf: &[u8]) {
+        assert!(T::deserialize(&mut buf).is_err());
+    }
+
+    #[test]
+    fn test_wire_header() {
+        let mut buf = [0; 16];
+        assert!(serialize_header(*b"toto", &mut &mut buf[..0]).is_err());
+        assert!(serialize_header(*b"toto", &mut &mut buf[..13]).is_err());
+        assert!(serialize_header(*b"toto", &mut &mut buf[..16]).is_err());
+        let mut buf = Vec::new();
+        serialize_header(*b"toto", &mut buf).unwrap();
+        assert!(buf.starts_with(b"boreal_wire_toto"));
+
+        assert!(deserialize_header(*b"toto", &mut io::Cursor::new(&buf[..0])).is_err());
+        assert!(deserialize_header(*b"toto", &mut io::Cursor::new(&buf[..13])).is_err());
+        assert!(deserialize_header(*b"toto", &mut io::Cursor::new(&buf[..16])).is_err());
+        deserialize_header(*b"toto", &mut io::Cursor::new(&buf)).unwrap();
+
+        // invalid magic
+        assert!(deserialize_header(
+            *b"toto",
+            &mut io::Cursor::new(b"wire_boreal_toto\x00\x00\x00\x00")
+        )
+        .is_err());
+        // invalid kind
+        assert!(deserialize_header(
+            *b"toto",
+            &mut io::Cursor::new(b"boreal_wire_nkgm\x00\x00\x00\x00")
+        )
+        .is_err());
+        // unknown version
+        assert!(deserialize_header(
+            *b"toto",
+            &mut io::Cursor::new(b"boreal_wire_toto\xCC\x00\x00\x00")
+        )
+        .is_err());
+    }
 }

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -346,13 +346,14 @@ fn test_scanner_serialize_module_use() {
     let _r = scanner.scan_mem(b"").unwrap();
     assert_eq!(&*LOGS.lock().unwrap(), &[1, 2]);
 
-    let buf = scanner.to_bytes().unwrap();
+    let mut buf = Vec::new();
+    scanner.to_bytes(&mut buf).unwrap();
     // Missing console module
-    assert!(Scanner::from_bytes(&buf, DeserializeParams::default()).is_err());
+    assert!(Scanner::from_bytes_unchecked(&buf, DeserializeParams::default()).is_err());
 
     let mut params = DeserializeParams::default();
     params.add_module(Console::with_callback(|_| LOGS.lock().unwrap().push(3)));
-    let mut scanner2 = Scanner::from_bytes(&buf, params).unwrap();
+    let mut scanner2 = Scanner::from_bytes_unchecked(&buf, params).unwrap();
 
     let _r = scanner2.scan_mem(b"").unwrap();
     assert_eq!(&*LOGS.lock().unwrap(), &[1, 2, 3]);


### PR DESCRIPTION
Add a `Scanner::to_bytes` and `Scanner::from_bytes_unchecked` method to serialize a scanner into bytes and deserialize from it.

This feature is gated by a feature because of two reasons:

- This adds a new dependency (on the borsh crate). This dependency could be removed by interning all the ser/deser impls on std types, but there is no real impetus on doing so.
- A few objects require storing additional data to be serializable. Those additional data are not stored if the feature is not enabled, so that people can choose to avoid this penalty if serialization is not required.