### PR TITLE
feat: generate error description in AddRuleError

### DIFF
--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -142,23 +142,14 @@ fn compile(
         (Some(filepath), None, None, None, None) => {
             let res = compiler
                 .add_rules_file(filepath)
-                // TODO: contents
-                .map_err(|err| convert_compiler_error(&err, filepath, ""))
-                .map_err(AddRuleError::new_err)?;
-            warnings = res
-                .warnings()
-                .map(|err| convert_compiler_error(err, filepath, ""))
-                .collect();
+                .map_err(|err| AddRuleError::new_err(format!("{err}")))?;
+            warnings = res.warnings().map(|err| format!("{err}")).collect();
         }
         (None, Some(source), None, None, None) => {
             let res = compiler
                 .add_rules_str(source)
-                .map_err(|err| convert_compiler_error(&err, "source", source))
-                .map_err(AddRuleError::new_err)?;
-            warnings = res
-                .warnings()
-                .map(|err| convert_compiler_error(err, "source", source))
-                .collect();
+                .map_err(|err| AddRuleError::new_err(format!("{err}")))?;
+            warnings = res.warnings().map(|err| format!("{err}")).collect();
         }
         (None, None, Some(file), None, None) => {
             // Read the file into a string
@@ -167,12 +158,8 @@ fn compile(
 
             let res = compiler
                 .add_rules_str(contents)
-                .map_err(|err| convert_compiler_error(&err, "file", contents))
-                .map_err(AddRuleError::new_err)?;
-            warnings = res
-                .warnings()
-                .map(|err| convert_compiler_error(err, "file", contents))
-                .collect();
+                .map_err(|err| AddRuleError::new_err(format!("{err}")))?;
+            warnings = res.warnings().map(|err| format!("{err}")).collect();
         }
         (None, None, None, Some(filepaths), None) => {
             for (key, value) in filepaths {
@@ -184,13 +171,8 @@ fn compile(
                 })?;
                 let res = compiler
                     .add_rules_file_in_namespace(filepath, namespace)
-                    // TODO: contents
-                    .map_err(|err| convert_compiler_error(&err, filepath, ""))
-                    .map_err(AddRuleError::new_err)?;
-                warnings.extend(
-                    res.warnings()
-                        .map(|err| convert_compiler_error(err, filepath, "")),
-                );
+                    .map_err(|err| AddRuleError::new_err(format!("{err}")))?;
+                warnings.extend(res.warnings().map(|err| format!("{err}")));
             }
         }
         (None, None, None, None, Some(sources)) => {
@@ -203,12 +185,8 @@ fn compile(
                 })?;
                 let res = compiler
                     .add_rules_str_in_namespace(source, namespace)
-                    .map_err(|err| convert_compiler_error(&err, namespace, source))
-                    .map_err(AddRuleError::new_err)?;
-                warnings.extend(
-                    res.warnings()
-                        .map(|err| convert_compiler_error(err, namespace, source)),
-                );
+                    .map_err(|err| AddRuleError::new_err(format!("{err}")))?;
+                warnings.extend(res.warnings().map(|err| format!("{err}")));
             }
         }
         _ => return Err(PyTypeError::new_err("invalid arguments passed")),
@@ -311,10 +289,6 @@ fn build_compiler() -> compiler::Compiler {
             }
         }))
         .build()
-}
-
-fn convert_compiler_error(err: &compiler::AddRuleError, input_name: &str, input: &str) -> String {
-    err.to_short_description(input_name, input)
 }
 
 fn add_externals(compiler: &mut compiler::Compiler, externals: &Bound<'_, PyDict>) -> PyResult<()> {

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -283,10 +283,13 @@ fn test_types_traits() {
     });
     test_type_traits_non_clonable(AddRuleError {
         path: None,
-        kind: AddRuleErrorKind::Compilation(CompilationError::DuplicatedRuleName {
-            name: "a".to_owned(),
-            span: 0..1,
-        }),
+        kind: Box::new(AddRuleErrorKind::Compilation(
+            CompilationError::DuplicatedRuleName {
+                name: "a".to_owned(),
+                span: 0..1,
+            },
+        )),
+        desc: String::new(),
     });
     test_type_traits(CompilerParams::default());
     test_type_traits(CompilerProfile::default());

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -42,16 +42,12 @@ fn test_add_rules_file_err() {
     let mut compiler = boreal::Compiler::new();
     let path = "non_existing";
     let err = compiler.add_rules_file(path).unwrap_err();
-    assert!(err
-        .to_short_description(path, "")
-        .starts_with("error: Cannot read rules file non_existing: "));
+    assert!(format!("{}", err).starts_with("error: Cannot read rules file non_existing: "));
 
     let err = compiler
         .add_rules_file_in_namespace(path, "ns")
         .unwrap_err();
-    assert!(err
-        .to_short_description(path, "")
-        .starts_with("error: Cannot read rules file non_existing: "));
+    assert!(format!("{}", err).starts_with("error: Cannot read rules file non_existing: "));
 }
 
 // An import is reused in the same namespace

--- a/boreal/tests/it/libyara_compat/rules.rs
+++ b/boreal/tests/it/libyara_compat/rules.rs
@@ -223,13 +223,13 @@ fn test_arithmetic_operators() {
 
     check_err(
         "rule test { condition: 9007199254740992KB > 0 }",
-        "mem:1:24: error: multiplication 9007199254740992 * 1024 overflows\n",
+        "mem:1:24: error: multiplication 9007199254740992 * 1024 overflows",
     );
 
     check_err(
         // integer too long
         "rule test { condition: 8796093022208MB > 0 }",
-        "mem:1:24: error: multiplication 8796093022208 * 1048576 overflows\n",
+        "mem:1:24: error: multiplication 8796093022208 * 1048576 overflows",
     );
 
     check_err(


### PR DESCRIPTION
This avoids forcing the caller to use the codespan-reporting code to generate the error, which is very awkward when the data came from a file: the file must be re-opened and re-read to generate the error. It also allows cleaning up some ugly code and makes AddRuleError a proper std::errorError.
