### PR TITLE
Reduce Expression enum size, reduce memory footprint of compiled rules

### DIFF
--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -80,7 +80,7 @@ pub struct VariableSet {
     /// Indexes of the variables selected in the set.
     ///
     /// The indexes are relative to the array of compiled variable stored in the compiled rule.
-    pub elements: Vec<usize>,
+    pub elements: Box<[usize]>,
 }
 
 /// Set of multiple rules.
@@ -89,7 +89,7 @@ pub struct RuleSet {
     /// Indexes of the rules selected in the set.
     ///
     /// The indexes are relative to the array of rule result.
-    pub elements: Vec<usize>,
+    pub elements: Box<[usize]>,
 
     /// Number of already matched elements.
     ///
@@ -191,9 +191,9 @@ pub enum Expression {
     ShiftRight(Box<Expression>, Box<Expression>),
 
     /// Boolean and operation.
-    And(Vec<Expression>),
+    And(Box<[Expression]>),
     /// Boolean or operation.
-    Or(Vec<Expression>),
+    Or(Box<[Expression]>),
 
     /// Boolean negation.
     Not(Box<Expression>),
@@ -557,7 +557,7 @@ pub(super) fn compile_expression(
             let ops = ops
                 .into_iter()
                 .map(|op| compile_expression(compiler, op).and_then(|e| to_bool_expr(compiler, e)))
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<_, _>>()?;
 
             Ok(Expr {
                 expr: Expression::And(ops),
@@ -569,7 +569,7 @@ pub(super) fn compile_expression(
             let ops = ops
                 .into_iter()
                 .map(|op| compile_expression(compiler, op).and_then(|e| to_bool_expr(compiler, e)))
-                .collect::<Result<Vec<_>, _>>()?;
+                .collect::<Result<_, _>>()?;
 
             Ok(Expr {
                 expr: Expression::Or(ops),
@@ -1064,7 +1064,9 @@ fn compile_variable_set(
         }
     }
 
-    Ok(VariableSet { elements: indexes })
+    Ok(VariableSet {
+        elements: indexes.into_boxed_slice(),
+    })
 }
 
 fn compile_rule_set(
@@ -1113,7 +1115,7 @@ fn compile_rule_set(
     }
 
     Ok(RuleSet {
-        elements: indexes,
+        elements: indexes.into_boxed_slice(),
         already_matched,
     })
 }
@@ -1128,7 +1130,7 @@ pub enum ForIterator {
         from: Box<Expression>,
         to: Box<Expression>,
     },
-    List(Vec<Expression>),
+    List(Box<[Expression]>),
 }
 
 fn compile_for_iterator(
@@ -1225,7 +1227,7 @@ fn compile_for_iterator(
                 _ => invalid_binding(1)?,
             }
 
-            Ok(ForIterator::List(res))
+            Ok(ForIterator::List(res.into_boxed_slice()))
         }
     }
 }
@@ -1620,7 +1622,7 @@ mod wire {
     fn deserialize_exprs<R: io::Read>(
         ctx: &DeserializeContext,
         reader: &mut R,
-    ) -> io::Result<Vec<Expression>> {
+    ) -> io::Result<Box<[Expression]>> {
         let len = u32::deserialize_reader(reader)?;
         let len = usize::try_from(len).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, format!("length too big: {len}"))
@@ -1629,7 +1631,7 @@ mod wire {
         for _ in 0..len {
             exprs.push(deserialize_expr(ctx, reader)?);
         }
-        Ok(exprs)
+        Ok(exprs.into_boxed_slice())
     }
 
     pub(super) fn deserialize_expr<R: io::Read>(
@@ -1966,7 +1968,7 @@ mod wire {
             let elements = <Vec<usize>>::deserialize_reader(reader)?;
             let already_matched = usize::deserialize_reader(reader)?;
             Ok(Self {
-                elements,
+                elements: elements.into_boxed_slice(),
                 already_matched,
             })
         }
@@ -1982,7 +1984,9 @@ mod wire {
     impl Deserialize for VariableSet {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
             let elements = <Vec<usize>>::deserialize_reader(reader)?;
-            Ok(Self { elements })
+            Ok(Self {
+                elements: elements.into_boxed_slice(),
+            })
         }
     }
 
@@ -2209,12 +2213,12 @@ mod wire {
                 &[0, 1, 2],
             );
             test_round_trip_custom_deser(
-                &Expression::And(vec![Expression::Entrypoint, Expression::Filesize]),
+                &Expression::And(Box::new([Expression::Entrypoint, Expression::Filesize])),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1],
             );
             test_round_trip_custom_deser(
-                &Expression::Or(vec![Expression::Entrypoint, Expression::Filesize]),
+                &Expression::Or(Box::new([Expression::Entrypoint, Expression::Filesize])),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1],
             );
@@ -2327,7 +2331,9 @@ mod wire {
             test_round_trip_custom_deser(
                 &Expression::For {
                     selection: ForSelection::Any,
-                    set: VariableSet { elements: vec![1] },
+                    set: VariableSet {
+                        elements: Box::new([1]),
+                    },
                     body: Box::new(Expression::Filesize),
                 },
                 |reader| deserialize_expr(&ctx, reader),
@@ -2336,7 +2342,7 @@ mod wire {
             test_round_trip_custom_deser(
                 &Expression::ForIdentifiers {
                     selection: ForSelection::Any,
-                    iterator: ForIterator::List(Vec::new()),
+                    iterator: ForIterator::List(Box::new([])),
                     body: Box::new(Expression::Filesize),
                 },
                 |reader| deserialize_expr(&ctx, reader),
@@ -2346,7 +2352,7 @@ mod wire {
                 &Expression::ForRules {
                     selection: ForSelection::Any,
                     set: RuleSet {
-                        elements: vec![1],
+                        elements: Box::new([1]),
                         already_matched: 3,
                     },
                 },
@@ -2450,7 +2456,7 @@ mod wire {
                 &[0, 1, 9],
             );
             test_round_trip_custom_deser(
-                &ForIterator::List(vec![Expression::Filesize, Expression::Integer(3)]),
+                &ForIterator::List(Box::new([Expression::Filesize, Expression::Integer(3)])),
                 |reader| deserialize_for_iterator(&ctx, reader),
                 &[0, 1, 9],
             );
@@ -2463,7 +2469,7 @@ mod wire {
         fn test_wire_rule_set() {
             test_round_trip(
                 &RuleSet {
-                    elements: vec![15, 23],
+                    elements: Box::new([15, 23]),
                     already_matched: 232,
                 },
                 &[0, 22],
@@ -2474,7 +2480,7 @@ mod wire {
         fn test_wire_variable_set() {
             test_round_trip(
                 &VariableSet {
-                    elements: vec![15, 23],
+                    elements: Box::new([15, 23]),
                 },
                 &[0],
             );
@@ -2514,10 +2520,10 @@ mod tests {
         test_type_traits(Type::Integer);
         test_type_traits(VariableIndex(None));
         test_type_traits(VariableSet {
-            elements: Vec::new(),
+            elements: Box::new([]),
         });
         test_type_traits(RuleSet {
-            elements: Vec::new(),
+            elements: Box::new([]),
             already_matched: 0,
         });
         test_type_traits_non_clonable(Expr {
@@ -2527,6 +2533,6 @@ mod tests {
         });
         test_type_traits_non_clonable(Expression::Boolean(true));
         test_type_traits_non_clonable(ForSelection::Any);
-        test_type_traits_non_clonable(ForIterator::List(Vec::new()));
+        test_type_traits_non_clonable(ForIterator::List(Box::new([])));
     }
 }

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -1,6 +1,7 @@
 //! Compiled expression used in a rule.
 //!
 //! This module contains all types describing a rule condition, built from the parsed AST.
+use std::num::NonZeroU32;
 use std::ops::Range;
 
 use boreal_parser::expression as parser;
@@ -72,7 +73,7 @@ impl Expr {
 /// If None, this indicates an unnamed variable, and the one selected in a for expression must be
 /// used (e.g. '$').
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct VariableIndex(pub Option<usize>);
+pub struct VariableIndex(pub Option<NonZeroU32>);
 
 /// Set of multiple variables.
 #[derive(Clone, Debug, PartialEq)]
@@ -1359,6 +1360,7 @@ fn compile_identifier_as_iterator(
 #[cfg(feature = "serialize")]
 mod wire {
     use std::io;
+    use std::num::NonZeroU32;
 
     use crate::BytesSymbol;
     use crate::regex::Regex;
@@ -2073,7 +2075,7 @@ mod wire {
 
     impl Deserialize for VariableIndex {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            Ok(Self(<Option<usize>>::deserialize_reader(reader)?))
+            Ok(Self(<Option<NonZeroU32>>::deserialize_reader(reader)?))
         }
     }
 
@@ -2565,7 +2567,7 @@ mod wire {
 
         #[test]
         fn test_wire_variable_index() {
-            test_round_trip(&VariableIndex(Some(3)), &[0, 1]);
+            test_round_trip(&VariableIndex(Some(NonZeroU32::new(3).unwrap())), &[0, 1]);
             test_round_trip(&VariableIndex(None), &[0]);
         }
 

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -341,7 +341,7 @@ pub enum Expression {
     },
 
     /// Call into a module
-    Module(ModuleExpression),
+    Module(Box<ModuleExpression>),
 
     /// Dependency on another rule.
     ///
@@ -1125,7 +1125,7 @@ fn compile_rule_set(
 #[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
 #[allow(variant_size_differences)]
 pub enum ForIterator {
-    ModuleIterator(ModuleExpression),
+    ModuleIterator(Box<ModuleExpression>),
     Range {
         from: Box<Expression>,
         to: Box<Expression>,
@@ -1174,7 +1174,7 @@ fn compile_for_iterator(
                 },
             }
 
-            Ok(ForIterator::ModuleIterator(expr))
+            Ok(ForIterator::ModuleIterator(Box::new(expr)))
         }
         parser::ForIterator::Range { from, to } => {
             let from = compile_expression(compiler, *from)?;
@@ -1857,7 +1857,10 @@ mod wire {
                 let set = RuleSet::deserialize_reader(reader)?;
                 Expression::ForRules { selection, set }
             }
-            40 => Expression::Module(ModuleExpression::deserialize(ctx, reader)?),
+            40 => {
+                let expr = ModuleExpression::deserialize(ctx, reader)?;
+                Expression::Module(Box::new(expr))
+            }
             41 => Expression::Rule(usize::deserialize_reader(reader)?),
             42 => Expression::ExternalSymbol(usize::deserialize_reader(reader)?),
             43 => Expression::Bytes(BytesSymbol::deserialize_reader(reader)?),
@@ -1937,7 +1940,7 @@ mod wire {
         match discriminant {
             0 => {
                 let module_expr = ModuleExpression::deserialize(ctx, reader)?;
-                Ok(ForIterator::ModuleIterator(module_expr))
+                Ok(ForIterator::ModuleIterator(Box::new(module_expr)))
             }
             1 => {
                 let from = Box::new(deserialize_expr(ctx, reader)?);
@@ -2360,15 +2363,15 @@ mod wire {
                 &[0, 1, 2],
             );
             test_round_trip_custom_deser(
-                &Expression::Module(ModuleExpression {
+                &Expression::Module(Box::new(ModuleExpression {
                     kind: ModuleExpressionKind::BoundedModuleValueUse {
                         index: BoundedValueIndex::Module(5),
                     },
                     operations: ModuleOperations {
-                        expressions: vec![],
-                        operations: vec![],
+                        expressions: Box::new([]),
+                        operations: Box::new([]),
                     },
-                }),
+                })),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1],
             );
@@ -2435,15 +2438,15 @@ mod wire {
             let ctx = DeserializeContext::default();
 
             test_round_trip_custom_deser(
-                &ForIterator::ModuleIterator(ModuleExpression {
+                &ForIterator::ModuleIterator(Box::new(ModuleExpression {
                     kind: ModuleExpressionKind::BoundedModuleValueUse {
                         index: BoundedValueIndex::Module(5),
                     },
                     operations: ModuleOperations {
-                        expressions: vec![],
-                        operations: vec![],
+                        expressions: Box::new([]),
+                        operations: Box::new([]),
                     },
-                }),
+                })),
                 |reader| deserialize_for_iterator(&ctx, reader),
                 &[0, 1],
             );

--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -253,7 +253,7 @@ pub enum Expression {
     IEquals(Box<Expression>, Box<Expression>),
 
     /// Does a string matches a regex.
-    Matches(Box<Expression>, Regex),
+    Matches(Box<Expression>, Box<Regex>),
 
     /// Is a given value defined.
     ///
@@ -292,53 +292,13 @@ pub enum Expression {
     },
 
     /// Evaluate multiple variables on a given expression.
-    ///
-    /// For each variable in `set`, evaluate `body`.
-    /// Then, if the number of evaluations returning true
-    /// matches the `selection`, then this expression returns true.
-    For {
-        /// How many variables must match for this expression to be true.
-        selection: ForSelection,
-
-        /// Which variables to select.
-        set: VariableSet,
-
-        /// Expression to evaluate for each variable.
-        ///
-        /// The body can contain `$`, `#`, `@` or `!` to refer to the
-        /// currently selected variable.
-        body: Box<Expression>,
-    },
+    For(Box<ForExpr>),
 
     /// Evaluate an identifier with multiple values on a given expression.
-    ///
-    /// Same as [`Self::For`], but instead of binding a variable,
-    /// an identifier is bounded to multiple values.
-    ///
-    /// For example: `for all i in (0..#a): ( @a[i] < 100 )`
-    ForIdentifiers {
-        /// How many times the body must evaluate to true for this expresion
-        /// to be true.
-        selection: ForSelection,
-
-        /// Identifiers names & values to bind.
-        iterator: ForIterator,
-
-        /// Body to evaluate for each binding.
-        body: Box<Expression>,
-    },
+    ForIdentifiers(Box<ForIdentifiers>),
 
     /// Depend on multiple rules already declared in the namespace.
-    ///
-    /// If the number of matching rules in the set matches the `selection`,
-    /// this expression returns true.
-    ForRules {
-        /// How many rules must match for this expression to be true.
-        selection: ForSelection,
-
-        /// Which rules to select.
-        set: RuleSet,
-    },
+    ForRules(Box<ForRules>),
 
     /// Call into a module
     Module(Box<ModuleExpression>),
@@ -357,7 +317,62 @@ pub enum Expression {
     Bytes(BytesSymbol),
 
     /// A regex.
-    Regex(Regex),
+    Regex(Box<Regex>),
+}
+
+/// Evaluate multiple variables on a given expression.
+///
+/// For each variable in `set`, evaluate `body`.
+/// Then, if the number of evaluations returning true
+/// matches the `selection`, then this expression returns true.
+#[derive(Debug)]
+#[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
+pub struct ForExpr {
+    /// How many variables must match for this expression to be true.
+    pub selection: ForSelection,
+
+    /// Which variables to select.
+    pub set: VariableSet,
+
+    /// Expression to evaluate for each variable.
+    ///
+    /// The body can contain `$`, `#`, `@` or `!` to refer to the
+    /// currently selected variable.
+    pub body: Box<Expression>,
+}
+
+/// Evaluate an identifier with multiple values on a given expression.
+///
+/// Same as [`Self::For`], but instead of binding a variable,
+/// an identifier is bounded to multiple values.
+///
+/// For example: `for all i in (0..#a): ( @a[i] < 100 )`
+#[derive(Debug)]
+#[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
+pub struct ForIdentifiers {
+    /// How many times the body must evaluate to true for this expresion
+    /// to be true.
+    pub selection: ForSelection,
+
+    /// Identifiers names & values to bind.
+    pub iterator: ForIterator,
+
+    /// Body to evaluate for each binding.
+    pub body: Box<Expression>,
+}
+
+/// Depend on multiple rules already declared in the namespace.
+///
+/// If the number of matching rules in the set matches the `selection`,
+/// this expression returns true.
+#[derive(Debug)]
+#[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
+pub struct ForRules {
+    /// How many rules must match for this expression to be true.
+    pub selection: ForSelection,
+
+    /// Which rules to select.
+    pub set: RuleSet,
 }
 
 impl Expression {
@@ -704,7 +719,7 @@ pub(super) fn compile_expression(
             Ok(Expr {
                 expr: Expression::Matches(
                     expr.unwrap_expr(Type::Bytes)?,
-                    compile_regex(compiler, regex)?,
+                    Box::new(compile_regex(compiler, regex)?),
                 ),
                 ty: Type::Boolean,
                 span,
@@ -781,7 +796,7 @@ pub(super) fn compile_expression(
             set,
             body,
         } => Ok(Expr {
-            expr: Expression::For {
+            expr: Expression::For(Box::new(ForExpr {
                 selection: compile_for_selection(compiler, selection)?,
                 set: compile_variable_set(compiler, set, span.clone())?,
                 body: match body {
@@ -791,7 +806,7 @@ pub(super) fn compile_expression(
                     }
                     None => Box::new(Expression::Variable(VariableIndex(None))),
                 },
-            },
+            })),
             ty: Type::Boolean,
             span,
         }),
@@ -806,7 +821,7 @@ pub(super) fn compile_expression(
             let to = compile_expression(compiler, *to)?;
 
             Ok(Expr {
-                expr: Expression::For {
+                expr: Expression::For(Box::new(ForExpr {
                     selection: compile_for_selection(compiler, selection)?,
                     set: compile_variable_set(compiler, set, span.clone())?,
                     body: Box::new(Expression::VariableIn {
@@ -814,7 +829,7 @@ pub(super) fn compile_expression(
                         from: from.unwrap_expr(Type::Integer)?,
                         to: to.unwrap_expr(Type::Integer)?,
                     }),
-                },
+                })),
                 ty: Type::Boolean,
                 span,
             })
@@ -828,14 +843,14 @@ pub(super) fn compile_expression(
             let offset = compile_expression(compiler, *offset)?;
 
             Ok(Expr {
-                expr: Expression::For {
+                expr: Expression::For(Box::new(ForExpr {
                     selection: compile_for_selection(compiler, selection)?,
                     set: compile_variable_set(compiler, set, span.clone())?,
                     body: Box::new(Expression::VariableAt {
                         variable_index: VariableIndex(None),
                         offset: offset.unwrap_expr(Type::Integer)?,
                     }),
-                },
+                })),
                 ty: Type::Boolean,
                 span,
             })
@@ -863,21 +878,21 @@ pub(super) fn compile_expression(
             }
 
             Ok(Expr {
-                expr: Expression::ForIdentifiers {
+                expr: Expression::ForIdentifiers(Box::new(ForIdentifiers {
                     selection,
                     iterator,
                     body: Box::new(to_bool_expr(compiler, body)?),
-                },
+                })),
                 ty: Type::Boolean,
                 span,
             })
         }
 
         parser::ExpressionKind::ForRules { selection, set } => Ok(Expr {
-            expr: Expression::ForRules {
+            expr: Expression::ForRules(Box::new(ForRules {
                 selection: compile_for_selection(compiler, selection)?,
                 set: compile_rule_set(compiler, set)?,
-            },
+            })),
             ty: Type::Boolean,
             span,
         }),
@@ -893,7 +908,7 @@ pub(super) fn compile_expression(
             span,
         }),
         parser::ExpressionKind::Regex(regex) => Ok(Expr {
-            expr: Expression::Regex(compile_regex(compiler, regex)?),
+            expr: Expression::Regex(Box::new(compile_regex(compiler, regex)?)),
             ty: Type::Regex,
             span,
         }),
@@ -1353,7 +1368,10 @@ mod wire {
     use crate::wire::DeserializeContext;
 
     use super::module::ModuleExpression;
-    use super::{Expression, ForIterator, ForSelection, RuleSet, VariableIndex, VariableSet};
+    use super::{
+        Expression, ForExpr, ForIdentifiers, ForIterator, ForRules, ForSelection, RuleSet,
+        VariableIndex, VariableSet,
+    };
 
     impl Serialize for Expression {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
@@ -1569,30 +1587,17 @@ mod wire {
                     from.serialize(writer)?;
                     to.serialize(writer)?;
                 }
-                Self::For {
-                    selection,
-                    set,
-                    body,
-                } => {
+                Self::For(for_expr) => {
                     37_u8.serialize(writer)?;
-                    selection.serialize(writer)?;
-                    set.serialize(writer)?;
-                    body.serialize(writer)?;
+                    for_expr.serialize(writer)?;
                 }
-                Self::ForIdentifiers {
-                    selection,
-                    iterator,
-                    body,
-                } => {
+                Self::ForIdentifiers(for_expr) => {
                     38_u8.serialize(writer)?;
-                    selection.serialize(writer)?;
-                    iterator.serialize(writer)?;
-                    body.serialize(writer)?;
+                    for_expr.serialize(writer)?;
                 }
-                Self::ForRules { selection, set } => {
+                Self::ForRules(for_expr) => {
                     39_u8.serialize(writer)?;
-                    selection.serialize(writer)?;
-                    set.serialize(writer)?;
+                    for_expr.serialize(writer)?;
                 }
                 Self::Module(module_expr) => {
                     40_u8.serialize(writer)?;
@@ -1808,7 +1813,7 @@ mod wire {
             }
             31 => {
                 let expr = Box::new(deserialize_expr(ctx, reader)?);
-                let regex = Regex::deserialize_reader(reader)?;
+                let regex = Box::new(Regex::deserialize_reader(reader)?);
                 Expression::Matches(expr, regex)
             }
             32 => Expression::Defined(Box::new(deserialize_expr(ctx, reader)?)),
@@ -1833,29 +1838,16 @@ mod wire {
                 }
             }
             37 => {
-                let selection = deserialize_for_selection(ctx, reader)?;
-                let set = VariableSet::deserialize_reader(reader)?;
-                let body = Box::new(deserialize_expr(ctx, reader)?);
-                Expression::For {
-                    selection,
-                    set,
-                    body,
-                }
+                let for_expr = deserialize_for_expr(ctx, reader)?;
+                Expression::For(Box::new(for_expr))
             }
             38 => {
-                let selection = deserialize_for_selection(ctx, reader)?;
-                let iterator = deserialize_for_iterator(ctx, reader)?;
-                let body = Box::new(deserialize_expr(ctx, reader)?);
-                Expression::ForIdentifiers {
-                    selection,
-                    iterator,
-                    body,
-                }
+                let for_identifiers = deserialize_for_identifiers(ctx, reader)?;
+                Expression::ForIdentifiers(Box::new(for_identifiers))
             }
             39 => {
-                let selection = deserialize_for_selection(ctx, reader)?;
-                let set = RuleSet::deserialize_reader(reader)?;
-                Expression::ForRules { selection, set }
+                let for_rules = deserialize_for_rules(ctx, reader)?;
+                Expression::ForRules(Box::new(for_rules))
             }
             40 => {
                 let expr = ModuleExpression::deserialize(ctx, reader)?;
@@ -1864,7 +1856,7 @@ mod wire {
             41 => Expression::Rule(usize::deserialize_reader(reader)?),
             42 => Expression::ExternalSymbol(usize::deserialize_reader(reader)?),
             43 => Expression::Bytes(BytesSymbol::deserialize_reader(reader)?),
-            44 => Expression::Regex(Regex::deserialize_reader(reader)?),
+            44 => Expression::Regex(Box::new(Regex::deserialize_reader(reader)?)),
             v => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -1872,6 +1864,86 @@ mod wire {
                 ));
             }
         })
+    }
+
+    impl Serialize for ForExpr {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            let Self {
+                selection,
+                set,
+                body,
+            } = self;
+
+            selection.serialize(writer)?;
+            set.serialize(writer)?;
+            body.serialize(writer)?;
+
+            Ok(())
+        }
+    }
+
+    fn deserialize_for_expr<R: io::Read>(
+        ctx: &DeserializeContext,
+        reader: &mut R,
+    ) -> io::Result<ForExpr> {
+        let selection = deserialize_for_selection(ctx, reader)?;
+        let set = VariableSet::deserialize_reader(reader)?;
+        let body = Box::new(deserialize_expr(ctx, reader)?);
+        Ok(ForExpr {
+            selection,
+            set,
+            body,
+        })
+    }
+
+    impl Serialize for ForIdentifiers {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            let Self {
+                selection,
+                iterator,
+                body,
+            } = self;
+
+            selection.serialize(writer)?;
+            iterator.serialize(writer)?;
+            body.serialize(writer)?;
+
+            Ok(())
+        }
+    }
+
+    fn deserialize_for_identifiers<R: io::Read>(
+        ctx: &DeserializeContext,
+        reader: &mut R,
+    ) -> io::Result<ForIdentifiers> {
+        let selection = deserialize_for_selection(ctx, reader)?;
+        let iterator = deserialize_for_iterator(ctx, reader)?;
+        let body = Box::new(deserialize_expr(ctx, reader)?);
+        Ok(ForIdentifiers {
+            selection,
+            iterator,
+            body,
+        })
+    }
+
+    impl Serialize for ForRules {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            let Self { selection, set } = self;
+
+            selection.serialize(writer)?;
+            set.serialize(writer)?;
+
+            Ok(())
+        }
+    }
+
+    fn deserialize_for_rules<R: io::Read>(
+        ctx: &DeserializeContext,
+        reader: &mut R,
+    ) -> io::Result<ForRules> {
+        let selection = deserialize_for_selection(ctx, reader)?;
+        let set = RuleSet::deserialize_reader(reader)?;
+        Ok(ForRules { selection, set })
     }
 
     impl Serialize for ForSelection {
@@ -2294,7 +2366,7 @@ mod wire {
             test_round_trip_custom_deser(
                 &Expression::Matches(
                     Box::new(Expression::Entrypoint),
-                    Regex::from_string("ab+c{2,3}".to_owned(), true, false).unwrap(),
+                    Box::new(Regex::from_string("ab+c{2,3}".to_owned(), true, false).unwrap()),
                 ),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1, 2],
@@ -2332,33 +2404,33 @@ mod wire {
                 &[0, 1, 2, 3],
             );
             test_round_trip_custom_deser(
-                &Expression::For {
+                &Expression::For(Box::new(ForExpr {
                     selection: ForSelection::Any,
                     set: VariableSet {
                         elements: Box::new([1]),
                     },
                     body: Box::new(Expression::Filesize),
-                },
+                })),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1, 2, 14],
             );
             test_round_trip_custom_deser(
-                &Expression::ForIdentifiers {
+                &Expression::ForIdentifiers(Box::new(ForIdentifiers {
                     selection: ForSelection::Any,
                     iterator: ForIterator::List(Box::new([])),
                     body: Box::new(Expression::Filesize),
-                },
+                })),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1, 2, 7],
             );
             test_round_trip_custom_deser(
-                &Expression::ForRules {
+                &Expression::ForRules(Box::new(ForRules {
                     selection: ForSelection::Any,
                     set: RuleSet {
                         elements: Box::new([1]),
                         already_matched: 3,
                     },
-                },
+                })),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1, 2],
             );
@@ -2392,7 +2464,9 @@ mod wire {
                 &[0, 1],
             );
             test_round_trip_custom_deser(
-                &Expression::Regex(Regex::from_string("abc".to_owned(), false, true).unwrap()),
+                &Expression::Regex(Box::new(
+                    Regex::from_string("abc".to_owned(), false, true).unwrap(),
+                )),
                 |reader| deserialize_expr(&ctx, reader),
                 &[0, 1],
             );

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -72,7 +72,7 @@ pub enum ModuleExpressionKind {
 
         /// List of subfields to apply to access the function.
         #[cfg(feature = "serialize")]
-        subfields: Vec<String>,
+        subfields: Box<[Box<str>]>,
     },
 }
 
@@ -87,17 +87,17 @@ pub struct ModuleOperations {
     /// as it can be done immutably.
     ///
     /// The expressions are stored in the same order the operations will be evaluated.
-    pub expressions: Vec<Expression>,
+    pub expressions: Box<[Expression]>,
 
     /// List of operations to apply to the module value.
-    pub operations: Vec<ValueOperation>,
+    pub operations: Box<[ValueOperation]>,
 }
 
 /// Operations on identifiers.
 #[derive(Debug, PartialEq)]
 pub enum ValueOperation {
     /// Object subfield, i.e. `value.subfield`.
-    Subfield(String),
+    Subfield(Box<str>),
     /// Array/dict subscript, i.e. `value[subscript]`.
     ///
     /// The value used as the subscript index is stored in [`ModuleOperations::expressions`].
@@ -247,7 +247,7 @@ pub(super) fn compile_identifier<'a, 'b>(
             kind: ModuleUseKind::Static {
                 current_value: value,
                 module_index: module.module_index,
-                applied_subfields: vec![subfield],
+                applied_subfields: vec![subfield.into_boxed_str()],
             },
         },
         None => {
@@ -300,7 +300,7 @@ enum ModuleUseKind<'a> {
     Static {
         current_value: &'a StaticValue,
         module_index: usize,
-        applied_subfields: Vec<String>,
+        applied_subfields: Vec<Box<str>>,
     },
     /// A static function.
     ///
@@ -311,7 +311,7 @@ enum ModuleUseKind<'a> {
         fun: StaticFunction,
         current_type: &'a ValueType,
         module_index: usize,
-        applied_subfields: Vec<String>,
+        applied_subfields: Vec<Box<str>>,
     },
     /// A dynamic value, coming from the `get_dynamic_values` methods.
     ///
@@ -331,9 +331,10 @@ impl ModuleUse<'_, '_> {
                 match &mut self.kind {
                     ModuleUseKind::Static {
                         applied_subfields, ..
-                    } => applied_subfields.push(subfield),
+                    } => applied_subfields.push(subfield.into_boxed_str()),
                     ModuleUseKind::StaticFunction { .. } | ModuleUseKind::Dynamic { .. } => {
-                        self.operations.push(ValueOperation::Subfield(subfield));
+                        self.operations
+                            .push(ValueOperation::Subfield(subfield.into_boxed_str()));
                     }
                 }
                 res
@@ -425,19 +426,19 @@ impl ModuleUse<'_, '_> {
                     let _ = module_index;
                     drop(applied_subfields);
                 }
-                let expr = Expression::Module(ModuleExpression {
+                let expr = Expression::Module(Box::new(ModuleExpression {
                     kind: ModuleExpressionKind::StaticFunction {
                         fun,
                         #[cfg(feature = "serialize")]
                         module_index,
                         #[cfg(feature = "serialize")]
-                        subfields: applied_subfields,
+                        subfields: applied_subfields.into_boxed_slice(),
                     },
                     operations: ModuleOperations {
-                        expressions: self.operations_expressions,
-                        operations: self.operations,
+                        expressions: self.operations_expressions.into_boxed_slice(),
+                        operations: self.operations.into_boxed_slice(),
                     },
-                });
+                }));
 
                 (expr, current_type.clone())
             }
@@ -445,15 +446,15 @@ impl ModuleUse<'_, '_> {
                 current_type,
                 bounded_value_index,
             } => {
-                let expr = Expression::Module(ModuleExpression {
+                let expr = Expression::Module(Box::new(ModuleExpression {
                     kind: ModuleExpressionKind::BoundedModuleValueUse {
                         index: bounded_value_index,
                     },
                     operations: ModuleOperations {
-                        expressions: self.operations_expressions,
-                        operations: self.operations,
+                        expressions: self.operations_expressions.into_boxed_slice(),
+                        operations: self.operations.into_boxed_slice(),
                     },
-                });
+                }));
                 (expr, current_type.clone())
             }
         };
@@ -480,8 +481,8 @@ impl ModuleUse<'_, '_> {
                         index: bounded_value_index,
                     },
                     operations: ModuleOperations {
-                        expressions: self.operations_expressions,
-                        operations: self.operations,
+                        expressions: self.operations_expressions.into_boxed_slice(),
+                        operations: self.operations.into_boxed_slice(),
                     },
                 };
                 let ty = match current_type {
@@ -765,8 +766,8 @@ mod wire {
         }
         let operations = <Vec<ValueOperation>>::deserialize_reader(reader)?;
         Ok(ModuleOperations {
-            expressions,
-            operations,
+            expressions: expressions.into_boxed_slice(),
+            operations: operations.into_boxed_slice(),
         })
     }
 
@@ -815,7 +816,7 @@ mod wire {
                     Some(fun) => Ok(ModuleExpressionKind::StaticFunction {
                         fun,
                         module_index,
-                        subfields,
+                        subfields: subfields.into_iter().map(String::into_boxed_str).collect(),
                     }),
                     None => Err(io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -899,7 +900,10 @@ mod wire {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
             let discriminant = u8::deserialize_reader(reader)?;
             match discriminant {
-                0 => Ok(Self::Subfield(String::deserialize_reader(reader)?)),
+                0 => {
+                    let subfield = String::deserialize_reader(reader)?;
+                    Ok(Self::Subfield(subfield.into_boxed_str()))
+                }
                 1 => Ok(Self::Subscript),
                 2 => {
                     let v = usize::deserialize_reader(reader)?;
@@ -930,8 +934,8 @@ mod wire {
                         index: BoundedValueIndex::Module(5),
                     },
                     operations: ModuleOperations {
-                        expressions: vec![],
-                        operations: vec![],
+                        expressions: Box::new([]),
+                        operations: Box::new([]),
                     },
                 },
                 |reader| deserialize_module_expression(&ctx, reader),
@@ -939,11 +943,11 @@ mod wire {
             );
             test_round_trip_custom_deser(
                 &ModuleOperations {
-                    expressions: vec![Expression::Integer(23)],
-                    operations: vec![
+                    expressions: Box::new([Expression::Integer(23)]),
+                    operations: Box::new([
                         ValueOperation::Subscript,
-                        ValueOperation::Subfield("abc".to_owned()),
-                    ],
+                        ValueOperation::Subfield(<Box<str>>::from("abc")),
+                    ]),
                 },
                 |reader| deserialize_module_operations(&ctx, reader),
                 &[0, 4, 12],
@@ -984,7 +988,7 @@ mod wire {
                 &ModuleExpressionKind::StaticFunction {
                     fun: now_fun,
                     module_index: 0,
-                    subfields: vec!["now".to_owned()],
+                    subfields: Box::new([<Box<str>>::from("now")]),
                 },
                 |reader| deserialize_module_expression_kind(&ctx, reader),
                 &[0, 1, 9],
@@ -993,7 +997,7 @@ mod wire {
                 &ModuleExpressionKind::StaticFunction {
                     fun: mean_fun,
                     module_index: 1,
-                    subfields: vec!["mean".to_owned()],
+                    subfields: Box::new([<Box<str>>::from("mean")]),
                 },
                 |reader| deserialize_module_expression_kind(&ctx, reader),
                 &[0, 1, 9],
@@ -1010,24 +1014,24 @@ mod wire {
             test_fail_deser(ModuleExpressionKind::StaticFunction {
                 fun: mean_fun,
                 module_index: 5,
-                subfields: vec!["mean".to_owned()],
+                subfields: Box::new([<Box<str>>::from("mean")]),
             });
 
             // Check invalid subfield value
             test_fail_deser(ModuleExpressionKind::StaticFunction {
                 fun: mean_fun,
                 module_index: 1,
-                subfields: vec![],
+                subfields: Box::new([]),
             });
             test_fail_deser(ModuleExpressionKind::StaticFunction {
                 fun: mean_fun,
                 module_index: 1,
-                subfields: vec!["toto".to_owned()],
+                subfields: Box::new([<Box<str>>::from("toto")]),
             });
             test_fail_deser(ModuleExpressionKind::StaticFunction {
                 fun: mean_fun,
                 module_index: 1,
-                subfields: vec!["MEAN_BYTES".to_owned(), "toto".to_owned()],
+                subfields: Box::new([<Box<str>>::from("MEAN_BYTES"), <Box<str>>::from("toto")]),
             });
 
             let mut reader = io::Cursor::new(b"\x05");
@@ -1044,7 +1048,7 @@ mod wire {
 
         #[test]
         fn test_wire_value_operation() {
-            test_round_trip(&ValueOperation::Subfield("aze".to_string()), &[0, 2]);
+            test_round_trip(&ValueOperation::Subfield(<Box<str>>::from("aze")), &[0, 2]);
             test_round_trip(&ValueOperation::Subscript, &[0]);
             test_round_trip(&ValueOperation::FunctionCall(23), &[0, 2]);
 
@@ -1069,19 +1073,19 @@ mod tests {
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(compile_module(&crate::module::Time));
-        test_type_traits_non_clonable(ValueOperation::Subfield("a".to_owned()));
+        test_type_traits_non_clonable(ValueOperation::Subfield(<Box<str>>::from("a")));
         test_type_traits_non_clonable(BoundedValueIndex::Module(0));
         test_type_traits_non_clonable(ModuleOperations {
-            expressions: Vec::new(),
-            operations: Vec::new(),
+            expressions: Box::new([]),
+            operations: Box::new([]),
         });
         test_type_traits_non_clonable(ModuleExpression {
             kind: ModuleExpressionKind::BoundedModuleValueUse {
                 index: BoundedValueIndex::Module(0),
             },
             operations: ModuleOperations {
-                expressions: Vec::new(),
-                operations: Vec::new(),
+                expressions: Box::new([]),
+                operations: Box::new([]),
             },
         });
         test_type_traits_non_clonable(ModuleExpressionKind::BoundedModuleValueUse {
@@ -1092,7 +1096,7 @@ mod tests {
             #[cfg(feature = "serialize")]
             module_index: 0,
             #[cfg(feature = "serialize")]
-            subfields: Vec::new(),
+            subfields: Box::new([]),
         });
         test_type_traits_non_clonable(IteratorType::Array(ValueType::Integer));
         test_type_traits_non_clonable(TypeError::UnknownSubfield("a".to_owned()));

--- a/boreal/src/compiler/params.rs
+++ b/boreal/src/compiler/params.rs
@@ -100,10 +100,12 @@ impl CompilerParams {
     ///
     /// If a rule contains more strings than this limit, its compilation will fail.
     ///
+    /// For optimization reasons, there is a hard cap on this value to `u32::MAX - 1`.
+    ///
     /// Default value is 10 000.
     #[must_use]
     pub fn max_strings_per_rule(mut self, max_strings_per_rule: usize) -> Self {
-        self.max_strings_per_rule = max_strings_per_rule;
+        self.max_strings_per_rule = std::cmp::min(max_strings_per_rule, (u32::MAX - 1) as usize);
         self
     }
 

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::num::NonZeroU32;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -192,7 +193,17 @@ impl<'a> RuleCompiler<'a> {
         if name.is_empty() {
             Ok(VariableIndex(None))
         } else {
-            Ok(VariableIndex(Some(self.find_named_variable(name, span)?)))
+            let idx = self.find_named_variable(name, span)?;
+
+            // Cast to NonZeroU32 to gain space in expressions. we add +1 to
+            // make it non zero, hence optimizing the Option around it.
+            #[allow(clippy::cast_possible_truncation)]
+            // Safety: this is *safe*, because there cannot be more than (u32::MAX - 1)
+            // variables in a given rule. This is enforced by the `max_strings_per_rule`
+            // parameter.
+            let idx = NonZeroU32::new((idx + 1) as u32).unwrap();
+
+            Ok(VariableIndex(Some(idx)))
         }
     }
 

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -223,10 +223,12 @@ macro_rules! apply_cmp_op {
 
 impl Evaluator<'_, '_, '_, '_> {
     fn get_variable_index(&self, var_index: VariableIndex) -> Result<usize, PoisonKind> {
-        var_index
-            .0
-            .or(self.currently_selected_variable_index)
-            .ok_or(PoisonKind::Undefined)
+        match var_index.0 {
+            Some(idx) => Ok((idx.get() - 1) as usize),
+            None => self
+                .currently_selected_variable_index
+                .ok_or(PoisonKind::Undefined),
+        }
     }
 
     fn get_var_matches(&self) -> Result<&variable::VarMatches<'_>, PoisonKind> {

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -36,7 +36,9 @@
 //!
 //! For all of those, an undefined value is considered to be equivalent to a false boolean value.
 use crate::bytes_pool::BytesPool;
-use crate::compiler::expression::{Expression, ForIterator, ForSelection, VariableIndex};
+use crate::compiler::expression::{
+    Expression, ForExpr, ForIdentifiers, ForIterator, ForRules, ForSelection, VariableIndex,
+};
 use crate::compiler::rule::Rule;
 use crate::memory::Memory;
 use crate::regex::Regex;
@@ -600,11 +602,12 @@ impl Evaluator<'_, '_, '_, '_> {
                 }
             }
 
-            Expression::For {
-                selection,
-                set,
-                body,
-            } => {
+            Expression::For(for_expr) => {
+                let ForExpr {
+                    selection,
+                    set,
+                    body,
+                } = &**for_expr;
                 let selection = match self.evaluate_for_selection(selection, set.elements.len())? {
                     ForSelectionEvaluation::Evaluator(e) => e,
                     ForSelectionEvaluation::Value(v) => return Ok(v),
@@ -617,11 +620,12 @@ impl Evaluator<'_, '_, '_, '_> {
                 result
             }
 
-            Expression::ForIdentifiers {
-                selection,
-                iterator,
-                body,
-            } => {
+            Expression::ForIdentifiers(for_identifiers) => {
+                let ForIdentifiers {
+                    selection,
+                    iterator,
+                    body,
+                } = &**for_identifiers;
                 if matches!(
                     selection,
                     ForSelection::Expr {
@@ -648,7 +652,8 @@ impl Evaluator<'_, '_, '_, '_> {
                 }
             }
 
-            Expression::ForRules { selection, set } => {
+            Expression::ForRules(for_rules) => {
+                let ForRules { selection, set } = &**for_rules;
                 let nb_elements = set.elements.len() + set.already_matched;
 
                 let mut selection = match self.evaluate_for_selection(selection, nb_elements)? {
@@ -688,7 +693,7 @@ impl Evaluator<'_, '_, '_, '_> {
             Expression::Integer(v) => Ok(Value::Integer(*v)),
             Expression::Double(v) => Ok(Value::Float(*v)),
             Expression::Bytes(v) => Ok(Value::Bytes(self.bytes_pool.get(*v).to_vec())),
-            Expression::Regex(v) => Ok(Value::Regex(v.clone())),
+            Expression::Regex(v) => Ok(Value::Regex(<Regex as Clone>::clone(v))),
             Expression::Boolean(v) => Ok(Value::Boolean(*v)),
         }
     }

--- a/boreal/src/wire.rs
+++ b/boreal/src/wire.rs
@@ -41,7 +41,7 @@ pub use borsh::BorshSerialize as Serialize;
 
 use crate::module::StaticValue;
 
-const VERSION: u32 = 0;
+const VERSION: u32 = 1;
 
 #[derive(Default)]
 pub(crate) struct DeserializeContext {


### PR DESCRIPTION
The condition of compiled rules is expressed using a tree of the `Expression` variant. This variant is sized according to the largest element, which means that a lot of bytes are wasted in most cases.

This PR reduces the size of the enum from 88 bytes to 24 bytes (for x64 arch). This is done through several optimizations:

- Growable types are replaced with boxed slices: Vec, String. This drops a usize for the capacity which is not used
- The largest elements are boxed, trading memory space for an indirection and dropping the size to a single usize
- The `VariableIndex`, used in many expressions, is optimized from 16 bytes to 4.

Those optimizations have a few visible consequences (outside of the memory footprint reduction):

- The serialization format version is bumped: previously serialized Scanners can no longer be loaded.
- The `max_strings_per_rule` limit is now capped to `u32::MAX - 1`. I hardly think this is an issue for anyone.

The benchmarks are not updated: further optimizations are planned to be done, and I won't recompute them for every optimizing PR.