### PR TITLE
Add serialize/deserialize and yara-x in benchmarks

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dev-dependencies]
-boreal = { path = "../boreal", version = "*", features = ["authenticode"] }
+boreal = { path = "../boreal", version = "*", features = ["authenticode", "serialize"] }
 criterion = "0.5"
 glob = "0.3.1"
 walkdir = "2.3"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/vthib/boreal"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 
-[dev-dependencies]
+[dependencies]
 boreal = { path = "../boreal", version = "*", features = ["authenticode", "serialize"] }
 criterion = "0.5"
 glob = "0.3.1"
@@ -22,6 +22,10 @@ path = "src/bench.rs"
 
 [lib]
 bench = false
+
+[[bin]]
+name = "serialized-size"
+path = "src/serialized_size.rs"
 
 # Keep it outside the boreal workspace, criterion and yara-x are way too
 # chunky, I don't want it polluting the Cargo.lock

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,7 @@ boreal = { path = "../boreal", version = "*", features = ["authenticode"] }
 criterion = "0.5"
 glob = "0.3.1"
 walkdir = "2.3"
-yara = { version = "0.19", features = ["vendored"] }
+yara = { version = "0.30", features = ["vendored"] }
 
 [[bench]]
 name = "boreal"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,6 +13,7 @@ criterion = "0.5"
 glob = "0.3.1"
 walkdir = "2.3"
 yara = { version = "0.30", features = ["vendored"] }
+yara-x = "0.14"
 
 [[bench]]
 name = "boreal"
@@ -22,6 +23,6 @@ path = "src/bench.rs"
 [lib]
 bench = false
 
-# Keep it outside the boreal workspace, criterion is too
-# chunky, I don't want it polluting by Cargo.lock
+# Keep it outside the boreal workspace, criterion and yara-x are way too
+# chunky, I don't want it polluting the Cargo.lock
 [workspace]

--- a/benches/src/bench.rs
+++ b/benches/src/bench.rs
@@ -1,27 +1,12 @@
 //! Benchmarks boreal against libyara
 use std::path::PathBuf;
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion, SamplingMode};
-use walkdir::WalkDir;
+use boreal_benches::{
+    build_boreal_compiler, build_boreal_scanner, build_yara_compiler, build_yara_rules,
+    build_yara_x_compiler, build_yara_x_rules, get_yara_files_from_path, RULES_SETS,
+};
 
