### PR TITLE
breaking: rename Compiler::into_scanner into finalize

### DIFF
--- a/benches/src/bench.rs
+++ b/benches/src/bench.rs
@@ -66,7 +66,7 @@ fn bench_compilation(c: &mut Criterion, rules_name: &str, rules: &[PathBuf]) {
             for path in rules {
                 compiler.add_rules_file(path).unwrap();
             }
-            compiler.into_scanner()
+            compiler.finalize()
         })
     });
     group.bench_with_input("boreal-memory", rules, |b, rules| {
@@ -75,7 +75,7 @@ fn bench_compilation(c: &mut Criterion, rules_name: &str, rules: &[PathBuf]) {
             for path in rules {
                 compiler.add_rules_file(path).unwrap();
             }
-            compiler.into_scanner()
+            compiler.finalize()
         })
     });
     group.bench_with_input("libyara", rules, |b, rules| {

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -95,7 +95,7 @@ pub fn build_boreal_scanner(rules: &[PathBuf], speed: bool) -> boreal::Scanner {
             )
         });
     }
-    boreal_compiler.into_scanner()
+    boreal_compiler.finalize()
 }
 
 pub fn build_yara_rules(rules: &[PathBuf]) -> yara::Rules {

--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -291,7 +291,7 @@ fn compile_rules(options: CompilerOptions, warning_mode: WarningMode) -> Option<
         }
     }
 
-    Some(compiler.into_scanner())
+    Some(compiler.finalize())
 }
 
 #[cfg(feature = "serialize")]

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -260,7 +260,7 @@ fn compile(
         _ => return Err(PyTypeError::new_err("invalid arguments passed")),
     }
 
-    Ok(scanner::Scanner::new(compiler.into_scanner(), warnings))
+    Ok(scanner::Scanner::new(compiler.finalize(), warnings))
 }
 
 /// Profile to use when compiling rules.

--- a/boreal/README.md
+++ b/boreal/README.md
@@ -77,7 +77,7 @@ rule example {
 }
 "#)?;
 
-let scanner = compiler.into_scanner();
+let scanner = compiler.finalize();
 let res = scanner.scan_mem(b"<\0t\0m\0p\0.\0d\0a\0t\0>\0");
 assert!(res.matched_rules.iter().any(|rule| rule.name == "example"));
 ```

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -611,12 +611,8 @@ impl Compiler {
     }
 
     /// Finalize the compiler and generate a [`Scanner`].
-    ///
-    /// # Errors
-    ///
-    /// Can fail if generating a set of all rules variables is not possible.
     #[must_use]
-    pub fn into_scanner(self) -> Scanner {
+    pub fn finalize(self) -> Scanner {
         Scanner::new(self)
     }
 }

--- a/boreal/src/lib.rs
+++ b/boreal/src/lib.rs
@@ -25,7 +25,7 @@
 //! "#)?;
 //!
 //! // Then, all added rules are compiled into a scanner object.
-//! let scanner = compiler.into_scanner();
+//! let scanner = compiler.finalize();
 //!
 //! // Use this object to scan strings or files.
 //! let res = scanner.scan_mem(b"<\0t\0m\0p\0.\0d\0a\0t\0>\0").unwrap();

--- a/boreal/src/module/console.rs
+++ b/boreal/src/module/console.rs
@@ -26,7 +26,7 @@ use super::{EvalContext, Module, ModuleData, ModuleDataMap, StaticValue, Type, V
 /// rule a {
 ///     condition: console.log("one")
 /// }"#).unwrap();
-/// let mut scanner = compiler.into_scanner();
+/// let mut scanner = compiler.finalize();
 ///
 /// scanner.scan_mem(b""); // Will not log anything
 ///

--- a/boreal/src/module/cuckoo.rs
+++ b/boreal/src/module/cuckoo.rs
@@ -19,7 +19,7 @@ use super::{EvalContext, Module, ModuleData, StaticValue, Type, Value};
 /// rule a {
 ///     condition: cuckoo.network.host(/crates.io/)
 /// }"#).unwrap();
-/// let mut scanner = compiler.into_scanner();
+/// let mut scanner = compiler.finalize();
 ///
 /// let report = r#"{ "network": { "hosts": ["crates.io"] } }"#;
 /// let cuckoo_data = CuckooData::from_json_report(report).unwrap();

--- a/boreal/src/module/mod.rs
+++ b/boreal/src/module/mod.rs
@@ -379,7 +379,7 @@ impl std::fmt::Debug for ModuleDataMap<'_> {
 ///     condition: bar.get_data_value() == 3
 /// }"#).unwrap();
 ///
-/// let mut scanner = compiler.into_scanner();
+/// let mut scanner = compiler.finalize();
 /// scanner.set_module_data::<Bar>(BarUserData { value: 3 });
 ///
 /// let result = scanner.scan_mem(b"").unwrap();

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -39,7 +39,7 @@ mod process;
 /// compiler.add_rules_str("rule a { strings: $a = \"abc\" condition: $a }")?;
 ///
 /// // Compile all the rules and generate a scanner.
-/// let scanner = compiler.into_scanner();
+/// let scanner = compiler.finalize();
 ///
 /// // Use the scanner to run the rules against byte strings or files.
 /// let scan_result = scanner.scan_mem(b"abc").unwrap();
@@ -55,7 +55,7 @@ mod process;
 /// let mut compiler = boreal::Compiler::new();
 /// compiler.define_symbol("extension", "");
 /// compiler.add_rules_str("rule a { condition: extension endswith \"pdf\" }")?;
-/// let scanner = compiler.into_scanner();
+/// let scanner = compiler.finalize();
 ///
 /// let thread1 = {
 ///     let mut scanner = scanner.clone();
@@ -682,7 +682,7 @@ impl Scanner {
     /// ```
     /// let mut compiler = boreal::Compiler::new();
     /// compiler.add_rules_str("rule a { strings: $a = \"abc\" condition: $a }").unwrap();
