### PR TITLE
Finish boreal-py implementation

### DIFF
--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -13,9 +13,6 @@ use pyo3::{create_exception, ffi, intern};
 
 use ::boreal::compiler;
 
-// TODO: all clone impls should be efficient...
-// TODO: check GIL handling in all functions (especially match)
-
 mod module;
 mod rule;
 mod rule_match;

--- a/boreal-py/src/rule.rs
+++ b/boreal-py/src/rule.rs
@@ -95,7 +95,8 @@ fn convert_metadata_value<'py>(
             // XXX: Yara forces a string conversion here, losing data in the
             // process. Prefer using the right type here.
             if YARA_PYTHON_COMPATIBILITY.load(Ordering::SeqCst) {
-                // FIXME: report this to pyo3, a c-string is expected here
+                // The \0 are required for soundness, see
+                // <https://github.com/PyO3/pyo3/issues/5005>
                 PyString::from_object(&bytes, "utf-8\0", "ignore\0")?.into_any()
             } else {
                 bytes

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -100,7 +100,8 @@ impl Scanner {
             scanner.set_module_data::<Console>(ConsoleData::new(move |log| {
                 Python::with_gil(|py| {
                     let pylog = PyString::new(py, &log);
-                    // FIXME: Ignore result
+                    // XXX: Ignore result, we cannot abort a scan here, while this
+                    // is allegedly possible in yara (though who would do this?).
                     let _r = cb.call1(py, (pylog,));
                 });
             }));
@@ -175,7 +176,6 @@ impl Scanner {
         // For the moment, simply disables computing the full matches when
         // in fast mode: this allows all the fast optims to run.
         if !fast {
-            eprintln!("NOT FAST MODE");
             params = params.compute_full_matches(true);
         }
 

--- a/boreal-py/src/string_matches.rs
+++ b/boreal-py/src/string_matches.rs
@@ -25,8 +25,11 @@ pub struct StringMatches {
 impl StringMatches {
     pub fn new(s: scanner::StringMatches) -> Self {
         Self {
-            // FIXME
-            identifier: format!("${}", &s.name),
+            identifier: if YARA_PYTHON_COMPATIBILITY.load(Ordering::SeqCst) {
+                format!("${}", &s.name)
+            } else {
+                s.name.to_string()
+            },
             instances: s
                 .matches
                 .into_iter()

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -386,11 +386,13 @@ rule b { condition: false }
         callback_rules.append(rule)
         return module.CALLBACK_CONTINUE
 
-    matches = rules.match(
-        data='dcabc <3>',
-        which_callbacks=module.CALLBACK_MATCHES,
-        callback=my_callback
-    )
+    # Compat mode to get the '$' prefix for identifiers
+    with YaraCompatibilityMode():
+        matches = rules.match(
+            data='dcabc <3>',
+            which_callbacks=module.CALLBACK_MATCHES,
+            callback=my_callback
+        )
     assert len(matches) == 1
     assert len(callback_rules) == 1
 
@@ -415,7 +417,7 @@ rule b { condition: false }
     assert r.namespace == "default"
     assert r.tags == ["tag1", "tag2"]
     assert r.meta == {
-        's': 'str' if is_yara else b'str',
+        's': 'str',
         'i': -23,
     }
     check_strings(r.strings)
@@ -426,7 +428,7 @@ rule b { condition: false }
     assert r['namespace'] == "default"
     assert r['tags'] == ["tag1", "tag2"]
     assert r['meta'] == {
-        's': 'str' if is_yara else b'str',
+        's': 'str',
         'i': -23,
     }
     check_strings(r['strings'])

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -364,8 +364,8 @@ rule r: tag {
         assert rules[0].namespace == "default"
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)
-def test_match_callback(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_match_callback(module):
     rules = module.compile(source="""
 global rule a: tag1 tag2 {
     meta:
@@ -557,7 +557,7 @@ rule a { condition: true }
 
     rules.match(data='', modules_callback=modules_callback)
 
-    # FIXME: difference with yara here
+    # Difference with yara here, but it's not a big deal.
     if is_yara:
         assert len(received_values) == 2
         assert received_values[0]['module'] == 'math'
@@ -712,7 +712,8 @@ rule my_rule {
     assert len(matches) == 1
 
     # It is also possible to abort
-    # FIXME: this does not work well in yara
+    # this does not work well in yara, it returns an "internal error: 30".
+    # Lets ignore it, this is not a big deal.
     if not is_yara:
         received_values = []
         def warnings_callback(warning_type, message):
@@ -803,8 +804,8 @@ rule my_rule {
         assert len(matches) == 1
 
 
-@pytest.mark.parametrize('module,is_yara', MODULES_DISTINCT)
-def test_save_load_invalid_types(module, is_yara):
+@pytest.mark.parametrize('module', MODULES)
+def test_save_load_invalid_types(module):
     # Do not run the test if boreal was not compiled with the
     # serialize feature
     if not hasattr(boreal, 'load'):

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -203,7 +203,7 @@ rule foo {
     # check special method __repr__
     assert i0.__repr__() == '<a>'
     assert i1.__repr__() == '<\td>'
-    # TODO: difference here, should we care about it?
+    # XXX: difference here, but i don't think this is a big deal.
     assert i2.__repr__() == '<\x00\\xff\\xfb>' if is_yara else '<\x00\uFFFD\uFFFD>'
 
     # In yara, the hash depends only on the matched_data

--- a/boreal-py/tests/test_types.py
+++ b/boreal-py/tests/test_types.py
@@ -124,7 +124,10 @@ rule foo {
     condition:
         any of them
 }""")
-    matches = rule.match(data=b'abca')
+    # Compat mode to get the identifiers with the '$' prefix
+    with YaraCompatibilityMode():
+        matches = rule.match(data=b'abca')
+
     assert len(matches) == 1
     m = matches[0]
     assert len(m.strings) == 3
@@ -151,6 +154,18 @@ rule foo {
     # outside of compat mode, this is not true
     if not is_yara:
         assert hash(s0) != hash(s1)
+
+    # Outside compat mode, we do not have this '$' prefix
+    if not is_yara:
+        matches = rule.match(data=b'abca')
+        m = matches[0]
+        s0 = m.strings[0]
+        s1 = m.strings[1]
+        s2 = m.strings[2]
+
+        assert s0.identifier == ''
+        assert s1.identifier == ''
+        assert s2.identifier == 'c'
 
 
 @pytest.mark.parametrize("module,is_yara", MODULES_DISTINCT)


### PR DESCRIPTION
- Add strict_escape handling for completeness
- Move '$' prefix of string identifiers in yara compat mode
- Clean up the todos and rest of the comments