### PR TITLE
Add ignored arguments in boreal cli

### DIFF
--- a/boreal-cli/src/args/callback.rs
+++ b/boreal-cli/src/args/callback.rs
@@ -56,8 +56,8 @@ pub fn add_callback_args(command: Command) -> Command {
                 .help("Print strings matches")
                 .long_help(
                     "Print strings matches.\n\n\
-                     Note that enabling this parameter will force the\
-                     computation of all string matches,\ndisabling\
+                     Note that enabling this parameter will force the \
+                     computation of all string matches,\ndisabling \
                      the no scan optimization in the process.",
                 ),
         )
@@ -69,8 +69,8 @@ pub fn add_callback_args(command: Command) -> Command {
                 .help("Print the length of strings matches")
                 .long_help(
                     "Print the length of strings matches.\n\n\
-                     Note that enabling this parameter will force the\
-                     computation of all string matches,\ndisabling\
+                     Note that enabling this parameter will force the \
+                     computation of all string matches,\ndisabling \
                      the no scan optimization in the process.",
                 ),
         )
@@ -82,8 +82,8 @@ pub fn add_callback_args(command: Command) -> Command {
                 .help("Print the xor key and the plaintext of matched strings")
                 .long_help(
                     "Print the xor key and the plaintext of matched strings.\n\n\
-                     Note that enabling this parameter will force the\
-                     computation of all string matches,\ndisabling\
+                     Note that enabling this parameter will force the \
+                     computation of all string matches,\ndisabling \
                      the no scan optimization in the process.",
                 ),
         )

--- a/boreal-cli/src/args/compiler.rs
+++ b/boreal-cli/src/args/compiler.rs
@@ -74,9 +74,9 @@ pub fn add_compiler_args(mut command: Command, in_yr_subcommand: bool) -> Comman
                 .help("Path to a file containing rules, can be repeated.")
                 .long_help(
                     "Path to a file containing rules, can be repeated.\n\n\
-                     The path can be prefixed by the namespace in which to\
+                     The path can be prefixed by the namespace in which to \
                      compile the rules, followed by a colon.\n\
-                     This can notably be used to avoid name collisions when\
+                     This can notably be used to avoid name collisions when \
                      using multiple rules files.",
                 ),
         );

--- a/boreal-cli/src/args/input.rs
+++ b/boreal-cli/src/args/input.rs
@@ -105,7 +105,7 @@ This can be either:\n
   - A path to a file.
   - A path to a directory, in which files will be scanned.
   - The pid of the a process to scan.
-  - A file containing a list of targets to scan, one per line, if --scan-list\
+  - A file containing a list of targets to scan, one per line, if --scan-list \
     is specified.",
                 ),
         );

--- a/boreal-cli/src/args/mod.rs
+++ b/boreal-cli/src/args/mod.rs
@@ -101,7 +101,7 @@ fn build_yr_subcommand() -> Command {
         .long_about(
             "This subcommand allows specifying options exactly as done with the yara CLI.\n\
              This allows substituting uses of the yara CLI without risks.\n\
-             This API can be a bit ambiguous at times with multiple rules inputs, and many options\
+             This API can be a bit ambiguous at times with multiple rules inputs, and many options \
              can be specified that will not be used in some contexts.\n\
              For these reasons, using the other subcommands is recommended for improved clarity.",
         );
@@ -115,8 +115,8 @@ fn build_yr_subcommand() -> Command {
                 .help("Load compiled rules from bytes.")
                 .long_help(
                     "Load compiled rules from bytes.\n\n\
-                    If specified, then a single rules path must be\
-                    specified, which must point to a file containing\
+                    If specified, then a single rules path must be \
+                    specified, which must point to a file containing \
                     serialized rules.\n\
                     See the scan subcommand for how to generate such a file.",
                 ),
@@ -148,17 +148,17 @@ fn build_yr_subcommand() -> Command {
 \
                 [NAMESPACE:]RULES_FILE... [FILE | DIRECTORY | PID | SCAN_LIST]\n\n\
 \
-                At least two arguments must be specified: the path to the\
-                rules file, and the input to scan.\nSeveral rules files can\
-                be specified: the last argument will always be the input to\
+                At least two arguments must be specified: the path to the \
+                rules file, and the input to scan.\nSeveral rules files can \
+                be specified: the last argument will always be the input to \
                 scan.\n\n\
 \
-                The path to rules files can be prefixed by the namespace in\
+                The path to rules files can be prefixed by the namespace in \
                 which to compile the rules, followed by a colon.\n\
-                This can notably be used to avoid name collisions when\
+                This can notably be used to avoid name collisions when \
                 using multiple rules files.\n\n\
 \
-                If --scan-list is specified, the input is a file containing\
+                If --scan-list is specified, the input is a file containing \
                 a list of inputs to scan, one per line.",
                 )
                 .required_unless_present("module_names"),

--- a/boreal-cli/src/args/mod.rs
+++ b/boreal-cli/src/args/mod.rs
@@ -164,6 +164,45 @@ fn build_yr_subcommand() -> Command {
                 .required_unless_present("module_names"),
         );
 
+    // Add arguments that are ignored: this is only to ease migration from yara CLI
+    command = command
+        .next_help_heading("Ignored options (present for yara compatibility)")
+        .arg(
+            Arg::new("strict_escape")
+                .short('E')
+                .long("strict-escape")
+                .action(ArgAction::SetTrue)
+                .help("warn on unknown escape sequences (ignored).")
+                .long_help(
+                    "warn on unknown escape sequences.\n\n\
+                    Ignored, unknown escape sequences in regexes \
+                    always generate warnings.",
+                ),
+        )
+        .arg(
+            Arg::new("fast")
+                .short('f')
+                .long("fast-scan")
+                .action(ArgAction::SetTrue)
+                .help("Scan in fast mode (ignored).")
+                .long_help(
+                    "Scan in fast mode.\n\n\
+                    Ignored, scans are always in \"fast mode\" unless an \
+                    option disables fast scanning.",
+                ),
+        )
+        .arg(
+            Arg::new("stack_size")
+                .short('k')
+                .long("stack-size")
+                .value_name("SLOTS")
+                .help("Maximum stack size (ignored).")
+                .long_help(
+                    "Maximum stack size.\n\n\
+                    Ignored, boreal does not use a stack to evaluate rules",
+                ),
+        );
+
     command
 }
 

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -1793,6 +1793,24 @@ fn test_rules_files_namespace() {
 }
 
 #[test]
+fn test_ignored_arguments() {
+    let rule_file = test_file(b"rule a { strings: $ = /abc/ condition: any of them }");
+    let input = test_file(b"abc");
+
+    boreal_cmd()
+        .arg("yr")
+        .arg("-E")
+        .arg("--fast-scan")
+        .arg("--stack-size=300")
+        .arg(rule_file.path())
+        .arg(input.path())
+        .assert()
+        .stdout(format!("a {}\n", input.path().display()))
+        .stderr("")
+        .success();
+}
+
+#[test]
 #[cfg(feature = "serialize")]
 fn test_save_load() {
     let rule_file = test_file(


### PR DESCRIPTION
Accept but ignore some arguments in boreal-cli in the yr subcommand.

In order to allow the boreal yr subcommand to be a substitute of the yara CLI, lets accepts some arguments which make no sense here but are ok to ignored.

The last argument that is not handled is the atom quality table, but it is preferable to not accept it for the moment to avoid tricking the user into thinking this quality table is properly loaded.