### PR TITLE
Remove growable types in compiled types

### DIFF
--- a/boreal-cli/src/main.rs
+++ b/boreal-cli/src/main.rs
@@ -656,7 +656,10 @@ fn display_rule(
         return;
     }
     if let Some(tag) = options.tag.as_ref()
-        && rule.tags.iter().all(|t| t != tag)
+        && rule
+            .tags
+            .iter()
+            .all(|t| scanner.get_string_symbol(*t) != tag)
     {
         return;
     }
@@ -667,7 +670,12 @@ fn display_rule(
     }
     write!(stdout, "{}", rule.name).unwrap();
     if options.print_tags {
-        write!(stdout, " [{}]", rule.tags.join(",")).unwrap();
+        let tags: Vec<_> = rule
+            .tags
+            .iter()
+            .map(|t| scanner.get_string_symbol(*t))
+            .collect();
+        write!(stdout, " [{}]", tags.join(",")).unwrap();
     }
     if options.print_metadata {
         print_metadata(stdout, scanner, rule.metadatas);

--- a/boreal-py/src/rule.rs
+++ b/boreal-py/src/rule.rs
@@ -43,11 +43,16 @@ impl Rule {
         scanner: &scanner::Scanner,
         rule: &scanner::RuleDetails,
     ) -> PyResult<Self> {
+        let tags: Vec<_> = rule
+            .tags
+            .iter()
+            .map(|sym| scanner.get_string_symbol(*sym))
+            .collect();
         Ok(Self {
             identifier: PyString::new(py, rule.name).unbind(),
             namespace: PyString::new(py, rule.namespace).unbind(),
             meta: convert_metadatas(py, scanner, rule.metadatas, false)?.unbind(),
-            tags: PyList::new(py, rule.tags)?.unbind(),
+            tags: PyList::new(py, tags)?.unbind(),
             is_global: rule.is_global,
             is_private: rule.is_private,
         })

--- a/boreal-py/src/rule_match.rs
+++ b/boreal-py/src/rule_match.rs
@@ -67,12 +67,17 @@ impl Match {
         rule: scanner::EvaluatedRule,
         allow_duplicate_metadata: bool,
     ) -> Result<Self, PyErr> {
+        let tags: Vec<_> = rule
+            .tags
+            .iter()
+            .map(|sym| scanner.get_string_symbol(*sym))
+            .collect();
         Ok(Self {
             rule: rule.name.to_string(),
             namespace: rule.namespace.to_string(),
             meta: convert_metadatas(py, scanner, rule.metadatas, allow_duplicate_metadata)?
                 .unbind(),
-            tags: PyList::new(py, rule.tags)?.unbind(),
+            tags: PyList::new(py, tags)?.unbind(),
             strings: PyList::new(py, rule.matches.into_iter().map(StringMatches::new))?.unbind(),
         })
     }

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -300,7 +300,7 @@ impl Compiler {
                 let idx = self.namespaces.len();
                 let _r = v.insert(idx);
                 self.namespaces.push(Namespace {
-                    name: namespace_name.to_string(),
+                    name: namespace_name.into(),
                     ..Namespace::default()
                 });
                 idx
@@ -469,7 +469,7 @@ impl Compiler {
                     status.statistics.push(statistics::CompiledRule {
                         filepath: current_filepath.map(ToOwned::to_owned),
                         namespace: namespace.name.clone(),
-                        name: rule.name.to_string(),
+                        name: rule.name.clone(),
                         strings: variables_statistics,
                     });
                 }
@@ -627,7 +627,7 @@ impl Compiler {
 #[derive(Debug, Default)]
 pub(crate) struct Namespace {
     /// Name of the namespace.
-    pub(crate) name: String,
+    pub(crate) name: Box<str>,
 
     /// Map of a rule name to its index in the `rules` vector in [`Compiler`].
     ///

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -469,7 +469,7 @@ impl Compiler {
                     status.statistics.push(statistics::CompiledRule {
                         filepath: current_filepath.map(ToOwned::to_owned),
                         namespace: namespace.name.clone(),
-                        name: rule.name.clone(),
+                        name: rule.name.to_string(),
                         strings: variables_statistics,
                     });
                 }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -27,7 +27,7 @@ pub(crate) struct Rule {
     pub(crate) namespace_index: usize,
 
     /// Tags associated with the rule.
-    pub(crate) tags: Vec<String>,
+    pub(crate) tags: Box<[StringSymbol]>,
 
     /// Metadata associated with the rule.
     pub(crate) metadatas: Box<[Metadata]>,
@@ -331,7 +331,11 @@ pub(super) fn compile_rule(
         rule: Rule {
             name: rule.name.into_boxed_str(),
             namespace_index,
-            tags: rule.tags.into_iter().map(|v| v.tag).collect(),
+            tags: rule
+                .tags
+                .into_iter()
+                .map(|v| compiler.bytes_pool.insert_str(&v.tag))
+                .collect(),
             metadatas,
             nb_variables: variables.len(),
             condition,
@@ -386,13 +390,13 @@ mod wire {
         let namespace_index = usize::deserialize_reader(reader)?;
         let nb_variables = usize::deserialize_reader(reader)?;
         let is_private = bool::deserialize_reader(reader)?;
-        let tags = <Vec<String>>::deserialize_reader(reader)?;
+        let tags = <Vec<StringSymbol>>::deserialize_reader(reader)?;
         let metadatas = <Vec<Metadata>>::deserialize_reader(reader)?;
         let condition = Expression::deserialize(ctx, reader)?;
         Ok(Rule {
             name: name.into_boxed_str(),
             namespace_index,
-            tags,
+            tags: tags.into_boxed_slice(),
             metadatas: metadatas.into_boxed_slice(),
             nb_variables,
             condition,
@@ -470,7 +474,7 @@ mod wire {
                     namespace_index: 0,
                     nb_variables: 0,
                     is_private: false,
-                    tags: Vec::new(),
+                    tags: Box::new([]),
                     metadatas: Box::new([]),
                     condition: Expression::Filesize,
                 },
@@ -529,7 +533,7 @@ mod tests {
         let build_rule = || Rule {
             name: "a".into(),
             namespace_index: 0,
-            tags: Vec::new(),
+            tags: Box::new([]),
             metadatas: Box::new([]),
             nb_variables: 0,
             condition: Expression::Filesize,

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -18,7 +18,7 @@ use crate::statistics;
 #[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
 pub(crate) struct Rule {
     /// Name of the rule.
-    pub(crate) name: String,
+    pub(crate) name: Box<str>,
 
     /// Index of the namespace containing the rule.
     ///
@@ -30,7 +30,7 @@ pub(crate) struct Rule {
     pub(crate) tags: Vec<String>,
 
     /// Metadata associated with the rule.
-    pub(crate) metadatas: Vec<Metadata>,
+    pub(crate) metadatas: Box<[Metadata]>,
 
     /// Number of variables used by the rule.
     pub(crate) nb_variables: usize,
@@ -287,7 +287,7 @@ pub(super) fn compile_rule(
         }
     }
 
-    let metadatas: Vec<_> = rule
+    let metadatas = rule
         .metadatas
         .into_iter()
         .map(|rule::Metadata { name, value }| Metadata {
@@ -329,7 +329,7 @@ pub(super) fn compile_rule(
 
     Ok(CompiledRule {
         rule: Rule {
-            name: rule.name,
+            name: rule.name.into_boxed_str(),
             namespace_index,
             tags: rule.tags.into_iter().map(|v| v.tag).collect(),
             metadatas,
@@ -390,10 +390,10 @@ mod wire {
         let metadatas = <Vec<Metadata>>::deserialize_reader(reader)?;
         let condition = Expression::deserialize(ctx, reader)?;
         Ok(Rule {
-            name,
+            name: name.into_boxed_str(),
             namespace_index,
             tags,
-            metadatas,
+            metadatas: metadatas.into_boxed_slice(),
             nb_variables,
             condition,
             is_private,
@@ -466,12 +466,12 @@ mod wire {
 
             test_round_trip_custom_deser(
                 &Rule {
-                    name: "a".to_owned(),
+                    name: "a".into(),
                     namespace_index: 0,
                     nb_variables: 0,
                     is_private: false,
                     tags: Vec::new(),
-                    metadatas: Vec::new(),
+                    metadatas: Box::new([]),
                     condition: Expression::Filesize,
                 },
                 |reader| deserialize_rule(&ctx, reader),
@@ -527,10 +527,10 @@ mod tests {
             bytes_pool: &mut BytesPoolBuilder::default(),
         });
         let build_rule = || Rule {
-            name: "a".to_owned(),
+            name: "a".into(),
             namespace_index: 0,
             tags: Vec::new(),
-            metadatas: Vec::new(),
+            metadatas: Box::new([]),
             nb_variables: 0,
             condition: Expression::Filesize,
             is_private: false,

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -3,7 +3,7 @@ use boreal_parser::rule::{VariableDeclaration, VariableDeclarationValue};
 use crate::atoms::{atoms_rank, pick_atom_in_literal};
 use crate::matcher::{Matcher, Modifiers};
 use crate::regex::regex_ast_to_hir;
-use crate::statistics;
+use crate::{StringSymbol, statistics};
 
 use super::CompilationError;
 use super::rule::RuleCompiler;
@@ -15,7 +15,7 @@ pub struct Variable {
     /// Name of the variable, without the '$'.
     ///
     /// Anonymous variables are just named "".
-    pub name: String,
+    pub name: StringSymbol,
 
     /// Is the variable marked as private.
     pub is_private: bool,
@@ -91,7 +91,7 @@ pub(super) fn compile_variable(
 
     let res = match res {
         Ok(matcher) => Variable {
-            name,
+            name: compiler.bytes_pool.insert_str(&name),
             is_private: modifiers.private,
             matcher,
         },
@@ -117,7 +117,7 @@ pub(super) fn compile_variable(
         let atoms_quality = atoms_rank(&atoms);
 
         Some(statistics::CompiledString {
-            name: res.name.clone(),
+            name,
             expr: parsed_contents[span.start..span.end].to_owned(),
             literals: res.matcher.literals.clone(),
             atoms,
@@ -154,6 +154,7 @@ impl std::fmt::Display for VariableCompilationError {
 mod wire {
     use std::io;
 
+    use crate::StringSymbol;
     use crate::wire::{Deserialize, Serialize};
 
     use super::{Matcher, Variable};
@@ -169,7 +170,7 @@ mod wire {
 
     impl Deserialize for Variable {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let name = String::deserialize_reader(reader)?;
+            let name = StringSymbol::deserialize_reader(reader)?;
             let is_private = bool::deserialize_reader(reader)?;
             let matcher = Matcher::deserialize_reader(reader)?;
             Ok(Self {
@@ -184,6 +185,7 @@ mod wire {
     mod tests {
         use boreal_parser::rule::VariableModifiers;
 
+        use crate::bytes_pool::BytesPoolBuilder;
         use crate::matcher::Matcher;
         use crate::wire::tests::test_round_trip;
 
@@ -191,9 +193,10 @@ mod wire {
 
         #[test]
         fn test_wire_variable() {
+            let mut pool = BytesPoolBuilder::default();
             test_round_trip(
                 &Variable {
-                    name: "abc".to_owned(),
+                    name: pool.insert_str("abc"),
                     is_private: true,
                     matcher: Matcher::new_bytes(Vec::new(), &VariableModifiers::default()),
                 },

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -26,7 +26,7 @@ pub(crate) struct Matcher {
     ///
     /// This is required in order to know which kind is a literal match, as checking its value
     /// would be buggy.
-    pub(crate) literals: Vec<Vec<u8>>,
+    pub(crate) literals: Box<[Box<[u8]>]>,
 
     kind: MatcherKind,
 
@@ -118,7 +118,7 @@ impl Matcher {
         if analysis.has_start_or_end_line {
             let kind = MatcherKind::Raw(raw::RawMatcher::new(hir, &analysis, modifiers)?);
             return Ok(Self {
-                literals: Vec::new(),
+                literals: Box::new([]),
                 kind,
                 modifiers,
             });
@@ -130,7 +130,7 @@ impl Matcher {
             if count < 100 && !modifiers.nocase && !modifiers.wide {
                 if let Some(literals) = only_literals::hir_to_only_literals(hir) {
                     return Ok(Self {
-                        literals,
+                        literals: literals.into_iter().map(Vec::into_boxed_slice).collect(),
                         kind: MatcherKind::Literals,
                         modifiers,
                     });
@@ -170,7 +170,7 @@ impl Matcher {
         };
 
         Ok(Self {
-            literals,
+            literals: literals.into_iter().map(Vec::into_boxed_slice).collect(),
             kind,
             modifiers,
         })
@@ -181,20 +181,21 @@ impl Matcher {
         if modifiers.wide {
             if modifiers.ascii {
                 let wide = string_to_wide(&value);
-                literals.push(value);
+                literals.push(value.into_boxed_slice());
                 literals.push(wide);
             } else {
                 literals.push(string_to_wide(&value));
             }
         } else {
-            literals.push(value);
+            literals.push(value.into_boxed_slice());
         }
 
         if let Some(xor_details) = modifiers.xor {
             // For each literal, for each byte in the xor range, build a new literal
             let xor_range = xor_details.0..=xor_details.1;
             let xor_range_len = xor_range.len(); // modifiers.xor_range.1.saturating_sub(modifiers.xor_range.0) + 1;
-            let mut new_literals: Vec<Vec<u8>> = Vec::with_capacity(literals.len() * xor_range_len);
+            let mut new_literals: Vec<Box<[u8]>> =
+                Vec::with_capacity(literals.len() * xor_range_len);
 
             // Ascii literals must be first, then wide literals. Since the "literals" var
             // is the ascii literals then the wide ones, the order is preserved.
@@ -204,7 +205,7 @@ impl Matcher {
                 }
             }
             return Self {
-                literals: new_literals,
+                literals: new_literals.into_boxed_slice(),
                 kind: MatcherKind::Literals,
                 modifiers: Modifiers {
                     fullword: modifiers.fullword,
@@ -232,7 +233,7 @@ impl Matcher {
                             if base64.wide {
                                 literals.push(string_to_wide(&lit));
                             }
-                            literals.push(lit);
+                            literals.push(lit.into_boxed_slice());
                         }
                     }
                 }
@@ -250,7 +251,7 @@ impl Matcher {
         }
 
         Matcher {
-            literals,
+            literals: literals.into_boxed_slice(),
             kind: MatcherKind::Literals,
             modifiers: Modifiers {
                 fullword: modifiers.fullword,
@@ -280,7 +281,7 @@ impl Matcher {
             if !literal.eq_ignore_ascii_case(&mem[mat.start..mat.end]) {
                 return None;
             }
-        } else if literal != &mem[mat.start..mat.end] {
+        } else if **literal != mem[mat.start..mat.end] {
             return None;
         }
 
@@ -437,13 +438,13 @@ fn widen_literal(literal: &[u8]) -> Vec<u8> {
 }
 
 /// Convert an ascii string to a wide string
-fn string_to_wide(s: &[u8]) -> Vec<u8> {
+fn string_to_wide(s: &[u8]) -> Box<[u8]> {
     let mut res = Vec::with_capacity(s.len() * 2);
     for b in s {
         res.push(*b);
         res.push(b'\0');
     }
-    res
+    res.into_boxed_slice()
 }
 
 #[cfg(feature = "serialize")]
@@ -473,7 +474,7 @@ mod wire {
             let modifiers = Modifiers::deserialize_reader(reader)?;
             let kind = deserialize_matcher_kind(modifiers, reader)?;
             Ok(Self {
-                literals,
+                literals: literals.into_iter().map(Vec::into_boxed_slice).collect(),
                 kind,
                 modifiers,
             })
@@ -564,7 +565,7 @@ mod wire {
         fn test_wire_matcher() {
             test_round_trip(
                 &Matcher {
-                    literals: vec![vec![3]],
+                    literals: Box::new([Box::new([3])]),
                     modifiers: Modifiers::default(),
                     kind: MatcherKind::Literals,
                 },
@@ -636,7 +637,7 @@ mod tests {
     #[test]
     fn test_types_traits() {
         test_type_traits_non_clonable(Matcher {
-            literals: vec![],
+            literals: Box::new([]),
             modifiers: Modifiers {
                 dot_all: false,
                 fullword: false,

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -11,7 +11,7 @@ use crate::regex::Hir;
 #[derive(Debug, PartialEq)]
 pub(crate) struct SimpleValidator {
     /// List of nodes to match
-    nodes: Vec<SimpleNode>,
+    nodes: Box<[SimpleNode]>,
     /// Total length of the expression
     length: usize,
 }
@@ -67,7 +67,10 @@ impl SimpleValidator {
             SimpleNode::Jump(len) => acc + usize::from(*len),
             _ => acc + 1,
         });
-        Some(Self { nodes, length })
+        Some(Self {
+            nodes: nodes.into_boxed_slice(),
+            length,
+        })
     }
 
     pub(crate) fn find_anchored_fwd(
@@ -211,7 +214,10 @@ mod wire {
             let nodes = <Vec<SimpleNode>>::deserialize_reader(reader)?;
             let length = usize::deserialize_reader(reader)?;
 
-            Ok(Self { nodes, length })
+            Ok(Self {
+                nodes: nodes.into_boxed_slice(),
+                length,
+            })
         }
     }
 
@@ -279,7 +285,7 @@ mod wire {
         fn test_wire_simple_validator() {
             test_round_trip(
                 &SimpleValidator {
-                    nodes: vec![SimpleNode::Byte(23), SimpleNode::Dot],
+                    nodes: Box::new([SimpleNode::Byte(23), SimpleNode::Dot]),
                     length: 23,
                 },
                 &[0, 1, 6, 12],

--- a/boreal/src/regex/mod.rs
+++ b/boreal/src/regex/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use visitor::{VisitAction, Visitor, visit};
 #[derive(Clone, Debug)]
 pub struct Regex {
     meta: meta::Regex,
-    expr: String,
+    expr: Box<str>,
     #[cfg(feature = "serialize")]
     case_insensitive: bool,
     #[cfg(feature = "serialize")]
@@ -58,7 +58,7 @@ impl Regex {
 
         Ok(Regex {
             meta,
-            expr,
+            expr: expr.into_boxed_str(),
             #[cfg(feature = "serialize")]
             case_insensitive,
             #[cfg(feature = "serialize")]

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -33,10 +33,10 @@ pub(crate) struct AcScan {
     aho: AhoCorasick,
 
     /// Map from a aho pattern index to a list details on the literals.
-    aho_index_to_literal_info: Vec<Vec<LiteralInfo>>,
+    aho_index_to_literal_info: Box<[Box<[LiteralInfo]>]>,
 
     /// List of indexes for vars that are not part of the aho corasick.
-    non_handled_var_indexes: Vec<usize>,
+    non_handled_var_indexes: Box<[usize]>,
 }
 
 /// Details on a literal of a variable.
@@ -143,8 +143,11 @@ impl AcScan {
 
         Self {
             aho,
-            aho_index_to_literal_info,
-            non_handled_var_indexes,
+            aho_index_to_literal_info: aho_index_to_literal_info
+                .into_iter()
+                .map(Vec::into_boxed_slice)
+                .collect(),
+            non_handled_var_indexes: non_handled_var_indexes.into_boxed_slice(),
         }
     }
 

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -360,7 +360,9 @@ fn build_string_identifier(
             return Some(StringIdentifier {
                 rule_namespace: scanner.namespaces[rule.namespace_index].as_ref(),
                 rule_name: &rule.name,
-                string_name: &scanner.variables[variable_index].name,
+                string_name: scanner
+                    .bytes_pool
+                    .get_str(scanner.variables[variable_index].name),
                 string_index: variable_index - index,
             });
         }

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1218,7 +1218,7 @@ impl EvalContext {
             let matched_rule = build_matched_rule(
                 rule,
                 vars,
-                &scanner.namespaces,
+                scanner,
                 var_matches.unwrap_or_default(),
                 matched,
             );
@@ -1401,16 +1401,16 @@ impl ScanData<'_, '_> {
     }
 }
 
-fn build_matched_rule<'a>(
-    rule: &'a Rule,
-    variables: &'a [Variable],
-    namespaces_names: &'a [Box<str>],
+fn build_matched_rule<'scanner>(
+    rule: &'scanner Rule,
+    variables: &'scanner [Variable],
+    scanner: &'scanner Inner,
     var_matches: Vec<Vec<StringMatch>>,
     matched: bool,
-) -> EvaluatedRule<'a> {
+) -> EvaluatedRule<'scanner> {
     EvaluatedRule {
         name: &rule.name,
-        namespace: namespaces_names[rule.namespace_index].as_ref(),
+        namespace: scanner.namespaces[rule.namespace_index].as_ref(),
         tags: &rule.tags,
         metadatas: &rule.metadatas,
         matches: var_matches
@@ -1419,7 +1419,7 @@ fn build_matched_rule<'a>(
             .filter(|(_, var)| !var.is_private)
             .filter(|(matches, _)| !matches.is_empty())
             .map(|(matches, var)| StringMatches {
-                name: &var.name,
+                name: scanner.bytes_pool.get_str(var.name),
                 matches,
                 has_xor_modifier: var.matcher.modifiers.xor_start.is_some(),
             })

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1865,10 +1865,10 @@ mod wire {
         fn test_wire_rules() {
             let ctx = DeserializeContext::default();
             let rules = vec![Rule {
-                name: "a".to_owned(),
+                name: "a".into(),
                 namespace_index: 0,
                 tags: Vec::new(),
-                metadatas: Vec::new(),
+                metadatas: Box::new([]),
                 nb_variables: 0,
                 condition: Expression::Filesize,
                 is_private: false,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -207,7 +207,7 @@ impl Scanner {
                 default_value,
             } = sym;
             external_symbols_values.push(default_value);
-            _ = external_symbols_map.insert(name, index);
+            _ = external_symbols_map.insert(name.into_boxed_str(), index);
         }
 
         Self {
@@ -714,7 +714,7 @@ impl Scanner {
 pub struct RulesIter<'scanner> {
     global_rules: std::slice::Iter<'scanner, Rule>,
     rules: std::slice::Iter<'scanner, Rule>,
-    namespaces: &'scanner [String],
+    namespaces: &'scanner [Box<str>],
 }
 
 impl<'scanner> Iterator for RulesIter<'scanner> {
@@ -790,10 +790,10 @@ struct Inner {
     modules: Box<[Box<dyn Module>]>,
 
     /// Mapping from names to index for external symbols.
-    external_symbols_map: HashMap<String, usize>,
+    external_symbols_map: HashMap<Box<str>, usize>,
 
     /// Namespaces names.
-    namespaces: Box<[String]>,
+    namespaces: Box<[Box<str>]>,
 
     /// Bytes intern pool.
     bytes_pool: BytesPool,
@@ -1402,7 +1402,7 @@ impl ScanData<'_, '_> {
 fn build_matched_rule<'a>(
     rule: &'a Rule,
     variables: &'a [Variable],
-    namespaces_names: &'a [String],
+    namespaces_names: &'a [Box<str>],
     var_matches: Vec<Vec<StringMatch>>,
     matched: bool,
 ) -> EvaluatedRule<'a> {
@@ -1606,7 +1606,7 @@ mod wire {
         params: DeserializeParams,
         reader: &mut R,
     ) -> io::Result<Inner> {
-        let external_symbols_map = <HashMap<String, usize>>::deserialize_reader(reader)?;
+        let external_symbols_map = <HashMap<Box<str>, usize>>::deserialize_reader(reader)?;
         let namespaces = <Vec<String>>::deserialize_reader(reader)?;
         let bytes_pool = BytesPool::deserialize_reader(reader)?;
         let variables = <Vec<Variable>>::deserialize_reader(reader)?;
@@ -1631,7 +1631,7 @@ mod wire {
             ac_scan,
             modules: modules.into_boxed_slice(),
             external_symbols_map,
-            namespaces: namespaces.into_boxed_slice(),
+            namespaces: namespaces.into_iter().map(String::into_boxed_str).collect(),
             bytes_pool,
             profile,
         })
@@ -1780,10 +1780,10 @@ mod wire {
         #[test]
         fn test_wire_inner() {
             let inner = Inner {
-                external_symbols_map: [("abc".to_owned(), 33), ("zyx".to_owned(), 12)]
+                external_symbols_map: [("abc".into(), 33), ("zyx".into(), 12)]
                     .into_iter()
                     .collect(),
-                namespaces: Box::new(["abc".to_owned()]),
+                namespaces: Box::new(["abc".into()]),
                 bytes_pool: BytesPoolBuilder::default().into_pool(),
                 variables: Box::new([]),
                 modules: Box::new([Box::new(Math), Box::new(Time)]),

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -748,7 +748,9 @@ pub struct RuleDetails<'scanner> {
     pub namespace: &'scanner str,
 
     /// Tags associated with the rule.
-    pub tags: &'scanner [String],
+    ///
+    /// Use [`crate::Scanner::get_string_symbol`] to retrieve each tag.
+    pub tags: &'scanner [StringSymbol],
 
     /// Metadata associated with the rule.
     pub metadatas: &'scanner [Metadata],
@@ -1456,7 +1458,7 @@ pub struct EvaluatedRule<'scanner> {
     pub namespace: &'scanner str,
 
     /// Tags associated with the rule.
-    pub tags: &'scanner [String],
+    pub tags: &'scanner [StringSymbol],
 
     /// Metadata associated with the rule.
     pub metadatas: &'scanner [Metadata],
@@ -1867,7 +1869,7 @@ mod wire {
             let rules = vec![Rule {
                 name: "a".into(),
                 namespace_index: 0,
-                tags: Vec::new(),
+                tags: Box::new([]),
                 metadatas: Box::new([]),
                 nb_variables: 0,
                 condition: Expression::Filesize,

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -94,8 +94,8 @@ pub struct Scanner {
 
     /// Default value of external symbols.
     ///
-    /// Compiled rules uses indexing into this vec to retrieve the symbols values.
-    external_symbols_values: Vec<ExternalValue>,
+    /// Compiled rules uses indexing into this array to retrieve the symbols values.
+    external_symbols_values: Box<[ExternalValue]>,
 
     /// User data associated to specific modules.
     ///
@@ -199,8 +199,8 @@ impl Scanner {
 
         let ac_scan = ac_scan::AcScan::new(&variables, profile);
 
-        let mut external_symbols_values = Vec::new();
-        let mut external_symbols_map = HashMap::new();
+        let mut external_symbols_values = Vec::with_capacity(external_symbols.len());
+        let mut external_symbols_map = HashMap::with_capacity(external_symbols.len());
         for (index, sym) in external_symbols.into_iter().enumerate() {
             let ExternalSymbol {
                 name,
@@ -212,11 +212,11 @@ impl Scanner {
 
         Self {
             inner: Arc::new(Inner {
-                rules,
-                global_rules,
-                variables,
+                rules: rules.into_boxed_slice(),
+                global_rules: global_rules.into_boxed_slice(),
+                variables: variables.into_boxed_slice(),
                 ac_scan,
-                modules: imported_modules,
+                modules: imported_modules.into_boxed_slice(),
                 external_symbols_map,
                 namespaces,
                 bytes_pool: bytes_pool.into_pool(),
@@ -224,7 +224,7 @@ impl Scanner {
                 profile,
             }),
             scan_params: ScanParams::default(),
-            external_symbols_values,
+            external_symbols_values: external_symbols_values.into_boxed_slice(),
             module_user_data: ModuleUserData::default(),
         }
     }
@@ -766,18 +766,18 @@ struct Inner {
     ///
     /// Order is important, as rules can depend on other rules, and uses indexes into this array
     /// to retrieve the truth value of rules it depends upon.
-    rules: Vec<Rule>,
+    rules: Box<[Rule]>,
 
     /// Compiled global rules.
     ///
     /// Those rules are interpreted first. If any of them is false, the other rules are not
     /// evaluated.
-    global_rules: Vec<Rule>,
+    global_rules: Box<[Rule]>,
 
     /// Compiled variables.
     ///
     /// Those are stored in the order the rules have been compiled in.
-    variables: Vec<Variable>,
+    variables: Box<[Variable]>,
 
     /// Regex set of all variables used in the rules.
     ///
@@ -787,13 +787,13 @@ struct Inner {
     ac_scan: ac_scan::AcScan,
 
     /// List of modules used during scanning.
-    modules: Vec<Box<dyn Module>>,
+    modules: Box<[Box<dyn Module>]>,
 
     /// Mapping from names to index for external symbols.
     external_symbols_map: HashMap<String, usize>,
 
     /// Namespaces names.
-    namespaces: Vec<String>,
+    namespaces: Box<[String]>,
 
     /// Bytes intern pool.
     bytes_pool: BytesPool,
@@ -1583,7 +1583,7 @@ mod wire {
         Ok(Scanner {
             inner: Arc::new(inner),
             scan_params,
-            external_symbols_values,
+            external_symbols_values: external_symbols_values.into_boxed_slice(),
             module_user_data: ModuleUserData::default(),
         })
     }
@@ -1625,13 +1625,13 @@ mod wire {
         let ac_scan = AcScan::new(&variables, profile);
 
         Ok(Inner {
-            rules,
-            global_rules,
-            variables,
+            rules: rules.into_boxed_slice(),
+            global_rules: global_rules.into_boxed_slice(),
+            variables: variables.into_boxed_slice(),
             ac_scan,
-            modules,
+            modules: modules.into_boxed_slice(),
             external_symbols_map,
-            namespaces,
+            namespaces: namespaces.into_boxed_slice(),
             bytes_pool,
             profile,
         })
@@ -1731,16 +1731,16 @@ mod wire {
         fn test_wire_scanner() {
             let scanner = Scanner {
                 scan_params: ScanParams::default(),
-                external_symbols_values: vec![ExternalValue::Integer(23)],
+                external_symbols_values: Box::new([ExternalValue::Integer(23)]),
                 module_user_data: ModuleUserData::default(),
                 inner: Arc::new(Inner {
                     external_symbols_map: HashMap::new(),
-                    namespaces: Vec::new(),
+                    namespaces: Box::new([]),
                     bytes_pool: BytesPoolBuilder::default().into_pool(),
-                    variables: Vec::new(),
-                    modules: vec![Box::new(Math)],
-                    global_rules: Vec::new(),
-                    rules: Vec::new(),
+                    variables: Box::new([]),
+                    modules: Box::new([Box::new(Math)]),
+                    global_rules: Box::new([]),
+                    rules: Box::new([]),
                     profile: CompilerProfile::Speed,
                     ac_scan: AcScan::new(&[], CompilerProfile::Speed),
                 }),
@@ -1783,12 +1783,12 @@ mod wire {
                 external_symbols_map: [("abc".to_owned(), 33), ("zyx".to_owned(), 12)]
                     .into_iter()
                     .collect(),
-                namespaces: vec!["abc".to_owned()],
+                namespaces: Box::new(["abc".to_owned()]),
                 bytes_pool: BytesPoolBuilder::default().into_pool(),
-                variables: Vec::new(),
-                modules: vec![Box::new(Math), Box::new(Time)],
-                global_rules: Vec::new(),
-                rules: Vec::new(),
+                variables: Box::new([]),
+                modules: Box::new([Box::new(Math), Box::new(Time)]),
+                global_rules: Box::new([]),
+                rules: Box::new([]),
                 profile: CompilerProfile::Speed,
                 ac_scan: AcScan::new(&[], CompilerProfile::Speed),
             };

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -33,7 +33,7 @@ pub struct CompiledString {
     pub expr: String,
 
     /// Literals extracted from the string.
-    pub literals: Vec<Vec<u8>>,
+    pub literals: Box<[Box<[u8]>]>,
 
     /// Atoms picked out of those literals.
     pub atoms: Vec<Vec<u8>>,
@@ -114,7 +114,7 @@ mod tests {
         test_type_traits(CompiledString {
             name: String::new(),
             expr: String::new(),
-            literals: Vec::new(),
+            literals: Box::new([]),
             atoms: Vec::new(),
             atoms_quality: 0,
             matching_algo: String::new(),

--- a/boreal/src/statistics.rs
+++ b/boreal/src/statistics.rs
@@ -12,10 +12,10 @@ pub struct CompiledRule {
     pub filepath: Option<PathBuf>,
 
     /// Namespace containing the rule.
-    pub namespace: String,
+    pub namespace: Box<str>,
 
     /// Name of the rule.
-    pub name: String,
+    pub name: Box<str>,
 
     /// Statistics on the compiled strings.
     ///
@@ -107,8 +107,8 @@ mod tests {
     fn test_types_traits() {
         test_type_traits(CompiledRule {
             filepath: Some(PathBuf::new()),
-            namespace: String::new(),
-            name: String::new(),
+            namespace: String::new().into_boxed_str(),
+            name: String::new().into_boxed_str(),
             strings: Vec::new(),
         });
         test_type_traits(CompiledString {

--- a/boreal/tests/it/api.rs
+++ b/boreal/tests/it/api.rs
@@ -144,7 +144,9 @@ rule r: tag {
     let r1 = &rules[1];
     assert_eq!(r1.name, "pg");
     assert_eq!(r1.namespace, "namespace");
-    assert_eq!(r1.tags, &["tag1", "tag2"]);
+    assert_eq!(r1.tags.len(), 2);
+    assert_eq!(scanner.get_string_symbol(r1.tags[0]), "tag1");
+    assert_eq!(scanner.get_string_symbol(r1.tags[1]), "tag2");
     assert!(r1.is_global);
     assert!(r1.is_private);
     assert_eq!(r1.metadatas.len(), 2);
@@ -162,7 +164,8 @@ rule r: tag {
     let r2 = &rules[2];
     assert_eq!(r2.name, "p");
     assert_eq!(r2.namespace, "default");
-    assert_eq!(r2.tags, &["tag"]);
+    assert_eq!(r2.tags.len(), 1);
+    assert_eq!(scanner.get_string_symbol(r2.tags[0]), "tag");
     assert!(!r2.is_global);
     assert!(r2.is_private);
     assert_eq!(r2.metadatas.len(), 1);
@@ -175,7 +178,8 @@ rule r: tag {
     let r3 = &rules[3];
     assert_eq!(r3.name, "r");
     assert_eq!(r3.namespace, "namespace");
-    assert_eq!(r3.tags, &["tag"]);
+    assert_eq!(r3.tags.len(), 1);
+    assert_eq!(scanner.get_string_symbol(r3.tags[0]), "tag");
     assert!(!r3.is_global);
     assert!(!r3.is_private);
     assert_eq!(r3.metadatas.len(), 0);


### PR DESCRIPTION
Replace all "growable" types in compiled objects into fixed sizes ones:

- `Vec<_>` => `Box<[_]>`
- `String` => `Box<str>`

This shaves one usize from each of those, which can compound into sizable savings in compiled size.

Additionally, move strings that are very often reused into the bytes pool.

This causes a public API change however, for the tags of a rule, which are now put in a bytes pool, forcing the caller to use `scanner.get_string_symbol` to retrieve them.