### PR TITLE
Allow passing multiple rules file and specifying namespace in boreal-cli

### DIFF
--- a/boreal-cli/src/args/callback.rs
+++ b/boreal-cli/src/args/callback.rs
@@ -55,8 +55,9 @@ pub fn add_callback_args(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Print strings matches")
                 .long_help(
-                    "Note that enabling this parameter will force the \
-                     computation of all string matches,\ndisabling \
+                    "Print strings matches.\n\n\
+                     Note that enabling this parameter will force the\
+                     computation of all string matches,\ndisabling\
                      the no scan optimization in the process.",
                 ),
         )
@@ -67,8 +68,9 @@ pub fn add_callback_args(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Print the length of strings matches")
                 .long_help(
-                    "Note that enabling this parameter will force the \
-                     computation of all string matches,\ndisabling \
+                    "Print the length of strings matches.\n\n\
+                     Note that enabling this parameter will force the\
+                     computation of all string matches,\ndisabling\
                      the no scan optimization in the process.",
                 ),
         )
@@ -79,8 +81,9 @@ pub fn add_callback_args(command: Command) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Print the xor key and the plaintext of matched strings")
                 .long_help(
-                    "Note that enabling this parameter will force the \
-                     computation of all string matches,\ndisabling \
+                    "Print the xor key and the plaintext of matched strings.\n\n\
+                     Note that enabling this parameter will force the\
+                     computation of all string matches,\ndisabling\
                      the no scan optimization in the process.",
                 ),
         )

--- a/boreal-cli/src/args/compiler.rs
+++ b/boreal-cli/src/args/compiler.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use boreal::compiler::{CompilerProfile, ExternalValue};
 use clap::parser::Values;
 use clap::{value_parser, Arg, ArgAction, ArgMatches, Command};
