### PR TITLE
Fix windows token leak on windows process scanning

### DIFF
--- a/boreal/src/scanner/process/sys/windows.rs
+++ b/boreal/src/scanner/process/sys/windows.rs
@@ -75,6 +75,10 @@ fn enable_se_debug_privilege() -> Result<(), std::io::Error> {
     if res == 0 {
         return Err(std::io::Error::last_os_error());
     }
+    // Safety:
+    // - The handle is valid since the call to OpenProcessToken succeeded
+    // - The handle must be closed with `CloseHandle`.
+    let self_token = unsafe { OwnedHandle::from_raw_handle(self_token.cast()) };
 
     let mut debug_privilege_luid = LUID {
         LowPart: 0,
@@ -107,7 +111,7 @@ fn enable_se_debug_privilege() -> Result<(), std::io::Error> {
     // - Rest of arguments are optional
     let res = unsafe {
         AdjustTokenPrivileges(
-            self_token,
+            handle_to_windows_handle(self_token.as_handle()),
             0,
             &cfg,
             0,

--- a/boreal/src/scanner/process/sys/windows.rs
+++ b/boreal/src/scanner/process/sys/windows.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_void;
 use std::mem::{MaybeUninit, size_of};
 use std::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, FromRawHandle, OwnedHandle};
+use std::sync::Once;
 
 use windows_sys::Win32::Foundation::{ERROR_INVALID_PARAMETER, HANDLE, LUID};
 use windows_sys::Win32::Security::{
@@ -18,14 +19,25 @@ use windows_sys::Win32::System::Threading::{
 use crate::memory::{FragmentedMemory, MemoryParams, Region, RegionDescription};
 use crate::scanner::ScanError;
 
+static ADD_SE_DEBUG_PRIVILEGE: Once = Once::new();
+
 pub fn process_memory(pid: u32) -> Result<Box<dyn FragmentedMemory>, ScanError> {
     // Enable the SeDebug privilege on our process, so as to be able to
     // open any process.
-    if enable_se_debug_privilege().is_err() {
-        // Attempt to open the process regardless, we might not need
-        // the SE_DEBUG privilege for this one.
-        // TODO: log this once logging is added.
-    }
+    //
+    // Do this only once: this is clearly enough for basically everyone, and would
+    // only be insufficient if the caller actually removes the privilege after we
+    // added it. In such a situation though:
+    // - The caller should very much know what he is doing
+    // - Removing the permission may break ongoing processes scans? I'm not sure,
+    //   but it's clearly a grey area, which is not supported.
+    ADD_SE_DEBUG_PRIVILEGE.call_once(|| {
+        if enable_se_debug_privilege().is_err() {
+            // Attempt to open the process regardless, we might not need
+            // the SE_DEBUG privilege for this one.
+            // TODO: log this once logging is added.
+        }
+    });
 
     // Safety: this is always safe to call.
     let res = unsafe {


### PR DESCRIPTION
To be able to read memory from processes for process scanning, the process must have the SE_DEBUG_NAME privilege. Boreal automatically adds it before starting the scan, but this function leaked the opened process token.

This MR fixes the leak, but also adds an improvement: this function is now only called once instead of for every process scan.