-const RULES_SETS: [(&str, &str); 7] = [
-    // 100 rules, 1998 variables
-    ("panopticon", "assets/panopticon/baseline_100.yar"),
-    // 4297 rules, 23630 vars
-    ("signature-base", "assets/signature-base/yara"),
-    // 147 rules, 644 variables
-    ("orion", "assets/orion"),
-    // 632 rules, 1536 variables
-    ("reversinglabs", "assets/reversinglabs"),
-    // 167 rules, 1408 variables
-    ("atr", "assets/atr"),
-    // 16431 rules, 13155 variables
-    ("icewater", "assets/icewater"),
-    // 121 rules, 5390 variables
-    ("c0ffee", "assets/c0ffee/rules.yar"),
-    // Extremely slow
-    // ("assets/yara-rules/index.yar", 12771),
-];
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, SamplingMode};
 
 fn setup_benches(c: &mut Criterion) {
     for (name, rules_path) in &RULES_SETS {
@@ -212,109 +197,6 @@ fn bench_deserialization(
     });
 
     group.finish();
-}
-
-fn build_boreal_compiler() -> boreal::Compiler {
-    let mut boreal_compiler = boreal::compiler::CompilerBuilder::new()
-        .profile(boreal::compiler::CompilerProfile::Speed)
-        .build();
-    let _ = boreal_compiler.define_symbol("owner", "owner");
-    let _ = boreal_compiler.define_symbol("filename", "filename");
-    let _ = boreal_compiler.define_symbol("filepath", "filepath");
-    let _ = boreal_compiler.define_symbol("extension", "bin");
-    let _ = boreal_compiler.define_symbol("filetype", "bin");
-    boreal_compiler
-}
-
-fn build_yara_compiler() -> yara::Compiler {
-    let mut yara_compiler = yara::Compiler::new().unwrap();
-    let _ = yara_compiler.define_variable("owner", "owner");
-    let _ = yara_compiler.define_variable("filename", "filename");
-    let _ = yara_compiler.define_variable("filepath", "filepath");
-    let _ = yara_compiler.define_variable("extension", "bin");
-    let _ = yara_compiler.define_variable("filetype", "bin");
-    yara_compiler
-}
-
-fn build_yara_x_compiler<'a>() -> yara_x::Compiler<'a> {
-    let mut compiler = yara_x::Compiler::new();
-    compiler.relaxed_re_syntax(true);
-    let _ = compiler.define_global("owner", "owner");
-    let _ = compiler.define_global("filename", "filename");
-    let _ = compiler.define_global("filepath", "filepath");
-    let _ = compiler.define_global("extension", "bin");
-    let _ = compiler.define_global("filetype", "bin");
-    compiler
-}
-
-fn get_yara_files_from_path(path: &str) -> Vec<PathBuf> {
-    WalkDir::new(path)
-        .into_iter()
-        .filter_map(|entry| {
-            let entry = entry.unwrap();
-            let path = entry.path();
-
-            if entry.file_type().is_dir() {
-                return None;
-            }
-
-            entry.path().extension().and_then(|ext| {
-                let ext = ext.to_string_lossy();
-                if ext == "yar" || ext == "yara" {
-                    Some(path.to_path_buf())
-                } else {
-                    None
-                }
-            })
-        })
-        .collect()
-}
-
-fn build_boreal_scanner(rules: &[PathBuf]) -> boreal::Scanner {
-    let mut boreal_compiler = build_boreal_compiler();
-
-    for path in rules {
-        boreal_compiler.add_rules_file(path).unwrap_or_else(|err| {
-            panic!(
-                "cannot parse rules from {} for boreal: {:?}",
-                path.display(),
-                err
-            )
-        });
-    }
-    boreal_compiler.into_scanner()
-}
-
-fn build_yara_rules(rules: &[PathBuf]) -> yara::Rules {
-    let mut yara_compiler = build_yara_compiler();
-    for path in rules {
-        yara_compiler = yara_compiler.add_rules_file(path).unwrap_or_else(|err| {
-            panic!(
-                "cannot parse rules from {} for libyara: {:?}",
-                path.display(),
-                err
-            )
-        });
-    }
-
-    yara_compiler.compile_rules().unwrap()
-}
-
-fn build_yara_x_rules(rules: &[PathBuf]) -> yara_x::Rules {
-    let mut yara_x_compiler = build_yara_x_compiler();
-    for path in rules {
-        yara_x_compiler
-            .add_source(&*std::fs::read_to_string(path).unwrap())
-            .unwrap_or_else(|err| {
-                panic!(
-                    "cannot parse rules from {} for yara_x: {:?}",
-                    path.display(),
-                    err
-                )
-            });
-    }
-
-    yara_x_compiler.build()
 }
 
 criterion_group!(benches, setup_benches);

--- a/benches/src/bench.rs
+++ b/benches/src/bench.rs
@@ -23,93 +23,94 @@ const RULES_SETS: [(&str, &str); 7] = [
     // ("assets/yara-rules/index.yar", 12771),
 ];
 