-    /// let scanner = compiler.into_scanner();
+    /// let scanner = compiler.finalize();
     ///
     /// let mut buffer = Vec::new();
     /// scanner.to_bytes(&mut buffer).unwrap();
@@ -1964,7 +1964,7 @@ mod tests {
     fn test_eval_with_poison(rule_str: &str, mem: &[u8], expected: Option<bool>) {
         let mut compiler = CompilerBuilder::default().add_module(Test).build();
         let _r = compiler.add_rules_str(rule_str).unwrap();
-        let scanner = compiler.into_scanner();
+        let scanner = compiler.finalize();
 
         let user_data = ModuleUserData::default();
         let mut module_values =

--- a/boreal/src/scanner/params.rs
+++ b/boreal/src/scanner/params.rs
@@ -370,7 +370,7 @@ impl ScanParams {
     ///
     /// ```
     /// use boreal::scanner::{CallbackEvents, ScanParams};
-    /// # let mut scanner = boreal::Compiler::new().into_scanner();
+    /// # let mut scanner = boreal::Compiler::new().finalize();
     ///
     /// scanner.set_scan_params(
     ///     ScanParams::default()

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -22,7 +22,7 @@ rule bar {
 }"#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
     assert!(scanner.scan_file("not_existing").is_err());
 
     let file = tempfile::NamedTempFile::new().unwrap();
@@ -85,7 +85,7 @@ rule a {
 }"#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
     scanner.scan_mem(b"").unwrap();
 
     assert!(!FIRST.load(Ordering::SeqCst));
@@ -128,7 +128,7 @@ rule r: tag {
         )
         .unwrap();
 
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
     let rules: Vec<_> = scanner.rules().collect();
 
     assert_eq!(rules.len(), 4);
@@ -219,7 +219,7 @@ rule yes2 { condition: true }
             "ns2",
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner
@@ -327,7 +327,7 @@ fn test_scanner_serialize_module_use() {
     }"#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     let _r = scanner.scan_mem(b"").unwrap();
     assert_eq!(&*LOGS.lock().unwrap(), &[1]);

--- a/boreal/tests/it/callback.rs
+++ b/boreal/tests/it/callback.rs
@@ -160,7 +160,7 @@ rule c {
 "#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     scan_mem(&scanner, b"<abcdef>", 2, |event, nb| {
         if nb == 0 {
@@ -202,7 +202,7 @@ rule c {
 "#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     scan_mem(&scanner, b"<abc>", 0, |_, _| panic!());
 
@@ -239,7 +239,7 @@ rule c { condition: filesize > 7 }
 "#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     scan_mem(&scanner, b"12", 0, |_, _| panic!());
     scan_mem(&scanner, b"123", 0, |_, _| panic!());
@@ -277,7 +277,7 @@ rule b { condition: filesize >= 3 }
     compiler
         .add_rules_str(format!("rule c {{ condition: {} }}", TIMEOUT_COND))
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
     scanner
         .set_scan_params(ScanParams::default().timeout_duration(Some(Duration::from_millis(100))));
 
@@ -313,7 +313,7 @@ rule d { condition: true }
 "#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     scan_mem_with_abort(&scanner, b"abc", 0, |event, _nb| {
         check_rule_match(event, "a", "default");
@@ -363,7 +363,7 @@ rule d { condition: true }
 "#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     scan_mem_with_abort(&scanner, b"", 0, |event, _nb| {
         check_rule_match(event, "a", "default");
@@ -411,7 +411,7 @@ fn test_scan_mem_with_callback_abort_timeout() {
     compiler
         .add_rules_str(format!("rule c {{ condition: {} }}", TIMEOUT_COND))
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
     scanner
         .set_scan_params(ScanParams::default().timeout_duration(Some(Duration::from_millis(100))));
 
@@ -426,7 +426,7 @@ fn test_scan_file_with_callback() {
     compiler
         .add_rules_str("rule a { condition: true }")
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     let mut counter = 0;
     let res = scanner.scan_file_with_callback("not_existing", |_event| {
@@ -455,7 +455,7 @@ fn test_scan_file_memmap_with_callback() {
     compiler
         .add_rules_str("rule a { condition: true }")
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     let mut counter = 0;
     // Safety: testing
@@ -497,7 +497,7 @@ rule a {
 }"#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     let regions = &[
         (0, Some(b"zyx".as_slice())),
@@ -535,7 +535,7 @@ rule a {
 }"#,
         )
         .unwrap();
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     let helper = BinHelper::run("stack");
     let mut counter = 0;
@@ -569,7 +569,7 @@ rule a {
 "#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
     scanner.set_scan_params(
         ScanParams::default()
             .callback_events(CallbackEvents::RULE_MATCH | CallbackEvents::MODULE_IMPORT),
@@ -673,7 +673,7 @@ rule b {
 "#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     // By default, we get rule match, but not module import
     scan_mem(&scanner, b"abcdef", 2, |event, nb| {
@@ -711,7 +711,7 @@ rule a {
 "#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     // By default, we get rule match, but not module import
     scanner.set_scan_params(
@@ -745,7 +745,7 @@ private rule e { condition: false }
 "#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
     scanner.set_scan_params(
         scanner
             .scan_params()
@@ -812,7 +812,7 @@ rule yes2 { condition: true }
             "ns2",
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner
@@ -918,7 +918,7 @@ rule c {
 "#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner
@@ -1014,7 +1014,7 @@ rule r4 {
             "ns3",
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner
@@ -1084,7 +1084,7 @@ global rule g3 {
 }"#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner
@@ -1141,7 +1141,7 @@ rule r1 {
 }"#,
         )
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
 
     scanner.set_scan_params(
         scanner

--- a/boreal/tests/it/modules.rs
+++ b/boreal/tests/it/modules.rs
@@ -532,7 +532,7 @@ rule a {
         )
         .unwrap();
 
-    let scanner = compiler.into_scanner();
+    let scanner = compiler.finalize();
 
     // Nothing emitted by default
     scanner.scan_mem(b"").unwrap();

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -231,7 +231,7 @@ impl Compiler {
 
     pub fn into_checker(self) -> Checker {
         Checker {
-            scanner: self.compiler.into_scanner(),
+            scanner: self.compiler.finalize(),
             yara_rules: self.yara_compiler.map(|v| v.compile_rules().unwrap()),
             assert_success: true,
             last_err: None,
@@ -881,7 +881,7 @@ pub fn compare_module_values_on_mem(
             module_name
         ))
         .unwrap();
-    let mut scanner = compiler.into_scanner();
+    let mut scanner = compiler.finalize();
     if process_memory {
         let params = scanner.scan_params().clone();
         scanner.set_scan_params(params.process_memory(true));


### PR DESCRIPTION
The into_scanner naming was a bit awkward, rename it to something more natural.