### PR TITLE
chore: update memmap2 in lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Update the dependency to avoid the advisory RUSTSEC-2026-0186. This issue did not impact our use of the crate, but it is still reported, so update to remove its notification.