### PR TITLE
fix: fix match counting bug on nocase string with case alt

### DIFF
--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -84,8 +84,21 @@ impl AcScan {
                     // as this would result in two identical matches for the same variable.
                     // To prevent this, a set is used here. Both the atom itself and its position
                     // in the literal are important.
-                    if !known_literals_of_var.insert((atom.clone(), start)) {
-                        continue;
+                    {
+                        let mut dedup_atom = atom.clone();
+
+                        // See `test_nocase_alternate_case` test. If the variable is "nocase",
+                        // then make sure we don't add to the AC two different atoms that
+                        // results in the same lowercase string. This shouldn't be done outside
+                        // of the "nocase" scenario, since different cases will be validated
+                        // properly against each literal.
+                        if var.matcher.modifiers.nocase {
+                            dedup_atom.make_ascii_lowercase();
+                        }
+
+                        if !known_literals_of_var.insert((dedup_atom, start)) {
+                            continue;
+                        }
                     }
 
                     // Ensure the literals provided to the aho corasick are not

--- a/boreal/tests/it/regex.rs
+++ b/boreal/tests/it/regex.rs
@@ -311,3 +311,21 @@ fn test_atom_alternates_extract() {
     checker.check(b"<a-c-c-23df-g>", false);
     checker.check(b"<a-ef-g>", true);
 }
+
+#[test]
+fn test_nocase_alternate_case() {
+    // Twisted case of a variable alternating on a case, but also specifying
+    // "nocase". This used to trigger a bug where the alternation would
+    // generate two atoms, which were made lowercase before addition to the
+    // AC. This thus generated two matches instead of 1.
+    let mut checker = Checker::new(
+        r#"
+rule a {
+    strings:
+        $a = /x[aA]yz/ nocase
+    condition:
+        #a == 1
+}"#,
+    );
+    checker.check(b"..xayz..", true);
+}


### PR DESCRIPTION
See comments for more details. This is a match counting bug that couldn't really happen in real rules, because to trigger it, you need:

- a string with the "nocase" modifier...
- ...that does an alternation on the case of a character...
- ...and that uses a "count" condition on the string