### PR TITLE
Simplify match validator, remove greedy case

### DIFF
--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -690,7 +690,7 @@ rule a {
     literals: ["barbaz"]
     atoms: ["rbaz"]
     atoms quality: 80
-    algo: Atomized { NonGreedy { reverse: Dfa, forward: none } }
+    algo: Atomized { Validator { reverse: Dfa, forward: none } }
   $d = /.{10}/ fullword
     literals: []
     atoms: []

--- a/boreal/src/matcher/literals.rs
+++ b/boreal/src/matcher/literals.rs
@@ -444,6 +444,13 @@ fn get_parts_rank(parts: &[HirPart]) -> Option<u32> {
 
     let literals = generate_literals(parts);
 
+    // If any alternation is empty, bail out: this would result in
+    // checking for the variable on every single offset of the data,
+    // which we do not want.
+    if literals.iter().any(Vec::is_empty) {
+        return None;
+    }
+
     let quality = literals
         .iter()
         .map(|v| atom_quality_from_literal(v))

--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -103,7 +103,7 @@ enum MatcherKind {
     /// The literals cover entirely the variable.
     Literals,
     /// The regex can confirm matches from AC literal matches.
-    Atomized { validator: validator::Validator },
+    Atomized(validator::Validator),
 
     /// The regex cannot confirm matches from AC literal matches.
     Raw(raw::RawMatcher),
@@ -159,14 +159,11 @@ impl Matcher {
         let kind = if literals.is_empty() {
             MatcherKind::Raw(raw::RawMatcher::new(hir, &analysis, modifiers)?)
         } else {
-            MatcherKind::Atomized {
-                validator: validator::Validator::new(
-                    pre_hir.as_ref(),
-                    post_hir.as_ref(),
-                    hir,
-                    modifiers,
-                )?,
-            }
+            MatcherKind::Atomized(validator::Validator::new(
+                pre_hir.as_ref(),
+                post_hir.as_ref(),
+                modifiers,
+            )?)
         };
 
         Ok(Self {
@@ -328,7 +325,7 @@ impl Matcher {
                     AcMatchStatus::None
                 }
             }
-            MatcherKind::Atomized { validator } => {
+            MatcherKind::Atomized(validator) => {
                 match validator.validate_match(mem, mat, start_position, match_type) {
                     Matches::None => AcMatchStatus::None,
                     Matches::Single(m) => {
@@ -376,13 +373,21 @@ impl Matcher {
     pub fn to_desc(&self) -> String {
         match &self.kind {
             MatcherKind::Literals => "Literals".to_owned(),
-            MatcherKind::Atomized { validator } => format!("Atomized {{ {validator} }}"),
+            MatcherKind::Atomized(validator) => format!("Atomized {{ {validator} }}"),
             MatcherKind::Raw(_) => "Raw".to_owned(),
         }
     }
 
     fn validate_fullword(&self, mem: &[u8], mat: &Range<usize>, match_type: MatchType) -> bool {
         !self.modifiers.fullword || check_fullword(mem, mat, match_type)
+    }
+
+    pub fn has_greedy_reverse_validator(&self) -> bool {
+        match &self.kind {
+            MatcherKind::Literals => false,
+            MatcherKind::Atomized(validator) => validator.reverse_is_greedy,
+            MatcherKind::Raw(_) => false,
+        }
     }
 }
 
@@ -487,7 +492,7 @@ mod wire {
                 Self::Literals => {
                     0_u8.serialize(writer)?;
                 }
-                Self::Atomized { validator } => {
+                Self::Atomized(validator) => {
                     1_u8.serialize(writer)?;
                     validator.serialize(writer)?;
                 }
@@ -509,7 +514,7 @@ mod wire {
             0 => Ok(MatcherKind::Literals),
             1 => {
                 let validator = Validator::deserialize(modifiers, reader)?;
-                Ok(MatcherKind::Atomized { validator })
+                Ok(MatcherKind::Atomized(validator))
             }
             2 => {
                 let matcher = RawMatcher::deserialize(modifiers, reader)?;
@@ -585,9 +590,7 @@ mod wire {
                 &[0],
             );
             test_round_trip_custom_deser(
-                &MatcherKind::Atomized {
-                    validator: Validator::new(None, None, &hir, modifiers).unwrap(),
-                },
+                &MatcherKind::Atomized(Validator::new(None, None, modifiers).unwrap()),
                 |reader| deserialize_matcher_kind(modifiers, reader),
                 &[0, 1],
             );

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -22,49 +22,18 @@ const MAX_SPLIT_MATCH_LENGTH: usize = 4096;
 
 #[derive(Debug)]
 #[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
-pub(super) enum Validator {
-    NonGreedy {
-        forward: Option<HalfValidator>,
-        reverse: Option<HalfValidator>,
-    },
-    Greedy {
-        reverse: dfa::DfaValidator,
-        full: dfa::DfaValidator,
-    },
+pub(super) struct Validator {
+    forward: Option<HalfValidator>,
+    reverse: Option<HalfValidator>,
+    pub(super) reverse_is_greedy: bool,
 }
 
 impl Validator {
     pub(super) fn new(
         pre: Option<&Hir>,
         post: Option<&Hir>,
-        full: &Hir,
         modifiers: Modifiers,
     ) -> Result<Self, crate::regex::Error> {
-        let reverse = match pre {
-            Some(pre) => {
-                let left_analysis = analyze_hir(pre, modifiers.dot_all);
-
-                // XXX: If the left HIR has greedy repetitions, then the HIR cannot be split into a
-                // (left, literals, right) triplet. This is because the greedy repetitions can
-                // "eat" the literals, leading to incorrect matches.
-                //
-                // For example, a regex that looks like: `a.+foo.b` will extract the literal foo,
-                // but against the string `aafoobbaafoobb`, it will match on the entire string,
-                // while a (pre, post) matching would match twice.
-                if left_analysis.has_greedy_repetitions {
-                    let reverse = dfa::DfaValidator::new(pre, &left_analysis, modifiers, true)?;
-
-                    let full_analysis = analyze_hir(full, modifiers.dot_all);
-                    let full = dfa::DfaValidator::new(full, &full_analysis, modifiers, false)?;
-
-                    return Ok(Self::Greedy { reverse, full });
-                }
-
-                Some(HalfValidator::new(pre, &left_analysis, modifiers, true)?)
-            }
-            None => None,
-        };
-
         let forward = match post {
             Some(hir) => {
                 let analysis = analyze_hir(hir, modifiers.dot_all);
@@ -73,7 +42,22 @@ impl Validator {
             None => None,
         };
 
-        Ok(Self::NonGreedy { forward, reverse })
+        match pre {
+            Some(pre) => {
+                let left_analysis = analyze_hir(pre, modifiers.dot_all);
+
+                Ok(Self {
+                    forward,
+                    reverse: Some(HalfValidator::new(pre, &left_analysis, modifiers, true)?),
+                    reverse_is_greedy: left_analysis.has_greedy_repetitions,
+                })
+            }
+            None => Ok(Self {
+                forward,
+                reverse: None,
+                reverse_is_greedy: false,
+            }),
+        }
     }
 
     #[cfg(feature = "serialize")]
@@ -91,66 +75,36 @@ impl Validator {
         start_position: usize,
         match_type: MatchType,
     ) -> Matches {
-        match self {
-            Self::NonGreedy { forward, reverse } => {
-                let end = match forward {
-                    Some(validator) => {
-                        let end = std::cmp::min(
-                            mem.len(),
-                            mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH),
-                        );
-                        match validator.find_anchored_fwd(mem, mat.start, end, match_type) {
-                            Some(end) => end,
-                            None => return Matches::None,
-                        }
-                    }
-                    None => mat.end,
-                };
-
-                match reverse {
-                    None => Matches::Single(mat.start..end),
-                    Some(validator) => {
-                        // The left validator can yield multiple matches.
-                        // For example, `a.?bb`, with the `bb` atom, can match as many times as there are
-                        // 'a' characters before the `bb` atom.
-                        let mut matches = Vec::new();
-                        let mut start = std::cmp::max(
-                            start_position,
-                            mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
-                        );
-                        while let Some(s) =
-                            validator.find_anchored_rev(mem, start, mat.end, match_type)
-                        {
-                            matches.push(s..end);
-                            start = s + 1;
-                            if start > mat.end {
-                                break;
-                            }
-                        }
-                        Matches::Multiple(matches)
-                    }
+        let end = match &self.forward {
+            Some(validator) => {
+                let end =
+                    std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
+                match validator.find_anchored_fwd(mem, mat.start, end, match_type) {
+                    Some(end) => end,
+                    None => return Matches::None,
                 }
             }
-            Self::Greedy { reverse, full } => {
-                let mut matches = Vec::new();
+            None => mat.end,
+        };
 
+        match &self.reverse {
+            None => Matches::Single(mat.start..end),
+            Some(validator) => {
+                // The left validator can yield multiple matches.
+                // For example, `a.?bb`, with the `bb` atom, can match as many times as there are
+                // 'a' characters before the `bb` atom.
+                let mut matches = Vec::new();
                 let mut start = std::cmp::max(
                     start_position,
                     mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                 );
-                let end =
-                    std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
-
-                while let Some(s) = reverse.find_anchored_rev(mem, start, mat.end, match_type) {
-                    if let Some(e) = full.find_anchored_fwd(mem, s, end, match_type) {
-                        matches.push(s..e);
-                    }
+                while let Some(s) = validator.find_anchored_rev(mem, start, mat.end, match_type) {
+                    matches.push(s..end);
                     start = s + 1;
                     if start > mat.end {
                         break;
                     }
                 }
-
                 Matches::Multiple(matches)
             }
         }
@@ -159,24 +113,20 @@ impl Validator {
 
 impl std::fmt::Display for Validator {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NonGreedy { forward, reverse } => {
-                write!(f, "NonGreedy {{ ")?;
-                match reverse {
-                    Some(v) => write!(f, "reverse: {v}")?,
-                    None => write!(f, "reverse: none")?,
-                }
-                write!(f, ", ")?;
-                match forward {
-                    Some(v) => write!(f, "forward: {v}")?,
-                    None => write!(f, "forward: none")?,
-                }
-                write!(f, " }}")
-            }
-            Self::Greedy { .. } => {
-                write!(f, "Greedy {{ reverse: Dfa, full: Dfa }}")
-            }
+        write!(f, "Validator {{ ")?;
+        match &self.reverse {
+            Some(v) => write!(f, "reverse: {v}")?,
+            None => write!(f, "reverse: none")?,
         }
+        if self.reverse_is_greedy {
+            write!(f, " (greedy)")?;
+        }
+        write!(f, ", ")?;
+        match &self.forward {
+            Some(v) => write!(f, "forward: {v}")?,
+            None => write!(f, "forward: none")?,
+        }
+        write!(f, " }}")
     }
 }
 
@@ -253,18 +203,9 @@ mod wire {
 
     impl Serialize for Validator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-            match self {
-                Validator::NonGreedy { forward, reverse } => {
-                    0_u8.serialize(writer)?;
-                    forward.serialize(writer)?;
-                    reverse.serialize(writer)?;
-                }
-                Validator::Greedy { reverse, full } => {
-                    1_u8.serialize(writer)?;
-                    reverse.serialize(writer)?;
-                    full.serialize(writer)?;
-                }
-            }
+            self.forward.serialize(writer)?;
+            self.reverse.serialize(writer)?;
+            self.reverse_is_greedy.serialize(writer)?;
             Ok(())
         }
     }
@@ -273,33 +214,24 @@ mod wire {
         modifiers: Modifiers,
         reader: &mut R,
     ) -> io::Result<Validator> {
-        let discriminant = u8::deserialize_reader(reader)?;
-        match discriminant {
-            0 => {
-                let forward_opt = bool::deserialize_reader(reader)?;
-                let forward = if forward_opt {
-                    Some(deserialize_half_validator(modifiers, false, reader)?)
-                } else {
-                    None
-                };
-                let reverse_opt = bool::deserialize_reader(reader)?;
-                let reverse = if reverse_opt {
-                    Some(deserialize_half_validator(modifiers, true, reader)?)
-                } else {
-                    None
-                };
-                Ok(Validator::NonGreedy { forward, reverse })
-            }
-            1 => {
-                let reverse = dfa::DfaValidator::deserialize(modifiers, true, reader)?;
-                let full = dfa::DfaValidator::deserialize(modifiers, true, reader)?;
-                Ok(Validator::Greedy { reverse, full })
-            }
-            v => Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid discriminant when deserializing a validator: {v}"),
-            )),
-        }
+        let forward_opt = bool::deserialize_reader(reader)?;
+        let forward = if forward_opt {
+            Some(deserialize_half_validator(modifiers, false, reader)?)
+        } else {
+            None
+        };
+        let reverse_opt = bool::deserialize_reader(reader)?;
+        let reverse = if reverse_opt {
+            Some(deserialize_half_validator(modifiers, true, reader)?)
+        } else {
+            None
+        };
+        let reverse_is_greedy = bool::deserialize_reader(reader)?;
+        Ok(Validator {
+            forward,
+            reverse,
+            reverse_is_greedy,
+        })
     }
 
     impl Serialize for HalfValidator {
@@ -356,32 +288,26 @@ mod wire {
             let modifiers = Modifiers::default();
 
             test_round_trip_custom_deser(
-                &Validator::NonGreedy {
+                &Validator {
                     forward: None,
                     reverse: Some(HalfValidator::Simple(
                         SimpleValidator::new(&hir, &analysis, modifiers, false).unwrap(),
                     )),
+                    reverse_is_greedy: true,
                 },
                 |reader| deserialize_validator(modifiers, reader),
                 &[0, 1, 2],
             );
             test_round_trip_custom_deser(
-                &Validator::NonGreedy {
+                &Validator {
                     forward: Some(HalfValidator::Simple(
                         SimpleValidator::new(&hir, &analysis, modifiers, false).unwrap(),
                     )),
                     reverse: None,
+                    reverse_is_greedy: false,
                 },
                 |reader| deserialize_validator(modifiers, reader),
                 &[0],
-            );
-            test_round_trip_custom_deser(
-                &Validator::Greedy {
-                    reverse: DfaValidator::new(&hir, &analysis, modifiers, false).unwrap(),
-                    full: DfaValidator::new(&hir, &analysis, modifiers, false).unwrap(),
-                },
-                |reader| deserialize_validator(modifiers, reader),
-                &[0, 1, 14],
             );
 
             // Test failure when compiling expressions.
@@ -422,9 +348,7 @@ mod tests {
 
     #[test]
     fn test_types_traits() {
-        test_type_traits_non_clonable(
-            Validator::new(None, None, &Hir::Empty, Modifiers::default()).unwrap(),
-        );
+        test_type_traits_non_clonable(Validator::new(None, None, Modifiers::default()).unwrap());
         test_type_traits_non_clonable(
             HalfValidator::new(
                 &Hir::Empty,

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -235,21 +235,26 @@ impl AcScan {
 
             // Shorten the mem to prevent new matches on the same starting byte.
             // For example, for `a.*?bb`, and input `abbb`, this can happen:
+            //
             // - extract atom `bb`
             // - get AC match on `a(bb)b`: call check_ac_match, this will return the
             //   match `(abb)b`.
             // - get AC match on `ab(bb)`: call check_ac_match, this will return the
             //   match `(abbb)`.
+            //
             // This is invalid, only one match per starting byte can happen.
             // To avoid this, ensure the mem given to check_ac_match starts one byte after the last
             // saved match.
             //
-            // This must only be done if the match is in the same region, otherwise the offset
-            // of the previous match makes no sense for this match, and will falsify results.
-            let start_position = match var_matches.last() {
-                Some(mat) if mat.base == region.start => mat.offset + 1,
-                _ => 0,
-            };
+            // Do not do so if the reverse validator is greedy however: in that case,
+            // we actually want to replace previous matches with new, longer ones, if they
+            // share the same start.
+            let mut start_position = 0;
+            if let Some(mat) = var_matches.last() {
+                if mat.base == region.start && !var.has_greedy_reverse_validator() {
+                    start_position = mat.offset + 1;
+                }
+            }
 
             let res = var.process_ac_match(region.mem, m, start_position, match_type);
 
@@ -262,20 +267,22 @@ impl AcScan {
 
             match res {
                 AcMatchStatus::None => (),
-                AcMatchStatus::Multiple(v) if v.is_empty() => (),
                 AcMatchStatus::Multiple(found_matches) => {
-                    var_matches.extend(found_matches.into_iter().map(|m| {
-                        StringMatch::new(region, m, scan_data.params.match_max_length, 0)
-                    }));
+                    for new_match in found_matches {
+                        let new_match = StringMatch::new(
+                            region,
+                            new_match,
+                            scan_data.params.match_max_length,
+                            0,
+                        );
+                        add_match(var, new_match, var_matches);
+                    }
                 }
                 AcMatchStatus::Single(m) => {
                     let xor_key = var.get_xor_key(literal_index);
-                    var_matches.push(StringMatch::new(
-                        region,
-                        m,
-                        scan_data.params.match_max_length,
-                        xor_key,
-                    ));
+                    let new_match =
+                        StringMatch::new(region, m, scan_data.params.match_max_length, xor_key);
+                    add_match(var, new_match, var_matches);
                 }
             }
 
@@ -300,6 +307,30 @@ impl AcScan {
         }
 
         Ok(())
+    }
+}
+
+fn add_match(var: &Matcher, new_match: StringMatch, var_matches: &mut Vec<StringMatch>) {
+    // XXX: If the left HIR has greedy repetitions, then the reverse validator
+    // may give matches that replaces existing matches.
+    //
+    // For example, a regex that looks like: `a.+foo.b` will extract the literal foo,
+    // but against the string `aafoobbaafoobb`, the only match should be the
+    // entire string. A first `foo` AC match will result in `aafoobb` being found,
+    // but the second `foo` AC match should then replace the first match.
+    //
+    // To handle this, we search into the existing matches if there are existing matches
+    // at the same offset. If there are, we replace them, since the longest match always
+    // wins.
+    if var.has_greedy_reverse_validator() {
+        match var_matches
+            .binary_search_by_key(&(new_match.base + new_match.offset), |m| m.base + m.offset)
+        {
+            Ok(position) => var_matches[position] = new_match,
+            Err(_) => var_matches.push(new_match),
+        }
+    } else {
+        var_matches.push(new_match);
     }
 }
 

--- a/boreal/tests/it/regex.rs
+++ b/boreal/tests/it/regex.rs
@@ -255,6 +255,82 @@ fn test_regex_size() {
 }
 
 #[test]
+fn test_regex_greedy_reverse() {
+    // The pre part (`a.+`) is greedy and unbounded, so it can reach past the first `foo`
+    // occurrence to consume the second one. Every valid start ends up reaching the very end
+    // of the data (offset + length == 14 for all three matches).
+    let mut checker = Checker::new(&build_rule(r"/a.+foo.b/"));
+    checker.check_full_matches(
+        b"aafoobbaafoobb",
+        vec![(
+            "default:a".to_owned(),
+            vec![(
+                "",
+                vec![
+                    (b"aafoobbaafoobb".as_slice(), 0, 14),
+                    (b"afoobbaafoobb".as_slice(), 1, 13),
+                    (b"aafoobb".as_slice(), 7, 7),
+                ],
+            )],
+        )],
+    );
+}
+
+#[test]
+fn test_regex_greedy_reverse_bounded() {
+    // Same shape as above, but the repetition is bounded (`.{1,4}`), so it cannot reach far
+    // enough to cross over to the second `foo` occurrence.
+    let mut checker = Checker::new(&build_rule(r"/a.{1,4}foo.b/"));
+    checker.check_full_matches(
+        b"aafoobbaafoobb",
+        vec![(
+            "default:a".to_owned(),
+            vec![(
+                "",
+                vec![(b"aafoobb".as_slice(), 0, 7), (b"aafoobb".as_slice(), 7, 7)],
+            )],
+        )],
+    );
+}
+
+#[test]
+fn test_regex_non_greedy_reverse() {
+    let mut checker = Checker::new(&build_rule(r"/a.+?foo.b/"));
+    checker.check_full_matches(
+        b"aafoobbaafoobb",
+        vec![(
+            "default:a".to_owned(),
+            vec![(
+                "",
+                vec![
+                    (b"aafoobb".as_slice(), 0, 7),
+                    (b"afoobbaafoobb".as_slice(), 1, 13),
+                    (b"aafoobb".as_slice(), 7, 7),
+                ],
+            )],
+        )],
+    );
+}
+
+#[test]
+fn test_regex_greedy_forward() {
+    let mut checker = Checker::new(&build_rule(r"/foo.+z/"));
+    checker.check_full_matches(
+        b"xfoobbfoobbzy",
+        vec![(
+            "default:a".to_owned(),
+            vec![(
+                "",
+                vec![
+                    (b"foobbfoobbz".as_slice(), 1, 11),
+                    (b"foobbz".as_slice(), 6, 6),
+                ],
+            )],
+        )],
+    );
+}
+
+#[test]
 fn test_regex_same_alternative() {
     let mut checker = Checker::new(
         r#"


### PR DESCRIPTION
When validating a match from the Aho-Corasick, two possible validators were used, with a specific one to handle a corner case where the part of the regex preceding the literal contains greedy repetitions.

Instead of handling this case with a specific validator that requires a reverse + full regex, rework the logic to integrate this into the other existing validator. This rework is done during the merge of new matches into the vec of existing matches for the variable, where new matches can now replace existing ones.