-/// Bench parsing + compilation duration
-fn bench_compilation(c: &mut Criterion) {
+fn setup_benches(c: &mut Criterion) {
     for (name, rules_path) in &RULES_SETS {
         let rules = get_yara_files_from_path(rules_path);
 
-        let mut group = c.benchmark_group(format!("Parse and compile {}", name));
-        group.sample_size(20);
-        group.bench_with_input("boreal", &rules, |b, rules| {
-            b.iter_with_large_drop(|| {
-                let mut compiler = build_boreal_compiler();
-                for path in rules {
-                    compiler.add_rules_file(path).unwrap();
-                }
-                compiler.into_scanner()
-            })
-        });
-        group.bench_with_input("libyara", &rules, |b, rules| {
-            b.iter_with_large_drop(|| {
-                let mut compiler = build_yara_compiler();
-                for path in rules {
-                    compiler = compiler.add_rules_file(path).unwrap();
-                }
-                compiler.compile_rules().unwrap()
-            })
-        });
+        bench_compilation(c, name, &rules);
 
-        group.finish();
+        let boreal_scanner = build_boreal_scanner(&rules);
+        let yara_rules = build_yara_rules(&rules);
+
+        bench_scan_pes(c, name, &boreal_scanner, &yara_rules);
+        bench_scan_process(c, name, &boreal_scanner, &yara_rules);
     }
+}
+
+/// Bench parsing + compilation duration
+fn bench_compilation(c: &mut Criterion, rules_name: &str, rules: &[PathBuf]) {
+    let mut group = c.benchmark_group(format!("Parse and compile {}", rules_name));
+    group.sample_size(20);
+    group.bench_with_input("boreal", rules, |b, rules| {
+        b.iter_with_large_drop(|| {
+            let mut compiler = build_boreal_compiler();
+            for path in rules {
+                compiler.add_rules_file(path).unwrap();
+            }
+            compiler.into_scanner()
+        })
+    });
+    group.bench_with_input("libyara", rules, |b, rules| {
+        b.iter_with_large_drop(|| {
+            let mut compiler = build_yara_compiler();
+            for path in rules {
+                compiler = compiler.add_rules_file(path).unwrap();
+            }
+            compiler.compile_rules().unwrap()
+        })
+    });
+
+    group.finish();
 }
 
 /// Bench scanning single PE files with different amount of rules
-fn bench_scan_pes(c: &mut Criterion) {
-    for (name, rules_path) in &RULES_SETS {
-        // Test files in assets/pes
-        for pe_path in glob::glob("assets/pes/*").unwrap() {
-            let pe_path = pe_path.unwrap();
-            let mem = std::fs::read(&pe_path).expect("can read asset file");
+fn bench_scan_pes(
+    c: &mut Criterion,
+    rules_name: &str,
+    boreal_scanner: &boreal::Scanner,
+    yara_rules: &yara::Rules,
+) {
+    // Test files in assets/pes
+    for pe_path in glob::glob("assets/pes/*").unwrap() {
+        let pe_path = pe_path.unwrap();
+        let mem = std::fs::read(&pe_path).expect("can read asset file");
 
-            let mut boreal_compiler = build_boreal_compiler();
-            let yara_compiler = build_yara_compiler();
-
-            let rules = get_yara_files_from_path(rules_path);
-            let yara_compiler = add_rules(&rules, &mut boreal_compiler, yara_compiler);
-
-            let boreal_scanner = boreal_compiler.into_scanner();
-            let yara_compiled_rules = yara_compiler.compile_rules().unwrap();
-
-            let mut group =
-                c.benchmark_group(format!("Scan {} using {} rules", pe_path.display(), name));
-            group.sample_size(20);
-            group.bench_with_input("boreal", &(boreal_scanner, &mem), |b, (scanner, mem)| {
-                b.iter(|| scanner.scan_mem(mem))
-            });
-            group.bench_with_input("libyara", &(yara_compiled_rules, &mem), |b, (yara, mem)| {
-                b.iter(|| yara.scan_mem(mem, 30))
-            });
-
-            group.finish();
-        }
-    }
-}
-
-fn bench_scan_process(c: &mut Criterion) {
-    // To update accordingly when benching the scan of a process.
-    let pid = 19766;
-
-    for (name, rules_path) in &RULES_SETS {
-        let mut boreal_compiler = build_boreal_compiler();
-        let yara_compiler = build_yara_compiler();
-
-        let rules = get_yara_files_from_path(rules_path);
-        let yara_compiler = add_rules(&rules, &mut boreal_compiler, yara_compiler);
-
-        let boreal_scanner = boreal_compiler.into_scanner();
-        let yara_compiled_rules = yara_compiler.compile_rules().unwrap();
-
-        let mut group = c.benchmark_group(format!("Scan process {} using {} rules", pid, name));
+        let mut group = c.benchmark_group(format!(
+            "Scan {} using {} rules",
+            pe_path.display(),
+            rules_name
+        ));
         group.sample_size(20);
-        group.bench_with_input("boreal", &boreal_scanner, |b, scanner| {
-            b.iter(|| scanner.scan_process(pid))
+        group.bench_with_input("boreal", &(boreal_scanner, &mem), |b, (scanner, mem)| {
+            b.iter(|| scanner.scan_mem(mem))
         });
-        group.bench_with_input("libyara", &yara_compiled_rules, |b, yara| {
-            b.iter(|| yara.scan_process(pid, 0))
+        group.bench_with_input("libyara", &(yara_rules, &mem), |b, (rules, mem)| {
+            b.iter(|| rules.scan_mem(mem, 30))
         });
 
         group.finish();
     }
+}
+
+fn bench_scan_process(
+    c: &mut Criterion,
+    rules_name: &str,
+    boreal_scanner: &boreal::Scanner,
+    yara_rules: &yara::Rules,
+) {
+    // To update accordingly when benching the scan of a process.
+    let pid = 19766;
+
+    let mut group = c.benchmark_group(format!("Scan process {} using {} rules", pid, rules_name));
+    group.sample_size(20);
+    group.bench_with_input("boreal", &boreal_scanner, |b, scanner| {
+        b.iter(|| scanner.scan_process(pid))
+    });
+    group.bench_with_input("libyara", &yara_rules, |b, rules| {
+        b.iter(|| rules.scan_process(pid, 0))
+    });
+
+    group.finish();
 }
 
 fn build_boreal_compiler() -> boreal::Compiler {
@@ -145,26 +146,21 @@ fn get_yara_files_from_path(path: &str) -> Vec<PathBuf> {
                 return None;
             }
 
-            match entry.path().extension() {
-                Some(v) => {
-                    let ext = v.to_string_lossy();
-                    if ext != "yar" && ext != "yara" {
-                        return None;
-                    }
+            entry.path().extension().and_then(|ext| {
+                let ext = ext.to_string_lossy();
+                if ext == "yar" || ext == "yara" {
+                    Some(path.to_path_buf())
+                } else {
+                    None
                 }
-                None => return None,
-            }
-
-            Some(path.to_path_buf())
+            })
         })
         .collect()
 }
 
-fn add_rules(
-    rules: &[PathBuf],
-    boreal_compiler: &mut boreal::Compiler,
-    mut yara_compiler: yara::Compiler,
-) -> yara::Compiler {
+fn build_boreal_scanner(rules: &[PathBuf]) -> boreal::Scanner {
+    let mut boreal_compiler = build_boreal_compiler();
+
     for path in rules {
         boreal_compiler.add_rules_file(path).unwrap_or_else(|err| {
             panic!(
@@ -173,6 +169,13 @@ fn add_rules(
                 err
             )
         });
+    }
+    boreal_compiler.into_scanner()
+}
+
+fn build_yara_rules(rules: &[PathBuf]) -> yara::Rules {
+    let mut yara_compiler = build_yara_compiler();
+    for path in rules {
         yara_compiler = yara_compiler.add_rules_file(path).unwrap_or_else(|err| {
             panic!(
                 "cannot parse rules from {} for libyara: {:?}",
@@ -182,13 +185,8 @@ fn add_rules(
         });
     }
 
-    yara_compiler
+    yara_compiler.compile_rules().unwrap()
 }
 
-criterion_group!(
-    benches,
-    bench_compilation,
-    bench_scan_pes,
-    bench_scan_process
-);
+criterion_group!(benches, setup_benches);
 criterion_main!(benches);

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,1 +1,127 @@
 // See src/bench.rs
+
+use std::path::PathBuf;
+
+use walkdir::WalkDir;
+
+pub const RULES_SETS: [(&str, &str); 7] = [
+    // 100 rules, 1998 variables
+    ("panopticon", "assets/panopticon/baseline_100.yar"),
+    // 4297 rules, 23630 vars
+    ("signature-base", "assets/signature-base/yara"),
+    // 147 rules, 644 variables
+    ("orion", "assets/orion"),
+    // 632 rules, 1536 variables
+    ("reversinglabs", "assets/reversinglabs"),
+    // 167 rules, 1408 variables
+    ("atr", "assets/atr"),
+    // 16431 rules, 13155 variables
+    ("icewater", "assets/icewater"),
+    // 121 rules, 5390 variables
+    ("c0ffee", "assets/c0ffee/rules.yar"),
+    // Extremely slow
+    // ("assets/yara-rules/index.yar", 12771),
+];
+
+pub fn get_yara_files_from_path(path: &str) -> Vec<PathBuf> {
+    WalkDir::new(path)
+        .into_iter()
+        .filter_map(|entry| {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            if entry.file_type().is_dir() {
+                return None;
+            }
+
+            entry.path().extension().and_then(|ext| {
+                let ext = ext.to_string_lossy();
+                if ext == "yar" || ext == "yara" {
+                    Some(path.to_path_buf())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect()
+}
+
+pub fn build_boreal_compiler() -> boreal::Compiler {
+    let mut boreal_compiler = boreal::compiler::CompilerBuilder::new()
+        .profile(boreal::compiler::CompilerProfile::Speed)
+        .build();
+    let _ = boreal_compiler.define_symbol("owner", "owner");
+    let _ = boreal_compiler.define_symbol("filename", "filename");
+    let _ = boreal_compiler.define_symbol("filepath", "filepath");
+    let _ = boreal_compiler.define_symbol("extension", "bin");
+    let _ = boreal_compiler.define_symbol("filetype", "bin");
+    boreal_compiler
+}
+
+pub fn build_yara_compiler() -> yara::Compiler {
+    let mut yara_compiler = yara::Compiler::new().unwrap();
+    let _ = yara_compiler.define_variable("owner", "owner");
+    let _ = yara_compiler.define_variable("filename", "filename");
+    let _ = yara_compiler.define_variable("filepath", "filepath");
+    let _ = yara_compiler.define_variable("extension", "bin");
+    let _ = yara_compiler.define_variable("filetype", "bin");
+    yara_compiler
+}
+
+pub fn build_yara_x_compiler<'a>() -> yara_x::Compiler<'a> {
+    let mut compiler = yara_x::Compiler::new();
+    compiler.relaxed_re_syntax(true);
+    let _ = compiler.define_global("owner", "owner");
+    let _ = compiler.define_global("filename", "filename");
+    let _ = compiler.define_global("filepath", "filepath");
+    let _ = compiler.define_global("extension", "bin");
+    let _ = compiler.define_global("filetype", "bin");
+    compiler
+}
+
+pub fn build_boreal_scanner(rules: &[PathBuf]) -> boreal::Scanner {
+    let mut boreal_compiler = build_boreal_compiler();
+
+    for path in rules {
+        boreal_compiler.add_rules_file(path).unwrap_or_else(|err| {
+            panic!(
+                "cannot parse rules from {} for boreal: {:?}",
+                path.display(),
+                err
+            )
+        });
+    }
+    boreal_compiler.into_scanner()
+}
+
+pub fn build_yara_rules(rules: &[PathBuf]) -> yara::Rules {
+    let mut yara_compiler = build_yara_compiler();
+    for path in rules {
+        yara_compiler = yara_compiler.add_rules_file(path).unwrap_or_else(|err| {
+            panic!(
+                "cannot parse rules from {} for libyara: {:?}",
+                path.display(),
+                err
+            )
+        });
+    }
+
+    yara_compiler.compile_rules().unwrap()
+}
+
+pub fn build_yara_x_rules(rules: &[PathBuf]) -> yara_x::Rules {
+    let mut yara_x_compiler = build_yara_x_compiler();
+    for path in rules {
+        yara_x_compiler
+            .add_source(&*std::fs::read_to_string(path).unwrap())
+            .unwrap_or_else(|err| {
+                panic!(
+                    "cannot parse rules from {} for yara_x: {:?}",
+                    path.display(),
+                    err
+                )
+            });
+    }
+
+    yara_x_compiler.build()
+}

--- a/benches/src/serialized_size.rs
+++ b/benches/src/serialized_size.rs
@@ -1,0 +1,39 @@
+use boreal_benches::{
+    build_boreal_scanner, build_yara_rules, build_yara_x_rules, get_yara_files_from_path,
+    RULES_SETS,
+};
+
+fn main() {
+    for (name, rules_path) in &RULES_SETS {
+        println!("{name}:");
+
+        let rules = get_yara_files_from_path(rules_path);
+
+        let boreal_scanner = build_boreal_scanner(&rules);
+        let mut yara_rules = build_yara_rules(&rules);
+        let yara_x_rules = build_yara_x_rules(&rules);
+
+        let mut out = Vec::new();
+        boreal_scanner.to_bytes(&mut out).unwrap();
+        println!("boreal: {}", datasize(out.len()));
+
+        let mut out = Vec::new();
+        yara_rules.save_to_stream(&mut out).unwrap();
+        println!("yara:   {}", datasize(out.len()));
+
+        let out = yara_x_rules.serialize().unwrap();
+        println!("yara-x: {}", datasize(out.len()));
+
+        println!("");
+    }
+}
+
+fn datasize(v: usize) -> String {
+    if v > 1024 * 1024 {
+        format!("{:.2}MB", (v as f64) / 1024. / 1024.)
+    } else if v > 1024 {
+        format!("{:.2}KB", (v as f64) / 1024.)
+    } else {
+        format!("{}B", v)
+    }
+}


### PR DESCRIPTION
- Rework how benches are declared to reduce the setup time
- Add yara-x as a point of comparison in benches
- Add serialize/deserialize benchmarks
- Add binary to easily compute and compare serialized size