@@ -10,21 +8,18 @@ pub struct CompilerOptions {
     pub compute_statistics: bool,
     pub max_strings_per_rule: Option<usize>,
     pub defines: Option<Values<(String, ExternalValue)>>,
-    pub rules_files: Vec<PathBuf>,
+    pub rules_files: Vec<String>,
 }
 
 impl CompilerOptions {
-    pub fn from_args(args: &mut ArgMatches, in_yr_subcommand: bool) -> Self {
+    pub fn from_args(args: &mut ArgMatches, rules_files: Option<Vec<String>>) -> Self {
         // In the yr subcommand, rules_file are part of the positional arguments,
         // and are parsed differently.
-        let rules_files = if in_yr_subcommand {
-            Vec::new()
-        } else {
-            match args.remove_many::<PathBuf>("rules_file") {
+        let rules_files =
+            rules_files.unwrap_or_else(|| match args.remove_many::<String>("rules_file") {
                 Some(v) => v.into_iter().collect(),
                 None => Vec::new(),
-            }
-        };
+            });
 
         Self {
             profile: args.remove_one::<CompilerProfile>("profile"),
@@ -75,7 +70,6 @@ pub fn add_compiler_args(mut command: Command, in_yr_subcommand: bool) -> Comman
                 .short('f')
                 .long("rules-file")
                 .value_name("RULES_FILE")
-                .value_parser(value_parser!(PathBuf))
                 .action(ArgAction::Append)
                 .help("Path to a file containing rules, can be repeated."),
         );

--- a/boreal-cli/src/args/compiler.rs
+++ b/boreal-cli/src/args/compiler.rs
@@ -69,9 +69,16 @@ pub fn add_compiler_args(mut command: Command, in_yr_subcommand: bool) -> Comman
             Arg::new("rules_file")
                 .short('f')
                 .long("rules-file")
-                .value_name("RULES_FILE")
+                .value_name("[NAMESPACE:]RULES_FILE")
                 .action(ArgAction::Append)
-                .help("Path to a file containing rules, can be repeated."),
+                .help("Path to a file containing rules, can be repeated.")
+                .long_help(
+                    "Path to a file containing rules, can be repeated.\n\n\
+                     The path can be prefixed by the namespace in which to\
+                     compile the rules, followed by a colon.\n\
+                     This can notably be used to avoid name collisions when\
+                     using multiple rules files.",
+                ),
         );
     }
 

--- a/boreal-cli/src/args/input.rs
+++ b/boreal-cli/src/args/input.rs
@@ -12,7 +12,7 @@ pub struct InputOptions {
 }
 
 impl InputOptions {
-    pub fn from_args(args: &mut ArgMatches) -> Self {
+    pub fn from_args(args: &mut ArgMatches, input: Option<String>) -> Self {
         let no_mmap = if cfg!(feature = "memmap") {
             args.get_flag("no_mmap")
         } else {
@@ -31,7 +31,7 @@ impl InputOptions {
             no_follow_symlinks: args.get_flag("no_follow_symlinks"),
             recursive: args.get_flag("recursive"),
             skip_larger: args.remove_one::<u64>("skip_larger"),
-            input: args.remove_one("input").unwrap(),
+            input: input.unwrap_or_else(|| args.remove_one("input").unwrap()),
             no_mmap,
             nb_threads,
         }
@@ -93,14 +93,14 @@ pub fn add_input_args(command: Command, in_yr_subcommand: bool) -> Command {
         );
     }
 
-    let mut input_arg = Arg::new("input")
-        .value_name("FILE | DIRECTORY | PID")
-        .value_parser(value_parser!(String))
-        .help("File, directory or pid to scan");
-    if in_yr_subcommand {
-        input_arg = input_arg.required_unless_present("module_names");
+    if !in_yr_subcommand {
+        command = command.next_help_heading(None).arg(
+            Arg::new("input")
+                .value_name("FILE | DIRECTORY | PID")
+                .value_parser(value_parser!(String))
+                .help("File, directory or pid to scan"),
+        );
     }
-    command = command.next_help_heading(None).arg(input_arg);
 
     command
 }

--- a/boreal-cli/src/args/input.rs
+++ b/boreal-cli/src/args/input.rs
@@ -85,7 +85,7 @@ pub fn add_input_args(command: Command, in_yr_subcommand: bool) -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Disable the use of memory maps.")
                 .long_help(
-                    "Disable the use of memory maps.\n\
+                    "Disable the use of memory maps.\n\n\
                     By default, memory maps are used to load files to scan.\n\
                     This can cause the program to abort unexpectedly \
                     if files are simultaneous truncated.",
@@ -96,9 +96,18 @@ pub fn add_input_args(command: Command, in_yr_subcommand: bool) -> Command {
     if !in_yr_subcommand {
         command = command.next_help_heading(None).arg(
             Arg::new("input")
-                .value_name("FILE | DIRECTORY | PID")
+                .value_name("FILE | DIRECTORY | PID | SCAN_LIST")
                 .value_parser(value_parser!(String))
-                .help("File, directory or pid to scan"),
+                .help("Target to scan")
+                .long_help(
+                    "Target to scan.\n\n\
+This can be either:\n
+  - A path to a file.
+  - A path to a directory, in which files will be scanned.
+  - The pid of the a process to scan.
+  - A file containing a list of targets to scan, one per line, if --scan-list\
+    is specified.",
+                ),
         );
     }
 

--- a/boreal-cli/src/args/mod.rs
+++ b/boreal-cli/src/args/mod.rs
@@ -101,9 +101,10 @@ fn build_yr_subcommand() -> Command {
         .long_about(
             "This subcommand allows specifying options exactly as done with the yara CLI.\n\
              This allows substituting uses of the yara CLI without risks.\n\
-             This API can be a bit ambiguous at times with multiple rules inputs, and many options\n\
+             This API can be a bit ambiguous at times with multiple rules inputs, and many options\
              can be specified that will not be used in some contexts.\n\
-             For these reasons, using the other subcommands is recommended for improved clarity.");
+             For these reasons, using the other subcommands is recommended for improved clarity.",
+        );
 
     if cfg!(feature = "serialize") {
         command = command.arg(
@@ -113,10 +114,10 @@ fn build_yr_subcommand() -> Command {
                 .action(ArgAction::SetTrue)
                 .help("Load compiled rules from bytes.")
                 .long_help(
-                    "Load compiled rules from bytes.\n\
-                    If specified, then a single rules path must be \n\
-                    specified, which must point to a file containing \n\
-                    serialized rules.\n
+                    "Load compiled rules from bytes.\n\n\
+                    If specified, then a single rules path must be\
+                    specified, which must point to a file containing\
+                    serialized rules.\n\
                     See the scan subcommand for how to generate such a file.",
                 ),
         );
@@ -190,8 +191,9 @@ impl CompileScanExecution {
 }
 
 fn build_scan_subcommand() -> Command {
-    let mut command =
-        Command::new("scan").about("Compile rules and scan a file, a directory or a process");
+    let mut command = Command::new("scan")
+        .about("Compile rules and scan a target")
+        .override_usage("boreal scan [OPTIONS] [-f RULES]... [FILE | DIRECTORY | PID | SCAN_LIST]");
 
     command = add_warnings_args(command);
     command = compiler::add_compiler_args(command, false);
@@ -219,18 +221,19 @@ impl CompileSaveExecution {
         Self {
             warning_mode,
             compiler_options: CompilerOptions::from_args(&mut args, None),
-            destination_path: args.remove_one("destination_path").unwrap(),
+            destination_path: args.remove_one("output_file").unwrap(),
         }
     }
 }
 
 #[cfg(feature = "serialize")]
 fn build_save_subcommand() -> Command {
-    let mut command =
-        Command::new("save").about("Compile rules and serialize the results into a file");
+    let mut command = Command::new("save")
+        .about("Compile rules and serialize the results into a file")
+        .override_usage("boreal save [OPTIONS] [-f RULES]... [OUTPUT_FILE]");
 
     command = command.arg(
-        Arg::new("destination_path")
+        Arg::new("output_file")
             .value_parser(value_parser!(PathBuf))
             .help("Path where the serialization of the compiled rules will be written"),
     );

--- a/boreal-cli/src/args/mod.rs
+++ b/boreal-cli/src/args/mod.rs
@@ -143,11 +143,21 @@ fn build_yr_subcommand() -> Command {
                 .action(ArgAction::Append)
                 .help("List of rules file followed by the file, directory or pid to scan")
                 .long_help(
-                    "At least two arguments must be specified: the path to the \n\
-                rules file, and the input to scan. Several rules files can \n\
-                be specified: the last argument will always be the input to \n\
+                    "List of rules file followed by the file, directory or pid to scan.\n\n\
+\
+                [NAMESPACE:]RULES_FILE... [FILE | DIRECTORY | PID | SCAN_LIST]\n\n\
+\
+                At least two arguments must be specified: the path to the\
+                rules file, and the input to scan.\nSeveral rules files can\
+                be specified: the last argument will always be the input to\
                 scan.\n\n\
-                If --scan-list is specified, the input is a file containing \n\
+\
+                The path to rules files can be prefixed by the namespace in\
+                which to compile the rules, followed by a colon.\n\
+                This can notably be used to avoid name collisions when\
+                using multiple rules files.\n\n\
+\
+                If --scan-list is specified, the input is a file containing\
                 a list of inputs to scan, one per line.",
                 )
                 .required_unless_present("module_names"),

--- a/boreal-cli/src/args/mod.rs
+++ b/boreal-cli/src/args/mod.rs
@@ -39,7 +39,7 @@ impl ExecutionMode {
 
         let positional_args: Values<String> = args.remove_many("args").unwrap();
         if positional_args.len() < 2 {
-            return Err("invalid number of arguments, at least one rules file \
+            return Err("Invalid number of arguments, at least one rules file \
                 and a scan target must be specified"
                 .to_owned());
         }
@@ -55,7 +55,7 @@ impl ExecutionMode {
         #[cfg(feature = "serialize")]
         if args.get_flag("load_from_bytes") {
             if rules_files.len() != 1 {
-                return Err("One a single rules path must be passed when -C is used".to_owned());
+                return Err("Only a single rules path must be passed when -C is used".to_owned());
             }
             return Ok(Self::LoadAndScan(LoadScanExecution {
                 scanner_options,

--- a/boreal-cli/src/args/scanner.rs
+++ b/boreal-cli/src/args/scanner.rs
@@ -77,7 +77,7 @@ pub fn add_scanner_args(command: Command) -> Command {
                 .value_parser(parse_module_data)
                 .help("Specify the data to use in a module")
                 .long_help(
-                    "Specify the data to use in a module.\n\
+                    "Specify the data to use in a module.\n\n\
                      Note that only the cuckoo module is supported.",
                 ),
         )


### PR DESCRIPTION
As is possible in yara CLI, allow passing multiple rules files, and allow specifying a namespace.
This makes the semantics of the yr subcommand a bit dubious, hence why it was separated in its own subcommand. For the `scan` subcommand, rules files must now be specified using the `-f` flag.