### PR TITLE
Remove Option for namespace, use name "default" for default namespace

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -901,7 +901,7 @@ fn handle_event(
             eprintln!(
                 "warning: string ${} in rule {}:{} reached the maximum number of matches",
                 string_identifier.string_name,
-                string_identifier.rule_namespace.unwrap_or("default"),
+                string_identifier.rule_namespace,
                 string_identifier.rule_name,
             );
 
@@ -939,7 +939,7 @@ fn display_rule(
 
     // <rule_namespace>:<rule_name> [<ruletags>] <matched object>
     if options.print_namespace {
-        write!(stdout, "{}:", rule.namespace.unwrap_or("default")).unwrap();
+        write!(stdout, "{}:", rule.namespace).unwrap();
     }
     write!(stdout, "{}", &rule.name).unwrap();
     if options.print_tags {
@@ -1083,11 +1083,7 @@ fn display_diagnostic(path: &Path, err: &boreal::compiler::AddRuleError) {
 }
 
 fn display_rule_stats(stats: &statistics::CompiledRule) {
-    print!(
-        "{}:{}",
-        stats.namespace.as_deref().unwrap_or("default"),
-        stats.name
-    );
+    print!("{}:{}", stats.namespace, stats.name);
     match &stats.filepath {
         Some(path) => println!(" (from {})", path.display()),
         None => println!(),

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -279,13 +279,9 @@ fn call_py_include_callback(
     include_callback: &Py<PyAny>,
     include_name: &str,
     current_path: Option<&Path>,
-    mut ns: Option<&str>,
+    ns: &str,
 ) -> Result<String, String> {
     let current_path = current_path.map(|v| v.display().to_string());
-
-    if YARA_PYTHON_COMPATIBILITY.load(Ordering::SeqCst) {
-        ns = Some(ns.unwrap_or("default"));
-    }
 
     Python::with_gil(|py| {
         let res = include_callback

--- a/boreal-py/src/rule.rs
+++ b/boreal-py/src/rule.rs
@@ -45,7 +45,7 @@ impl Rule {
     ) -> PyResult<Self> {
         Ok(Self {
             identifier: PyString::new(py, rule.name).unbind(),
-            namespace: PyString::new(py, rule.namespace.unwrap_or_default()).unbind(),
+            namespace: PyString::new(py, rule.namespace).unbind(),
             meta: convert_metadatas(py, scanner, rule.metadatas, false)?.unbind(),
             tags: PyList::new(py, rule.tags)?.unbind(),
             is_global: rule.is_global,

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -69,7 +69,7 @@ impl Match {
     ) -> Result<Self, PyErr> {
         Ok(Self {
             rule: rule.name.to_string(),
-            namespace: rule.namespace.unwrap_or("default").to_string(),
+            namespace: rule.namespace.to_string(),
             meta: convert_metadatas(py, scanner, rule.metadatas, allow_duplicate_metadata)?
                 .unbind(),
             tags: PyList::new(py, rule.tags)?.unbind(),

--- a/boreal-py/src/rule_string.rs
+++ b/boreal-py/src/rule_string.rs
@@ -22,7 +22,7 @@ pub struct RuleString {
 impl RuleString {
     pub fn new(py: Python, id: &StringIdentifier) -> Self {
         Self {
-            namespace: PyString::new(py, id.rule_namespace.unwrap_or("default")).unbind(),
+            namespace: PyString::new(py, id.rule_namespace).unbind(),
             rule: PyString::new(py, id.rule_name).unbind(),
             string: PyString::new(py, &format!("${}", id.string_name)).unbind(),
         }

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -357,11 +357,11 @@ rule r: tag {
     assert not r3.is_private
     assert r3.meta == {}
 
-    # Test the namespace value for the default one
     if not is_yara:
+        # Test the namespace value for the default one
         scanner = module.compile(source="rule a { condition: true }")
         rules = [r for r in scanner]
-        assert rules[0].namespace == ""
+        assert rules[0].namespace == "default"
 
 
 @pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -185,7 +185,7 @@ impl Compiler {
 
     /// Add rules to compile from a file.
     ///
-    /// The default namespace will be used.
+    /// The namespace named "default" will be used.
     ///
     /// # Errors
     ///
@@ -201,8 +201,6 @@ impl Compiler {
     }
 
     /// Add rules to compile from a file into a specific namespace.
-    ///
-    /// The default namespace will be used.
     ///
     /// # Errors
     ///
@@ -236,7 +234,7 @@ impl Compiler {
 
     /// Add rules to compile from a string.
     ///
-    /// The default namespace will be used.
+    /// The namespace named "default" will be used.
     ///
     /// # Errors
     ///

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -326,10 +326,7 @@ fn build_string_identifier(
     for rule in scanner.global_rules.iter().chain(scanner.rules.iter()) {
         if index + rule.nb_variables > variable_index {
             return Some(StringIdentifier {
-                rule_namespace: scanner
-                    .namespaces
-                    .get(rule.namespace_index)
-                    .and_then(|v| v.as_deref()),
+                rule_namespace: scanner.namespaces[rule.namespace_index].as_ref(),
                 rule_name: &rule.name,
                 string_name: &scanner.variables[variable_index].name,
                 string_index: variable_index - index,

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -12,9 +12,7 @@ pub struct CompiledRule {
     pub filepath: Option<PathBuf>,
 
     /// Namespace containing the rule.
-    ///
-    /// None for the default namespace.
-    pub namespace: Option<String>,
+    pub namespace: String,
 
     /// Name of the rule.
     pub name: String,
@@ -109,7 +107,7 @@ mod tests {
     fn test_types_traits() {
         test_type_traits(CompiledRule {
             filepath: Some(PathBuf::new()),
-            namespace: Some(String::new()),
+            namespace: String::new(),
             name: String::new(),
             strings: Vec::new(),
         });

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -139,7 +139,7 @@ rule r: tag {
 
     let r0 = &rules[0];
     assert_eq!(r0.name, "g");
-    assert_eq!(r0.namespace, None);
+    assert_eq!(r0.namespace, "default");
     assert_eq!(r0.tags.len(), 0);
     assert!(r0.is_global);
     assert!(!r0.is_private);
@@ -147,7 +147,7 @@ rule r: tag {
 
     let r1 = &rules[1];
     assert_eq!(r1.name, "pg");
-    assert_eq!(r1.namespace, Some("namespace"));
+    assert_eq!(r1.namespace, "namespace");
     assert_eq!(r1.tags, &["tag1", "tag2"]);
     assert!(r1.is_global);
     assert!(r1.is_private);
@@ -165,7 +165,7 @@ rule r: tag {
 
     let r2 = &rules[2];
     assert_eq!(r2.name, "p");
-    assert_eq!(r2.namespace, None);
+    assert_eq!(r2.namespace, "default");
     assert_eq!(r2.tags, &["tag"]);
     assert!(!r2.is_global);
     assert!(r2.is_private);
@@ -178,7 +178,7 @@ rule r: tag {
 
     let r3 = &rules[3];
     assert_eq!(r3.name, "r");
-    assert_eq!(r3.namespace, Some("namespace"));
+    assert_eq!(r3.namespace, "namespace");
     assert_eq!(r3.tags, &["tag"]);
     assert!(!r3.is_global);
     assert!(!r3.is_private);
@@ -239,11 +239,7 @@ rule yes2 { condition: true }
             .rules
             .iter()
             .map(|v| {
-                let name = if let Some(ns) = &v.namespace {
-                    format!("{}:{}", ns, v.name)
-                } else {
-                    format!("default:{}", v.name)
-                };
+                let name = format!("{}:{}", v.namespace, v.name);
                 (name, v.matched)
             })
             .collect();
@@ -372,7 +368,7 @@ fn test_compiler_set_include_callback() {
     compiler.set_include_callback(|include_name, current_path, namespace| {
         let current_path = current_path.map(|v| v.display().to_string());
 
-        if namespace.is_none() {
+        if namespace == "default" {
             match (include_name, current_path.as_deref()) {
                 ("first.yar", None) => Ok(r#"
                         include "second/../boo.yar"
@@ -398,7 +394,7 @@ fn test_compiler_set_include_callback() {
                     include_name, current_path
                 ),
             }
-        } else if namespace == Some("ns") {
+        } else if namespace == "ns" {
             match (include_name, current_path.as_deref()) {
                 ("first.yar", _) => {
                     // Check the end of the path, but the rest is from a tempdir.

--- a/boreal/tests/it/callback.rs
+++ b/boreal/tests/it/callback.rs
@@ -25,7 +25,7 @@ const TIMEOUT_COND: &str = r#"
 "#;
 
 #[track_caller]
-fn check_rule_match(event: ScanEvent, rule_name: &str, namespace: Option<&str>) {
+fn check_rule_match(event: ScanEvent, rule_name: &str, namespace: &str) {
     match &event {
         ScanEvent::RuleMatch(m) => {
             assert!(
@@ -41,7 +41,7 @@ fn check_rule_match(event: ScanEvent, rule_name: &str, namespace: Option<&str>) 
 }
 
 #[track_caller]
-fn check_rule_no_match(event: ScanEvent, rule_name: &str, namespace: Option<&str>) {
+fn check_rule_no_match(event: ScanEvent, rule_name: &str, namespace: &str) {
     match &event {
         ScanEvent::RuleNoMatch(m) => assert!(
             m.name == rule_name && m.namespace == namespace,
@@ -79,7 +79,7 @@ fn check_module_import(
 #[track_caller]
 fn check_string_reached_match_limit(
     event: ScanEvent,
-    expected_rule_namespace: Option<&str>,
+    expected_rule_namespace: &str,
     expected_rule_name: &str,
     expected_string_name: &str,
     expected_string_index: usize,
@@ -167,14 +167,14 @@ rule c {
 
     scan_mem(&scanner, b"<abcdef>", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 
     scan_mem(&scanner, b"<abef>", 1, |event, _nb| {
-        check_rule_match(event, "a", None);
+        check_rule_match(event, "a", "default");
     });
 }
 
@@ -211,19 +211,19 @@ rule c {
 
     scan_mem(&scanner, b"<abcdef>", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
     });
 
     scan_mem(&scanner, b"<abcdefghi>", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 
@@ -249,19 +249,19 @@ rule c { condition: filesize > 7 }
 
     scan_mem(&scanner, b"12345", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
     });
 
     scan_mem(&scanner, b"12345678", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 }
@@ -287,9 +287,9 @@ rule b { condition: filesize >= 3 }
     let mut counter = 0;
     let res = scanner.scan_mem_with_callback(b"123", |event| {
         if counter == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if counter == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
         counter += 1;
         ScanCallbackResult::Continue
@@ -319,36 +319,36 @@ rule d { condition: true }
     let scanner = compiler.into_scanner();
 
     scan_mem_with_abort(&scanner, b"abc", 0, |event, _nb| {
-        check_rule_match(event, "a", None);
+        check_rule_match(event, "a", "default");
     });
 
     scan_mem_with_abort(&scanner, b"abc", 1, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
     });
 
     scan_mem_with_abort(&scanner, b"abc", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 
     scan_mem_with_abort(&scanner, b"abc", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         } else if nb == 3 {
-            check_rule_match(event, "d", None);
+            check_rule_match(event, "d", "default");
         }
     });
 }
@@ -369,36 +369,36 @@ rule d { condition: true }
     let scanner = compiler.into_scanner();
 
     scan_mem_with_abort(&scanner, b"", 0, |event, _nb| {
-        check_rule_match(event, "a", None);
+        check_rule_match(event, "a", "default");
     });
 
     scan_mem_with_abort(&scanner, b"", 1, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
     });
 
     scan_mem_with_abort(&scanner, b"", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 
     scan_mem_with_abort(&scanner, b"", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         } else if nb == 3 {
-            check_rule_match(event, "d", None);
+            check_rule_match(event, "d", "default");
         }
     });
 }
@@ -419,7 +419,7 @@ fn test_scan_mem_with_callback_abort_timeout() {
         .set_scan_params(ScanParams::default().timeout_duration(Some(Duration::from_millis(100))));
 
     scan_mem_with_abort(&scanner, b"", 0, |event, _nb| {
-        check_rule_match(event, "a", None);
+        check_rule_match(event, "a", "default");
     });
 }
 
@@ -443,7 +443,7 @@ fn test_scan_file_with_callback() {
     let mut counter = 0;
     scanner
         .scan_file_with_callback(&file, |event| {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
             counter += 1;
             ScanCallbackResult::Continue
         })
@@ -476,7 +476,7 @@ fn test_scan_file_memmap_with_callback() {
     // Safety: testing
     unsafe {
         scanner.scan_file_memmap_with_callback(&file, |event| {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
             counter += 1;
             ScanCallbackResult::Continue
         })
@@ -510,7 +510,7 @@ rule a {
     let mut counter = 0;
     scanner
         .scan_fragmented_with_callback(FragmentedSlices::new(regions), |event| {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
             counter += 1;
             ScanCallbackResult::Continue
         })
@@ -544,7 +544,7 @@ rule a {
     let mut counter = 0;
     scanner
         .scan_process_with_callback(helper.pid(), |event| {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
             counter += 1;
             ScanCallbackResult::Continue
         })
@@ -590,7 +590,7 @@ fn test_module_import_event() {
         } else if nb == 1 {
             check_module_import(event, "time", None);
         } else if nb == 2 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         }
     });
 }
@@ -617,7 +617,7 @@ fn test_module_import_event_fragmented() {
                 } else if counter == 1 {
                     check_module_import(event, "time", None);
                 } else if counter == 2 {
-                    check_rule_match(event, "a", None);
+                    check_rule_match(event, "a", "default");
                 }
                 counter += 1;
                 ScanCallbackResult::Continue
@@ -681,9 +681,9 @@ rule b {
     // By default, we get rule match, but not module import
     scan_mem(&scanner, b"abcdef", 2, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_match(event, "b", None);
+            check_rule_match(event, "b", "default");
         }
     });
 
@@ -759,21 +759,21 @@ private rule e { condition: false }
 
     scan_mem(&scanner, b"abcde", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "b", None);
+            check_rule_no_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_match(event, "c", None);
+            check_rule_match(event, "c", "default");
         }
     });
 
     scan_mem(&scanner, b"", 3, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "b", None);
+            check_rule_no_match(event, "b", "default");
         } else if nb == 2 {
-            check_rule_no_match(event, "c", None);
+            check_rule_no_match(event, "c", "default");
         }
     });
 }
@@ -828,68 +828,68 @@ rule yes2 { condition: true }
     // Nothing matches
     scan_mem(&scanner, b"", 6, |event, nb| {
         if nb == 0 {
-            check_rule_no_match(event, "ga", None);
+            check_rule_no_match(event, "ga", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "gb", None);
+            check_rule_no_match(event, "gb", "default");
         } else if nb == 2 {
-            check_rule_no_match(event, "gc", Some("ns2"));
+            check_rule_no_match(event, "gc", "ns2");
         } else if nb == 3 {
-            check_rule_no_match(event, "yes1", None);
+            check_rule_no_match(event, "yes1", "default");
         } else if nb == 4 {
-            check_rule_no_match(event, "no", None);
+            check_rule_no_match(event, "no", "default");
         } else if nb == 5 {
-            check_rule_no_match(event, "yes2", Some("ns2"));
+            check_rule_no_match(event, "yes2", "ns2");
         }
     });
 
     // Namespace ns2 matches
     scan_mem(&scanner, b"c", 6, |event, nb| {
         if nb == 0 {
-            check_rule_no_match(event, "ga", None);
+            check_rule_no_match(event, "ga", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "gb", None);
+            check_rule_no_match(event, "gb", "default");
         } else if nb == 2 {
-            check_rule_match(event, "gc", Some("ns2"));
+            check_rule_match(event, "gc", "ns2");
         } else if nb == 3 {
-            check_rule_no_match(event, "yes1", None);
+            check_rule_no_match(event, "yes1", "default");
         } else if nb == 4 {
-            check_rule_no_match(event, "no", None);
+            check_rule_no_match(event, "no", "default");
         } else if nb == 5 {
-            check_rule_match(event, "yes2", Some("ns2"));
+            check_rule_match(event, "yes2", "ns2");
         }
     });
 
     // gc1 matches in theory but is invalidated by the other global rule
     scan_mem(&scanner, b"a", 6, |event, nb| {
         if nb == 0 {
-            check_rule_no_match(event, "ga", None);
+            check_rule_no_match(event, "ga", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "gb", None);
+            check_rule_no_match(event, "gb", "default");
         } else if nb == 2 {
-            check_rule_no_match(event, "gc", Some("ns2"));
+            check_rule_no_match(event, "gc", "ns2");
         } else if nb == 3 {
-            check_rule_no_match(event, "yes1", None);
+            check_rule_no_match(event, "yes1", "default");
         } else if nb == 4 {
-            check_rule_no_match(event, "no", None);
+            check_rule_no_match(event, "no", "default");
         } else if nb == 5 {
-            check_rule_no_match(event, "yes2", Some("ns2"));
+            check_rule_no_match(event, "yes2", "ns2");
         }
     });
 
     // Both matches, this is now ok
     scan_mem(&scanner, b"ab", 6, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "ga", None);
+            check_rule_match(event, "ga", "default");
         } else if nb == 1 {
-            check_rule_match(event, "gb", None);
+            check_rule_match(event, "gb", "default");
         } else if nb == 2 {
-            check_rule_no_match(event, "gc", Some("ns2"));
+            check_rule_no_match(event, "gc", "ns2");
         } else if nb == 3 {
-            check_rule_match(event, "yes1", None);
+            check_rule_match(event, "yes1", "default");
         } else if nb == 4 {
-            check_rule_no_match(event, "no", None);
+            check_rule_no_match(event, "no", "default");
         } else if nb == 5 {
-            check_rule_no_match(event, "yes2", Some("ns2"));
+            check_rule_no_match(event, "yes2", "ns2");
         }
     });
 }
@@ -934,16 +934,16 @@ rule c {
     // Abort on global that fails
     scan_mem_with_abort(&scanner, b"", 0, |event, nb| {
         if nb == 0 {
-            check_rule_no_match(event, "a", None);
+            check_rule_no_match(event, "a", "default");
         }
     });
 
     // Abort on rule that fails
     scan_mem_with_abort(&scanner, b"a", 1, |event, nb| {
         if nb == 0 {
-            check_rule_match(event, "a", None);
+            check_rule_match(event, "a", "default");
         } else if nb == 1 {
-            check_rule_no_match(event, "b", None);
+            check_rule_no_match(event, "b", "default");
         }
     });
 }
@@ -1034,21 +1034,21 @@ rule r4 {
         b"aaaaa eeeeee fffff kkkkkk lllll nnnnn iiiii ddddd",
         15,
         |event, nb| match nb {
-            0 => check_string_reached_match_limit(event, None, "g1", "str1", 0),
-            1 => check_string_reached_match_limit(event, None, "r1", "str2", 1),
-            2 => check_string_reached_match_limit(event, Some("ns2"), "r2", "", 0),
-            3 => check_string_reached_match_limit(event, Some("ns3"), "g3", "", 1),
-            4 => check_string_reached_match_limit(event, Some("ns3"), "r4", "str1", 0),
-            5 => check_string_reached_match_limit(event, Some("ns3"), "r4", "str3", 2),
-            6 => check_string_reached_match_limit(event, Some("ns2"), "g2", "", 2),
-            7 => check_string_reached_match_limit(event, None, "r1", "str1", 0),
-            8 => check_rule_match(event, "g1", None),
-            9 => check_rule_match(event, "g2", Some("ns2")),
-            10 => check_rule_match(event, "g3", Some("ns3")),
-            11 => check_rule_match(event, "r1", None),
-            12 => check_rule_match(event, "r2", Some("ns2")),
-            13 => check_rule_match(event, "r3", Some("ns3")),
-            14 => check_rule_match(event, "r4", Some("ns3")),
+            0 => check_string_reached_match_limit(event, "default", "g1", "str1", 0),
+            1 => check_string_reached_match_limit(event, "default", "r1", "str2", 1),
+            2 => check_string_reached_match_limit(event, "ns2", "r2", "", 0),
+            3 => check_string_reached_match_limit(event, "ns3", "g3", "", 1),
+            4 => check_string_reached_match_limit(event, "ns3", "r4", "str1", 0),
+            5 => check_string_reached_match_limit(event, "ns3", "r4", "str3", 2),
+            6 => check_string_reached_match_limit(event, "ns2", "g2", "", 2),
+            7 => check_string_reached_match_limit(event, "default", "r1", "str1", 0),
+            8 => check_rule_match(event, "g1", "default"),
+            9 => check_rule_match(event, "g2", "ns2"),
+            10 => check_rule_match(event, "g3", "ns3"),
+            11 => check_rule_match(event, "r1", "default"),
+            12 => check_rule_match(event, "r2", "ns2"),
+            13 => check_rule_match(event, "r3", "ns3"),
+            14 => check_rule_match(event, "r4", "ns3"),
             _ => (),
         },
     );
@@ -1104,19 +1104,19 @@ global rule g3 {
         b"aaaaa eeeeee fffff kkkkkk lllll nnnnn iiiii ddddd",
         6,
         |event, nb| match nb {
-            0 => check_string_reached_match_limit(event, None, "g1", "str1", 0),
-            1 => check_string_reached_match_limit(event, None, "g3", "", 1),
-            2 => check_string_reached_match_limit(event, None, "g2", "", 2),
-            3 => check_rule_match(event, "g1", None),
-            4 => check_rule_match(event, "g2", None),
-            5 => check_rule_match(event, "g3", None),
+            0 => check_string_reached_match_limit(event, "default", "g1", "str1", 0),
+            1 => check_string_reached_match_limit(event, "default", "g3", "", 1),
+            2 => check_string_reached_match_limit(event, "default", "g2", "", 2),
+            3 => check_rule_match(event, "g1", "default"),
+            4 => check_rule_match(event, "g2", "default"),
+            5 => check_rule_match(event, "g3", "default"),
             _ => (),
         },
     );
 
     scan_mem(&scanner, b"aaaaa kkkkkk", 2, |event, nb| match nb {
-        0 => check_string_reached_match_limit(event, None, "g1", "str1", 0),
-        1 => check_string_reached_match_limit(event, None, "g3", "", 1),
+        0 => check_string_reached_match_limit(event, "default", "g1", "str1", 0),
+        1 => check_string_reached_match_limit(event, "default", "g3", "", 1),
         _ => (),
     });
 }
@@ -1158,20 +1158,20 @@ rule r1 {
 
     scan_mem_with_abort(&scanner, b"aaaaa eeeeee", 0, |event, nb| {
         if nb == 0 {
-            check_string_reached_match_limit(event, None, "g1", "str1", 0)
+            check_string_reached_match_limit(event, "default", "g1", "str1", 0)
         }
     });
 
     scan_mem_with_abort(&scanner, b"aaaaa eeeeee", 1, |event, nb| match nb {
-        0 => check_string_reached_match_limit(event, None, "g1", "str1", 0),
-        1 => check_string_reached_match_limit(event, None, "r1", "str2", 1),
+        0 => check_string_reached_match_limit(event, "default", "g1", "str1", 0),
+        1 => check_string_reached_match_limit(event, "default", "r1", "str2", 1),
         _ => (),
     });
 
     scan_mem_with_abort(&scanner, b"aaaaa eeeeee", 2, |event, nb| match nb {
-        0 => check_string_reached_match_limit(event, None, "g1", "str1", 0),
-        1 => check_string_reached_match_limit(event, None, "r1", "str2", 1),
-        2 => check_rule_match(event, "g1", None),
+        0 => check_string_reached_match_limit(event, "default", "g1", "str1", 0),
+        1 => check_string_reached_match_limit(event, "default", "r1", "str2", 1),
+        2 => check_rule_match(event, "g1", "default"),
         _ => (),
     });
 }

--- a/boreal/tests/it/namespaces.rs
+++ b/boreal/tests/it/namespaces.rs
@@ -73,6 +73,17 @@ fn test_namespaces_errors() {
     );
 }
 
+// Check the default namespace is named "default".
+#[test]
+fn test_namespace_default() {
+    let mut compiler = Compiler::new();
+    compiler.add_rules_in_namespace("rule a { condition: true }", "default");
+    compiler.check_add_rules_err(
+        "rule a { condition: true }",
+        "mem:1:6: error: rule `a` is already declared in this namespace",
+    );
+}
+
 // Dependencies on other rules in a given namespace
 #[test]
 fn test_rule_dependencies() {


### PR DESCRIPTION
Instead of using an `Option<String>` for the namespace name in all the public API, use a string, and use "default" for the default namespace.

This has two benefits:

- It aligns with what yara does
- It makes most of the code using it simpler