### PR TITLE
Add EvaluatedModule object, include static values in module dumps

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -589,16 +589,13 @@ fn handle_event(
                 display_rule(&mut stdout, &rule, scanner, what, options);
             }
         }
-        ScanEvent::ModuleImport {
-            module_name,
-            dynamic_values,
-        } => {
+        ScanEvent::ModuleImport(evaluated_module) => {
             // A module value must be an object. Filter out empty ones, it means the module has not
             // generated any values.
-            if let ModuleValue::Object(map) = &dynamic_values {
+            if let ModuleValue::Object(map) = &evaluated_module.dynamic_values {
                 if !map.is_empty() {
-                    write!(stdout, "{module_name}").unwrap();
-                    print_module_value(&mut stdout, dynamic_values, 4);
+                    write!(stdout, "{}", evaluated_module.module.get_name()).unwrap();
+                    print_module_value(&mut stdout, &evaluated_module.dynamic_values, 4);
                 }
             }
         }

--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -611,6 +611,12 @@ rule a {
         cmd.assert()
             .stdout(
                 predicate::str::starts_with("pe\n")
+                    // Static values
+                    // Integer
+                    .and(predicate::str::contains("DLL = 8192 (0x2000)"))
+                    // Function
+                    .and(predicate::str::contains("section_index[function]"))
+                    // Dynamic values
                     // Integer
                     .and(predicate::str::contains("base_of_code = 4096 (0x1000)"))
                     // Undef
@@ -618,9 +624,9 @@ rule a {
                     // Array
                     .and(predicate::str::contains(
                         r#"
-    data_directories
-        [0]
-            size = 220 (0xdc)
+        data_directories
+            [0]
+                size = 220 (0xdc)
 "#,
                     ))
                     // Empty array
@@ -635,16 +641,16 @@ rule a {
                     // Struct
                     .and(predicate::str::contains(
                         r#"
-    image_version
-        major = 10 (0xa)
-        minor = 0 (0x0)
+        image_version
+            major = 10 (0xa)
+            minor = 0 (0x0)
 "#,
                     ))
                     // Dictionary
                     .and(predicate::str::contains(
                         r#"
-    version_info
-        ["CompanyName"] = "Microsoft Corporation"
+        version_info
+            ["CompanyName"] = "Microsoft Corporation"
 "#,
                     )),
             )

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -504,6 +504,12 @@ rule a { condition: true }
 
     assert len(received_values) == 1
     v = received_values[0]
+
+    # static values are present
+    assert v['DLL'] == 8192
+    # but functions are not included
+    assert 'section_index' not in v
+
     # string
     assert v['module'] == 'pe'
     # integer

--- a/boreal/tests/it/callback.rs
+++ b/boreal/tests/it/callback.rs
@@ -59,17 +59,14 @@ fn check_module_import(
     dynamic_value_field: Option<&str>,
 ) {
     match &event {
-        ScanEvent::ModuleImport {
-            module_name,
-            dynamic_values,
-        } => {
-            assert_eq!(*module_name, expected_module_name);
-            match dynamic_values {
+        ScanEvent::ModuleImport(module) => {
+            assert_eq!(module.module.get_name(), expected_module_name);
+            match &module.dynamic_values {
                 Value::Object(obj) => match dynamic_value_field {
                     Some(field) => assert!(obj.contains_key(field)),
                     None => assert_eq!(obj.len(), 0),
                 },
-                _ => panic!("invalid dynamic values {:?}", dynamic_values),
+                _ => panic!("invalid dynamic values {:?}", module.dynamic_values),
             }
         }
         evt => panic!("unexpected event {:?}", evt),

--- a/boreal/tests/it/dex.rs
+++ b/boreal/tests/it/dex.rs
@@ -1,13 +1,11 @@
-use boreal::module::Dex;
-
 use crate::libyara_compat::util::DEX_FILE;
 use crate::utils::{check, compare_module_values_on_mem};
 
 #[test]
 fn test_coverage_dex_file() {
     let diffs = [];
-    compare_module_values_on_mem(Dex, "DEX_FILE", DEX_FILE, false, &diffs);
-    compare_module_values_on_mem(Dex, "DEX_FILE", DEX_FILE, true, &diffs);
+    compare_module_values_on_mem("dex", "DEX_FILE", DEX_FILE, false, &diffs);
+    compare_module_values_on_mem("dex", "DEX_FILE", DEX_FILE, true, &diffs);
 }
 
 #[track_caller]

--- a/boreal/tests/it/dotnet.rs
+++ b/boreal/tests/it/dotnet.rs
@@ -1,5 +1,3 @@
-use boreal::module::Dotnet;
-
 use crate::utils::{check_file, compare_module_values_on_file, Checker};
 
 #[test]
@@ -860,68 +858,68 @@ fn test_recursive_limit() {
 fn test_coverage_0ca09bde() {
     let diffs = [];
     let path = "tests/assets/libyara/data/0ca09bde7602769120fadc4f7a4147347a7a97271370583586c9e587fd396171";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
-    compare_module_values_on_file(Dotnet, path, true, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_756684f4() {
     let diffs = [];
     let path = "tests/assets/libyara/data/756684f4017ba7e931a26724ae61606b16b5f8cc84ed38a260a34e50c5016f59";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
-    compare_module_values_on_file(Dotnet, path, true, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_bad_dotnet_pe() {
     let diffs = [];
     let path = "tests/assets/libyara/data/bad_dotnet_pe";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
-    compare_module_values_on_file(Dotnet, path, true, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_types() {
     let diffs = [];
     let path = "tests/assets/dotnet/types.exe";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
-    compare_module_values_on_file(Dotnet, path, true, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, true, &diffs);
 }
 
 #[test]
 fn test_coverage_types2() {
     let diffs = [];
     let path = "tests/assets/dotnet/types2.dll";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
 
     // DLL so not considered when scanning as a process memory
-    compare_module_values_on_file(Dotnet, path, true, &[]);
+    compare_module_values_on_file("dotnet", path, true, &[]);
 }
 
 #[test]
 fn test_coverage_assembly() {
     let diffs = [];
     let path = "tests/assets/dotnet/assembly.dll";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
 
     // DLL so not considered when scanning as a process memory
-    compare_module_values_on_file(Dotnet, path, true, &[]);
+    compare_module_values_on_file("dotnet", path, true, &[]);
 }
 
 #[test]
 fn test_coverage_classes() {
     let diffs = [];
     let path = "tests/assets/dotnet/classes.dll";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
 
     // DLL so not considered when scanning as a process memory
-    compare_module_values_on_file(Dotnet, path, true, &[]);
+    compare_module_values_on_file("dotnet", path, true, &[]);
 }
 
 #[test]
 fn test_coverage_constants() {
     let diffs = [];
     let path = "tests/assets/dotnet/constants.exe";
-    compare_module_values_on_file(Dotnet, path, false, &diffs);
-    compare_module_values_on_file(Dotnet, path, true, &diffs);
+    compare_module_values_on_file("dotnet", path, false, &diffs);
+    compare_module_values_on_file("dotnet", path, true, &diffs);
 }

--- a/boreal/tests/it/elf.rs
+++ b/boreal/tests/it/elf.rs
@@ -1,5 +1,3 @@
-use boreal::module::Elf;
-
 use crate::libyara_compat::util::{
     ELF32_FILE, ELF32_MIPS_FILE, ELF32_NOSECTIONS, ELF32_SHAREDOBJ, ELF64_FILE, ELF_X64_FILE,
 };
@@ -44,71 +42,71 @@ condition:
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf32() {
-    compare_module_values_on_mem(Elf, "ELF32_FILE", ELF32_FILE, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF32_FILE", ELF32_FILE, true, &[]);
+    compare_module_values_on_mem("elf", "ELF32_FILE", ELF32_FILE, false, &[]);
+    compare_module_values_on_mem("elf", "ELF32_FILE", ELF32_FILE, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf64() {
-    compare_module_values_on_mem(Elf, "ELF64_FILE", ELF64_FILE, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF64_FILE", ELF64_FILE, true, &[]);
+    compare_module_values_on_mem("elf", "ELF64_FILE", ELF64_FILE, false, &[]);
+    compare_module_values_on_mem("elf", "ELF64_FILE", ELF64_FILE, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf32_nosections() {
-    compare_module_values_on_mem(Elf, "ELF32_NOSECTIONS", ELF32_NOSECTIONS, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF32_NOSECTIONS", ELF32_NOSECTIONS, true, &[]);
+    compare_module_values_on_mem("elf", "ELF32_NOSECTIONS", ELF32_NOSECTIONS, false, &[]);
+    compare_module_values_on_mem("elf", "ELF32_NOSECTIONS", ELF32_NOSECTIONS, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf32_sharedobj() {
-    compare_module_values_on_mem(Elf, "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, true, &[]);
+    compare_module_values_on_mem("elf", "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, false, &[]);
+    compare_module_values_on_mem("elf", "ELF32_SHAREDOBJ", ELF32_SHAREDOBJ, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf32_mips() {
-    compare_module_values_on_mem(Elf, "ELF32_MIPS_FILE", ELF32_MIPS_FILE, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF32_MIPS_FILE", ELF32_MIPS_FILE, true, &[]);
+    compare_module_values_on_mem("elf", "ELF32_MIPS_FILE", ELF32_MIPS_FILE, false, &[]);
+    compare_module_values_on_mem("elf", "ELF32_MIPS_FILE", ELF32_MIPS_FILE, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_elf_x64_file() {
-    compare_module_values_on_mem(Elf, "ELF_X64_FILE", ELF_X64_FILE, false, &[]);
-    compare_module_values_on_mem(Elf, "ELF_X64_FILE", ELF_X64_FILE, true, &[]);
+    compare_module_values_on_mem("elf", "ELF_X64_FILE", ELF_X64_FILE, false, &[]);
+    compare_module_values_on_mem("elf", "ELF_X64_FILE", ELF_X64_FILE, true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_smallest() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/smallest", false, &[]);
-    compare_module_values_on_file(Elf, "tests/assets/elf/smallest", true, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/smallest", false, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/smallest", true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_invalid_sections() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_sections", false, &[]);
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_sections", true, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_sections", false, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_sections", true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_invalid_program_header() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_program_header", false, &[]);
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_program_header", true, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_program_header", false, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_program_header", true, &[]);
 }
 
 #[test]
 #[cfg(feature = "hash")]
 fn test_coverage_invalid_symbols() {
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_symbols", false, &[]);
-    compare_module_values_on_file(Elf, "tests/assets/elf/invalid_symbols", true, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_symbols", false, &[]);
+    compare_module_values_on_file("elf", "tests/assets/elf/invalid_symbols", true, &[]);
 }
 
 #[test]

--- a/boreal/tests/it/macho.rs
+++ b/boreal/tests/it/macho.rs
@@ -1,5 +1,3 @@
-use boreal::module::MachO;
-
 use crate::libyara_compat::util::{
     ELF32_FILE, MACHO_PPC_FILE, MACHO_X86_64_DYLIB_FILE, MACHO_X86_FILE, MACHO_X86_OBJECT_FILE,
 };
@@ -108,33 +106,33 @@ fn test_entry_point_for_arch() {
 
 #[test]
 fn test_coverage_non_macho() {
-    compare_module_values_on_mem(MachO, "ELF32_FILE", ELF32_FILE, false, &[]);
-    compare_module_values_on_mem(MachO, "ELF32_FILE", ELF32_FILE, true, &[]);
+    compare_module_values_on_mem("macho", "ELF32_FILE", ELF32_FILE, false, &[]);
+    compare_module_values_on_mem("macho", "ELF32_FILE", ELF32_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_x86() {
-    compare_module_values_on_mem(MachO, "MACHO_X86_FILE", MACHO_X86_FILE, false, &[]);
-    compare_module_values_on_mem(MachO, "MACHO_X86_FILE", MACHO_X86_FILE, true, &[]);
+    compare_module_values_on_mem("macho", "MACHO_X86_FILE", MACHO_X86_FILE, false, &[]);
+    compare_module_values_on_mem("macho", "MACHO_X86_FILE", MACHO_X86_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_ppc() {
-    compare_module_values_on_mem(MachO, "MACHO_PPC_FILE", MACHO_PPC_FILE, false, &[]);
-    compare_module_values_on_mem(MachO, "MACHO_PPC_FILE", MACHO_PPC_FILE, true, &[]);
+    compare_module_values_on_mem("macho", "MACHO_PPC_FILE", MACHO_PPC_FILE, false, &[]);
+    compare_module_values_on_mem("macho", "MACHO_PPC_FILE", MACHO_PPC_FILE, true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_x86_object() {
     compare_module_values_on_mem(
-        MachO,
+        "macho",
         "MACHO_X86_OBJECT_FILE",
         MACHO_X86_OBJECT_FILE,
         false,
         &[],
     );
     compare_module_values_on_mem(
-        MachO,
+        "macho",
         "MACHO_X86_OBJECT_FILE",
         MACHO_X86_OBJECT_FILE,
         true,
@@ -145,14 +143,14 @@ fn test_coverage_macho_x86_object() {
 #[test]
 fn test_coverage_macho_x64_dylib() {
     compare_module_values_on_mem(
-        MachO,
+        "macho",
         "MACHO_X86_64_DYLIB_FILE",
         MACHO_X86_64_DYLIB_FILE,
         false,
         &[],
     );
     compare_module_values_on_mem(
-        MachO,
+        "macho",
         "MACHO_X86_64_DYLIB_FILE",
         MACHO_X86_64_DYLIB_FILE,
         true,
@@ -162,29 +160,34 @@ fn test_coverage_macho_x64_dylib() {
 
 #[test]
 fn test_coverage_macho_tiny_macho() {
-    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-macho", false, &[]);
-    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-macho", true, &[]);
+    compare_module_values_on_file("macho", "tests/assets/libyara/data/tiny-macho", false, &[]);
+    compare_module_values_on_file("macho", "tests/assets/libyara/data/tiny-macho", true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_tiny_universal() {
     compare_module_values_on_file(
-        MachO,
+        "macho",
         "tests/assets/libyara/data/tiny-universal",
         false,
         &[],
     );
-    compare_module_values_on_file(MachO, "tests/assets/libyara/data/tiny-universal", true, &[]);
+    compare_module_values_on_file(
+        "macho",
+        "tests/assets/libyara/data/tiny-universal",
+        true,
+        &[],
+    );
 }
 
 #[test]
 fn test_coverage_macho_entry_points() {
-    compare_module_values_on_file(MachO, "tests/assets/macho/entry_points", false, &[]);
-    compare_module_values_on_file(MachO, "tests/assets/macho/entry_points", true, &[]);
+    compare_module_values_on_file("macho", "tests/assets/macho/entry_points", false, &[]);
+    compare_module_values_on_file("macho", "tests/assets/macho/entry_points", true, &[]);
 }
 
 #[test]
 fn test_coverage_macho_fat64() {
-    compare_module_values_on_file(MachO, "tests/assets/macho/fat64", false, &[]);
-    compare_module_values_on_file(MachO, "tests/assets/macho/fat64", true, &[]);
+    compare_module_values_on_file("macho", "tests/assets/macho/fat64", false, &[]);
+    compare_module_values_on_file("macho", "tests/assets/macho/fat64", true, &[]);
 }

--- a/boreal/tests/it/pe.rs
+++ b/boreal/tests/it/pe.rs
@@ -1,5 +1,3 @@
-use boreal::module::Pe;
-
 use crate::utils::{check_file, compare_module_values_on_file};
 
 #[test]
@@ -439,8 +437,8 @@ fn test_coverage_pe_ord_and_delay() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/ord_and_delay.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -453,8 +451,8 @@ fn test_coverage_pe_resources_only() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/resources_only.dll";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -475,8 +473,8 @@ fn test_coverage_pe_libyara_079a472d() {
     let path = "tests/assets/libyara/data/\
         079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885";
 
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -490,8 +488,8 @@ fn test_coverage_pe_libyara_079a472d_upx() {
     ];
     let path = "tests/assets/libyara/data/\
         079a472d22290a94ebb212aa8015cdc8dd28a968c6b4d3b88acdd58ce2d3b885.upx";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -505,8 +503,8 @@ fn test_coverage_pe_libyara_0ca09bde() {
     ];
     let path = "tests/assets/libyara/data/\
         0ca09bde7602769120fadc4f7a4147347a7a97271370583586c9e587fd396171";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -520,8 +518,8 @@ fn test_coverage_pe_libyara_33fc70f9() {
     ];
     let path = "tests/assets/libyara/data/\
         33fc70f99be6d2833ae48852d611c8048d0c053ed0b2c626db4dbe902832a08b";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -545,8 +543,8 @@ fn test_coverage_pe_libyara_3b8b9015() {
     ];
     let path = "tests/assets/libyara/data/\
         3b8b90159fa9b6048cc5410c5d53f116943564e4d05b04a843f9b3d0540d0c1c";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -560,8 +558,8 @@ fn test_coverage_pe_libyara_ca21e1c32() {
     ];
     let path = "tests/assets/libyara/data/\
         ca21e1c32065352d352be6cde97f89c141d7737ea92434831f998080783d5386";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -574,8 +572,8 @@ fn test_coverage_pe_libyara_mtxex() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/mtxex.dll";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -588,8 +586,8 @@ fn test_coverage_pe_libyara_mtxex_modified() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/mtxex_modified_rsrc_rva.dll";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &[]);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &[]);
 }
 
 #[test]
@@ -602,8 +600,8 @@ fn test_coverage_pe_libyara_pe_imports() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/pe_imports";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -616,8 +614,8 @@ fn test_coverage_pe_libyara_pe_mingw() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/pe_mingw";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -630,8 +628,8 @@ fn test_coverage_pe_libyara_tiny() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/tiny";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -644,8 +642,8 @@ fn test_coverage_pe_libyara_tiny_51ff() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/tiny-idata-51ff";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -658,8 +656,8 @@ fn test_coverage_pe_libyara_tiny_5200() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/tiny-idata-5200";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -672,8 +670,8 @@ fn test_coverage_pe_libyara_tiny_overlay() {
         "pe.is_signed",
     ];
     let path = "tests/assets/libyara/data/tiny-overlay";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -686,8 +684,8 @@ fn test_coverage_pe_1561_std() {
         "pe.is_signed",
     ];
     let path = "tests/assets/yara_1561/x64/FileTest.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -700,8 +698,8 @@ fn test_coverage_pe_1561_align_40() {
         "pe.is_signed",
     ];
     let path = "tests/assets/yara_1561/x64/FileTest_alignment_40.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -714,8 +712,8 @@ fn test_coverage_pe_1561_32_align_40() {
         "pe.is_signed",
     ];
     let path = "tests/assets/yara_1561/Win32/FileTest_Alignment_40.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -728,8 +726,8 @@ fn test_coverage_pe_1561_32_section1() {
         "pe.is_signed",
     ];
     let path = "tests/assets/yara_1561/Win32/FileTest_Section1_Starts_at_header.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -743,8 +741,8 @@ fn test_coverage_pe_c6f9709f() {
     ];
     let path = "tests/assets/libyara/data/\
          c6f9709feccf42f2d9e22057182fe185f177fb9daaa2649b4669a24f2ee7e3ba_0h_410h";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -757,8 +755,8 @@ fn test_coverage_pe_long_name_exporter() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/long_name_exporter.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -771,8 +769,8 @@ fn test_coverage_pe_long_dll_name() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/long_dll_name.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -785,8 +783,8 @@ fn test_coverage_pe_long_name_importer() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/long_name_importer.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -799,8 +797,8 @@ fn test_coverage_pe_invalid_dll_names() {
         "pe.is_signed",
     ];
     let path = "tests/assets/pe/invalid_dll_names.exe";
-    compare_module_values_on_file(Pe, path, false, &diffs);
-    compare_module_values_on_file(Pe, path, true, &diffs);
+    compare_module_values_on_file("pe", path, false, &diffs);
+    compare_module_values_on_file("pe", path, true, &diffs);
 }
 
 #[test]
@@ -893,6 +891,6 @@ fn test_signatures_verify() {
         checker.check(&mem, true);
 
         // Check full coverage
-        compare_module_values_on_file(Pe, &path, false, &diffs);
+        compare_module_values_on_file("pe", &path, false, &diffs);
     }
 }

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -911,11 +911,11 @@ pub fn compare_module_values_on_mem<M: Module>(
     };
 
     let mut boreal_value = res
-        .module_values
+        .modules
         .into_iter()
-        .find_map(|(name, module_value)| {
-            if name == module.get_name() {
-                Some(module_value)
+        .find_map(|evaluated_module| {
+            if evaluated_module.module.get_name() == module.get_name() {
+                Some(evaluated_module.dynamic_values)
             } else {
                 None
             }


### PR DESCRIPTION
Rework the ModuleImport callback event and "module_values" scan result field to use the same object: a new EvaluatedModule struct, which now holds a pointer to the module.

This allows accessing the static values (lazily, which is ideal) and cleans up this event. The two consumer of this event now uses it to also access the static values:

- boreal-cli now prints the static values when -D is used
- boreal-py now adds the static values in the module data returned in modules_callback

Closes #191 