### PR TITLE
fix: properly handle strict_escape mode in boreal-py

### DIFF
--- a/boreal-py/tests/test_compile.py
+++ b/boreal-py/tests/test_compile.py
@@ -349,3 +349,8 @@ def test_compile_strict_escape(module, is_yara):
         rules = module.compile(source=data)
         assert len(rules.warnings) == 1
         assert "unknown escape sequence" in rules.warnings[0]
+
+    # If disabling strict_escape but making warnings fails the
+    # compilation, compilation should work
+    rules = module.compile(source=data, strict_escape=False, error_on_warning=True)
+    assert len(rules.warnings) == 0

--- a/boreal/src/compiler/params.rs
+++ b/boreal/src/compiler/params.rs
@@ -17,6 +17,9 @@ pub struct CompilerParams {
 
     /// Maximum number of strings in a single rule.
     pub(crate) max_strings_per_rule: usize,
+
+    /// Disable unknown escapes in regex warnings.
+    pub(crate) disable_unknown_escape_warning: bool,
 }
 
 impl Default for CompilerParams {
@@ -27,6 +30,7 @@ impl Default for CompilerParams {
             compute_statistics: false,
             disable_includes: false,
             max_strings_per_rule: 10_000,
+            disable_unknown_escape_warning: false,
         }
     }
 }
@@ -96,6 +100,18 @@ impl CompilerParams {
     #[must_use]
     pub fn max_strings_per_rule(mut self, max_strings_per_rule: usize) -> Self {
         self.max_strings_per_rule = max_strings_per_rule;
+        self
+    }
+
+    /// Disable the "unknown escape sequence" warning.
+    ///
+    /// By default, unknown escape sequences in regexes generate warnings.
+    /// Setting this parameter to true removes those warnings.
+    ///
+    /// Default value is false
+    #[must_use]
+    pub fn disable_unknown_escape_warning(mut self, disable_unknown_escape_warning: bool) -> Self {
+        self.disable_unknown_escape_warning = disable_unknown_escape_warning;
         self
     }
 }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -240,6 +240,12 @@ impl<'a> RuleCompiler<'a> {
     }
 
     pub(super) fn add_warning(&mut self, err: CompilationError) -> Result<(), CompilationError> {
+        if matches!(err, CompilationError::RegexUnknownEscape { .. })
+            && self.params.disable_unknown_escape_warning
+        {
+            return Ok(());
+        }
+
         if self.params.fail_on_warnings {
             Err(err)
         } else {

--- a/boreal/tests/it/warning.rs
+++ b/boreal/tests/it/warning.rs
@@ -117,3 +117,20 @@ fn test_fail_on_warning_param() {
         "mem:1:21: warning: implicit cast from a bytes value to a boolean",
     );
 }
+
+#[test]
+fn test_disable_unknown_escape_warning() {
+    let mut compiler = Compiler::new();
+
+    let params = boreal::compiler::CompilerParams::default()
+        .fail_on_warnings(true)
+        .disable_unknown_escape_warning(true);
+    compiler.set_params(params);
+    compiler.add_rules(
+        r"
+rule a {
+    condition:
+        /\V/
+}",
+    );
+}


### PR DESCRIPTION
To properly handle disabling this mode, this needs to be handled inside boreal, so that the fail_on_warning flag do not make the compilation fail on such warnings.