### PR TITLE
Optimize "previous results" array during scan

### DIFF
--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -1130,6 +1130,10 @@ fn compile_rule_set(
         }
     }
 
+    for index in &indexes {
+        compiler.rules_depended_upon.push(*index);
+    }
+
     Ok(RuleSet {
         elements: indexes.into_boxed_slice(),
         already_matched,
@@ -1298,7 +1302,10 @@ fn compile_identifier(
     } else if let Some(index) = compiler.namespace.rules_indexes.get(&identifier.name) {
         if identifier.operations.is_empty() {
             let expr = match index {
-                Some(index) => Expression::Rule(*index),
+                Some(index) => {
+                    compiler.rules_depended_upon.push(*index);
+                    Expression::Rule(*index)
+                }
                 // The referenced rule is global. Since this rule can only be evaluated if all
                 // global rules pass, then this can be just replaced by true.
                 None => Expression::Boolean(true),

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -435,6 +435,7 @@ impl Compiler {
                     variables_statistics,
                     warnings,
                     rule_wildcard_uses,
+                    rules_depended_upon,
                 } = rule::compile_rule(
                     *rule,
                     namespace,
@@ -484,6 +485,10 @@ impl Compiler {
                         parsed_contents,
                     )
                 }));
+
+                for rule_index in rules_depended_upon {
+                    self.rules[rule_index].is_depended_upon = true;
+                }
 
                 namespace.forbidden_rule_prefixes.extend(rule_wildcard_uses);
 

--- a/boreal/src/compiler/mod.rs
+++ b/boreal/src/compiler/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod rule;
 pub(crate) mod variable;
 
 use crate::bytes_pool::BytesPoolBuilder;
+use crate::matcher::Matcher;
 use crate::{Scanner, statistics};
 
 /// Object used to compile rules.
@@ -36,8 +37,8 @@ pub struct Compiler {
     /// List of compiled, global rules.
     pub(crate) global_rules: Vec<rule::Rule>,
 
-    /// List of compiled variables.
-    pub(crate) variables: Vec<variable::Variable>,
+    /// List of matchers (matching logic for variables).
+    pub(crate) matchers: Vec<Matcher>,
 
     /// Number of variables used by global rules.
     nb_global_rules_variables: usize,
@@ -168,7 +169,7 @@ impl Compiler {
             namespaces: Vec::new(),
             rules: Vec::new(),
             global_rules: Vec::new(),
-            variables: Vec::new(),
+            matchers: Vec::new(),
             nb_global_rules_variables: 0,
             namespaces_indexes: HashMap::new(),
             imported_modules: Vec::new(),
@@ -430,7 +431,7 @@ impl Compiler {
 
                 let rule::CompiledRule {
                     rule,
-                    variables,
+                    matchers,
                     variables_statistics,
                     warnings,
                     rule_wildcard_uses,
@@ -494,17 +495,17 @@ impl Compiler {
                     // compiled global rules, but before the normal rules.
                     // This is ok to do since there is no reference to variable indexes anywhere in
                     // compiled rules.
-                    let nb_vars = variables.len();
+                    let nb_vars = matchers.len();
                     let index = self.nb_global_rules_variables;
 
-                    let _r = self.variables.splice(index..index, variables);
+                    let _r = self.matchers.splice(index..index, matchers);
                     self.nb_global_rules_variables += nb_vars;
                 } else {
                     let _r = namespace
                         .rules_indexes
                         .insert(rule_name, Some(self.rules.len()));
                     self.rules.push(rule);
-                    self.variables.extend(variables);
+                    self.matchers.extend(matchers);
                 }
             }
         }

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -36,11 +36,14 @@ pub(crate) struct Rule {
     /// Condition of the rule.
     pub(crate) condition: Expression,
 
+    /// List of variables used in the rule
+    pub(crate) variables: Box<[RuleVariable]>,
+
     /// Is the rule marked as private.
     pub(crate) is_private: bool,
 
-    /// List of variables used in the rule
-    pub(crate) variables: Box<[RuleVariable]>,
+    /// Is the rule depended upon by other rules.
+    pub(crate) is_depended_upon: bool,
 }
 
 /// Some details about a rule variable.
@@ -133,6 +136,9 @@ pub(super) struct RuleCompiler<'a> {
     /// Warnings emitted while compiling the rule.
     pub warnings: Vec<CompilationError>,
 
+    /// Rules depended upon by this rule.
+    pub rules_depended_upon: Vec<usize>,
+
     /// Bytes intern pool.
     pub bytes_pool: &'a mut BytesPoolBuilder,
 }
@@ -191,6 +197,7 @@ impl<'a> RuleCompiler<'a> {
             params,
             condition_depth: 0,
             warnings: Vec::new(),
+            rules_depended_upon: Vec::new(),
             bytes_pool,
         })
     }
@@ -362,13 +369,15 @@ pub(super) fn compile_rule(
                 .collect(),
             metadatas,
             condition,
-            is_private: rule.is_private,
             variables: rule_variables.into_boxed_slice(),
+            is_private: rule.is_private,
+            is_depended_upon: false,
         },
         matchers,
         variables_statistics,
         warnings: compiler.warnings,
         rule_wildcard_uses: compiler.rule_wildcard_uses,
+        rules_depended_upon: compiler.rules_depended_upon,
     })
 }
 
@@ -379,6 +388,7 @@ pub(super) struct CompiledRule {
     pub variables_statistics: Vec<statistics::CompiledString>,
     pub warnings: Vec<CompilationError>,
     pub rule_wildcard_uses: Vec<String>,
+    pub rules_depended_upon: Vec<usize>,
 }
 
 #[cfg(feature = "serialize")]
@@ -401,6 +411,7 @@ mod wire {
             self.tags.serialize(writer)?;
             self.metadatas.serialize(writer)?;
             self.variables.serialize(writer)?;
+            self.is_depended_upon.serialize(writer)?;
             self.condition.serialize(writer)?;
             Ok(())
         }
@@ -416,6 +427,7 @@ mod wire {
         let tags = <Vec<StringSymbol>>::deserialize_reader(reader)?;
         let metadatas = <Vec<Metadata>>::deserialize_reader(reader)?;
         let variables = <Vec<RuleVariable>>::deserialize_reader(reader)?;
+        let is_depended_upon = bool::deserialize_reader(reader)?;
         let condition = Expression::deserialize(ctx, reader)?;
 
         Ok(Rule {
@@ -424,8 +436,9 @@ mod wire {
             tags: tags.into_boxed_slice(),
             metadatas: metadatas.into_boxed_slice(),
             condition,
-            is_private,
             variables: variables.into_boxed_slice(),
+            is_private,
+            is_depended_upon,
         })
     }
 
@@ -523,10 +536,11 @@ mod wire {
                     tags: Box::new([]),
                     metadatas: Box::new([]),
                     variables: Box::new([]),
+                    is_depended_upon: false,
                     condition: Expression::Filesize,
                 },
                 |reader| deserialize_rule(&ctx, reader),
-                &[0, 5, 13, 14, 18, 22, 26],
+                &[0, 5, 13, 14, 18, 22, 26, 27],
             );
         }
 
@@ -589,6 +603,7 @@ mod tests {
             params: &CompilerParams::default(),
             condition_depth: 0,
             warnings: Vec::new(),
+            rules_depended_upon: Vec::new(),
             bytes_pool: &mut BytesPoolBuilder::default(),
         });
         let build_rule = || Rule {
@@ -597,8 +612,9 @@ mod tests {
             tags: Box::new([]),
             metadatas: Box::new([]),
             condition: Expression::Filesize,
-            is_private: false,
             variables: Box::new([]),
+            is_private: false,
+            is_depended_upon: false,
         };
         test_type_traits_non_clonable(build_rule());
         test_type_traits_non_clonable(CompiledRule {
@@ -607,6 +623,7 @@ mod tests {
             variables_statistics: Vec::new(),
             warnings: Vec::new(),
             rule_wildcard_uses: Vec::new(),
+            rules_depended_upon: Vec::new(),
         });
         test_type_traits_non_clonable(RuleCompilerVariable {
             name: "a".to_owned(),

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -32,14 +32,30 @@ pub(crate) struct Rule {
     /// Metadata associated with the rule.
     pub(crate) metadatas: Box<[Metadata]>,
 
-    /// Number of variables used by the rule.
-    pub(crate) nb_variables: usize,
-
     /// Condition of the rule.
     pub(crate) condition: Expression,
 
     /// Is the rule marked as private.
     pub(crate) is_private: bool,
+
+    /// List of variables used in the rule
+    pub(crate) variables: Box<[RuleVariable]>,
+}
+
+/// Some details about a rule variable.
+#[derive(Debug)]
+#[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
+pub(crate) struct RuleVariable {
+    /// Name of the variable, without the '$'.
+    ///
+    /// Anonymous variables are just named "".
+    pub name: StringSymbol,
+
+    /// Is the variable marked as private.
+    pub(crate) is_private: bool,
+
+    /// Does the variable have a xor modifier.
+    pub(crate) has_xor_modifier: bool,
 }
 
 impl Rule {
@@ -311,14 +327,21 @@ pub(super) fn compile_rule(
 
     let mut variables = Vec::with_capacity(rule.variables.len());
     let mut variables_statistics = Vec::new();
+    let mut rule_variables = Vec::new();
 
-    for (i, var) in rule.variables.into_iter().enumerate() {
-        if !compiler.variables[i].used && !var.name.starts_with('_') {
+    for (var_index, var) in rule.variables.into_iter().enumerate() {
+        if !compiler.variables[var_index].used && !var.name.starts_with('_') {
             return Err(CompilationError::UnusedVariable {
                 name: var.name,
                 span: var.span,
             });
         }
+
+        rule_variables.push(RuleVariable {
+            name: compiler.bytes_pool.insert_str(&var.name),
+            is_private: var.modifiers.private,
+            has_xor_modifier: var.modifiers.xor.is_some(),
+        });
 
         let (var, stats) = variable::compile_variable(&mut compiler, var, parsed_contents)?;
         if let Some(stats) = stats {
@@ -337,9 +360,9 @@ pub(super) fn compile_rule(
                 .map(|v| compiler.bytes_pool.insert_str(&v.tag))
                 .collect(),
             metadatas,
-            nb_variables: variables.len(),
             condition,
             is_private: rule.is_private,
+            variables: rule_variables.into_boxed_slice(),
         },
         variables,
         variables_statistics,
@@ -367,16 +390,16 @@ mod wire {
     use crate::wire::DeserializeContext;
     use crate::{BytesSymbol, StringSymbol};
 
-    use super::{Metadata, MetadataValue, Rule};
+    use super::{Metadata, MetadataValue, Rule, RuleVariable};
 
     impl Serialize for Rule {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.name.serialize(writer)?;
             self.namespace_index.serialize(writer)?;
-            self.nb_variables.serialize(writer)?;
             self.is_private.serialize(writer)?;
             self.tags.serialize(writer)?;
             self.metadatas.serialize(writer)?;
+            self.variables.serialize(writer)?;
             self.condition.serialize(writer)?;
             Ok(())
         }
@@ -388,20 +411,43 @@ mod wire {
     ) -> io::Result<Rule> {
         let name = String::deserialize_reader(reader)?;
         let namespace_index = usize::deserialize_reader(reader)?;
-        let nb_variables = usize::deserialize_reader(reader)?;
         let is_private = bool::deserialize_reader(reader)?;
         let tags = <Vec<StringSymbol>>::deserialize_reader(reader)?;
         let metadatas = <Vec<Metadata>>::deserialize_reader(reader)?;
+        let variables = <Vec<RuleVariable>>::deserialize_reader(reader)?;
         let condition = Expression::deserialize(ctx, reader)?;
+
         Ok(Rule {
             name: name.into_boxed_str(),
             namespace_index,
             tags: tags.into_boxed_slice(),
             metadatas: metadatas.into_boxed_slice(),
-            nb_variables,
             condition,
             is_private,
+            variables: variables.into_boxed_slice(),
         })
+    }
+
+    impl Serialize for RuleVariable {
+        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
+            self.name.serialize(writer)?;
+            self.is_private.serialize(writer)?;
+            self.has_xor_modifier.serialize(writer)?;
+            Ok(())
+        }
+    }
+
+    impl Deserialize for RuleVariable {
+        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let name = StringSymbol::deserialize_reader(reader)?;
+            let is_private = bool::deserialize_reader(reader)?;
+            let has_xor_modifier = bool::deserialize_reader(reader)?;
+            Ok(Self {
+                name,
+                is_private,
+                has_xor_modifier,
+            })
+        }
     }
 
     impl Serialize for Metadata {
@@ -472,14 +518,14 @@ mod wire {
                 &Rule {
                     name: "a".into(),
                     namespace_index: 0,
-                    nb_variables: 0,
                     is_private: false,
                     tags: Box::new([]),
                     metadatas: Box::new([]),
+                    variables: Box::new([]),
                     condition: Expression::Filesize,
                 },
                 |reader| deserialize_rule(&ctx, reader),
-                &[0, 5, 13, 21, 22, 26, 30],
+                &[0, 5, 13, 14, 18, 22, 26],
             );
         }
 
@@ -508,6 +554,20 @@ mod wire {
 
             test_invalid_deserialization::<MetadataValue>(b"\x05");
         }
+
+        #[test]
+        fn test_wire_rule_variable() {
+            let mut pool = BytesPoolBuilder::default();
+
+            test_round_trip(
+                &RuleVariable {
+                    name: pool.insert_str("a"),
+                    is_private: true,
+                    has_xor_modifier: false,
+                },
+                &[0, 16, 17],
+            );
+        }
     }
 }
 
@@ -535,9 +595,9 @@ mod tests {
             namespace_index: 0,
             tags: Box::new([]),
             metadatas: Box::new([]),
-            nb_variables: 0,
             condition: Expression::Filesize,
             is_private: false,
+            variables: Box::new([]),
         };
         test_type_traits_non_clonable(build_rule());
         test_type_traits_non_clonable(CompiledRule {

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -10,6 +10,7 @@ use super::expression::{Expression, VariableIndex, compile_bool_expression};
 use super::external_symbol::ExternalSymbol;
 use super::{CompilationError, CompilerParams, Namespace, variable};
 use crate::bytes_pool::{BytesPoolBuilder, BytesSymbol, StringSymbol};
+use crate::matcher::Matcher;
 use crate::module::Type as ModuleType;
 use crate::statistics;
 
@@ -325,7 +326,7 @@ pub(super) fn compile_rule(
     )?;
     let condition = compile_bool_expression(&mut compiler, rule.condition)?;
 
-    let mut variables = Vec::with_capacity(rule.variables.len());
+    let mut matchers = Vec::with_capacity(rule.variables.len());
     let mut variables_statistics = Vec::new();
     let mut rule_variables = Vec::new();
 
@@ -343,11 +344,11 @@ pub(super) fn compile_rule(
             has_xor_modifier: var.modifiers.xor.is_some(),
         });
 
-        let (var, stats) = variable::compile_variable(&mut compiler, var, parsed_contents)?;
+        let (matcher, stats) = variable::compile_variable(&mut compiler, var, parsed_contents)?;
         if let Some(stats) = stats {
             variables_statistics.push(stats);
         }
-        variables.push(var);
+        matchers.push(matcher);
     }
 
     Ok(CompiledRule {
@@ -364,7 +365,7 @@ pub(super) fn compile_rule(
             is_private: rule.is_private,
             variables: rule_variables.into_boxed_slice(),
         },
-        variables,
+        matchers,
         variables_statistics,
         warnings: compiler.warnings,
         rule_wildcard_uses: compiler.rule_wildcard_uses,
@@ -374,7 +375,7 @@ pub(super) fn compile_rule(
 #[derive(Debug)]
 pub(super) struct CompiledRule {
     pub rule: Rule,
-    pub variables: Vec<variable::Variable>,
+    pub matchers: Vec<Matcher>,
     pub variables_statistics: Vec<statistics::CompiledString>,
     pub warnings: Vec<CompilationError>,
     pub rule_wildcard_uses: Vec<String>,
@@ -602,7 +603,7 @@ mod tests {
         test_type_traits_non_clonable(build_rule());
         test_type_traits_non_clonable(CompiledRule {
             rule: build_rule(),
-            variables: Vec::new(),
+            matchers: Vec::new(),
             variables_statistics: Vec::new(),
             warnings: Vec::new(),
             rule_wildcard_uses: Vec::new(),

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -152,6 +152,7 @@ mod tests {
             params: &CompilerParams::default(),
             condition_depth: 0,
             warnings: Vec::new(),
+            rules_depended_upon: Vec::new(),
             bytes_pool: &mut BytesPoolBuilder::default(),
         };
         test_type_traits_non_clonable(

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -8,19 +8,11 @@ use crate::statistics;
 use super::CompilationError;
 use super::rule::RuleCompiler;
 
-/// A compiled variable used in a rule.
-#[derive(Debug)]
-#[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
-pub struct Variable {
-    /// Matcher for the variable.
-    pub(crate) matcher: Matcher,
-}
-
 pub(super) fn compile_variable(
     compiler: &mut RuleCompiler,
     decl: VariableDeclaration,
     parsed_contents: &str,
-) -> Result<(Variable, Option<statistics::CompiledString>), CompilationError> {
+) -> Result<(Matcher, Option<statistics::CompiledString>), CompilationError> {
     let VariableDeclaration {
         name,
         value,
@@ -81,8 +73,8 @@ pub(super) fn compile_variable(
         .map_err(VariableCompilationError::Regex),
     };
 
-    let res = match res {
-        Ok(matcher) => Variable { matcher },
+    let matcher = match res {
+        Ok(matcher) => matcher,
         Err(error) => {
             return Err(CompilationError::VariableCompilation {
                 variable_name: name,
@@ -93,8 +85,7 @@ pub(super) fn compile_variable(
     };
 
     let stats = if compiler.params.compute_statistics {
-        let atoms: Vec<_> = res
-            .matcher
+        let atoms: Vec<_> = matcher
             .literals
             .iter()
             .map(|lit| {
@@ -107,16 +98,16 @@ pub(super) fn compile_variable(
         Some(statistics::CompiledString {
             name,
             expr: parsed_contents[span.start..span.end].to_owned(),
-            literals: res.matcher.literals.clone(),
+            literals: matcher.literals.clone(),
             atoms,
             atoms_quality,
-            matching_algo: res.matcher.to_desc(),
+            matching_algo: matcher.to_desc(),
         })
     } else {
         None
     };
 
-    Ok((res, stats))
+    Ok((matcher, stats))
 }
 
 /// Error during the compilation of a variable.
@@ -134,49 +125,6 @@ impl std::fmt::Display for VariableCompilationError {
         match self {
             Self::Empty => write!(f, "variable is empty"),
             Self::Regex(e) => e.fmt(f),
-        }
-    }
-}
-
-#[cfg(feature = "serialize")]
-mod wire {
-    use std::io;
-
-    use crate::wire::{Deserialize, Serialize};
-
-    use super::{Matcher, Variable};
-
-    impl Serialize for Variable {
-        fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-            self.matcher.serialize(writer)?;
-            Ok(())
-        }
-    }
-
-    impl Deserialize for Variable {
-        fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let matcher = Matcher::deserialize_reader(reader)?;
-            Ok(Self { matcher })
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use boreal_parser::rule::VariableModifiers;
-
-        use crate::matcher::Matcher;
-        use crate::wire::tests::test_round_trip;
-
-        use super::*;
-
-        #[test]
-        fn test_wire_variable() {
-            test_round_trip(
-                &Variable {
-                    matcher: Matcher::new_bytes(Vec::new(), &VariableModifiers::default()),
-                },
-                &[0, 7, 8],
-            );
         }
     }
 }

--- a/boreal/src/compiler/variable.rs
+++ b/boreal/src/compiler/variable.rs
@@ -3,7 +3,7 @@ use boreal_parser::rule::{VariableDeclaration, VariableDeclarationValue};
 use crate::atoms::{atoms_rank, pick_atom_in_literal};
 use crate::matcher::{Matcher, Modifiers};
 use crate::regex::regex_ast_to_hir;
-use crate::{StringSymbol, statistics};
+use crate::statistics;
 
 use super::CompilationError;
 use super::rule::RuleCompiler;
@@ -12,14 +12,6 @@ use super::rule::RuleCompiler;
 #[derive(Debug)]
 #[cfg_attr(all(test, feature = "serialize"), derive(PartialEq))]
 pub struct Variable {
-    /// Name of the variable, without the '$'.
-    ///
-    /// Anonymous variables are just named "".
-    pub name: StringSymbol,
-
-    /// Is the variable marked as private.
-    pub is_private: bool,
-
     /// Matcher for the variable.
     pub(crate) matcher: Matcher,
 }
@@ -90,11 +82,7 @@ pub(super) fn compile_variable(
     };
 
     let res = match res {
-        Ok(matcher) => Variable {
-            name: compiler.bytes_pool.insert_str(&name),
-            is_private: modifiers.private,
-            matcher,
-        },
+        Ok(matcher) => Variable { matcher },
         Err(error) => {
             return Err(CompilationError::VariableCompilation {
                 variable_name: name,
@@ -154,15 +142,12 @@ impl std::fmt::Display for VariableCompilationError {
 mod wire {
     use std::io;
 
-    use crate::StringSymbol;
     use crate::wire::{Deserialize, Serialize};
 
     use super::{Matcher, Variable};
 
     impl Serialize for Variable {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-            self.name.serialize(writer)?;
-            self.is_private.serialize(writer)?;
             self.matcher.serialize(writer)?;
             Ok(())
         }
@@ -170,14 +155,8 @@ mod wire {
 
     impl Deserialize for Variable {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let name = StringSymbol::deserialize_reader(reader)?;
-            let is_private = bool::deserialize_reader(reader)?;
             let matcher = Matcher::deserialize_reader(reader)?;
-            Ok(Self {
-                name,
-                is_private,
-                matcher,
-            })
+            Ok(Self { matcher })
         }
     }
 
@@ -185,7 +164,6 @@ mod wire {
     mod tests {
         use boreal_parser::rule::VariableModifiers;
 
-        use crate::bytes_pool::BytesPoolBuilder;
         use crate::matcher::Matcher;
         use crate::wire::tests::test_round_trip;
 
@@ -193,11 +171,8 @@ mod wire {
 
         #[test]
         fn test_wire_variable() {
-            let mut pool = BytesPoolBuilder::default();
             test_round_trip(
                 &Variable {
-                    name: pool.insert_str("abc"),
-                    is_private: true,
                     matcher: Matcher::new_bytes(Vec::new(), &VariableModifiers::default()),
                 },
                 &[0, 7, 8],

--- a/boreal/src/evaluator/mod.rs
+++ b/boreal/src/evaluator/mod.rs
@@ -106,6 +106,24 @@ impl From<ExternalValue> for Value {
     }
 }
 
+/// A list of indexes of rules that matched.
+///
+/// This is **only** filled for rules that are depended upon, and not for all rules.
+///
+/// The array is sorted, allowing binary search into it.
+#[derive(Default)]
+pub(crate) struct MatchedDependencyRules(Vec<usize>);
+
+impl MatchedDependencyRules {
+    pub(crate) fn insert(&mut self, rule_index: usize) {
+        self.0.push(rule_index);
+    }
+
+    pub(crate) fn contains(&self, rule_index: usize) -> bool {
+        self.0.binary_search(&rule_index).is_ok()
+    }
+}
+
 /// Evaluates an expression on a given byte slice.
 ///
 /// Returns true if the expression (with the associated variables) matches on the given
@@ -113,14 +131,14 @@ impl From<ExternalValue> for Value {
 pub(crate) fn evaluate_rule<'scan>(
     rule: &Rule,
     var_matches: Option<&'scan [Vec<variable::StringMatch>]>,
-    previous_rules_results: &'scan [bool],
+    matched_dependency_rules: &'scan MatchedDependencyRules,
     bytes_pool: &'scan BytesPool,
     mem: &'scan mut Memory,
     scan_data: &'scan mut ScanData,
 ) -> Result<bool, EvalError> {
     let mut evaluator = Evaluator {
         var_matches: var_matches.map(variable::VarMatches::new),
-        previous_rules_results,
+        matched_dependency_rules,
         currently_selected_variable_index: None,
         bounded_identifiers_stack: Vec::new(),
         bytes_pool,
@@ -138,10 +156,8 @@ pub(crate) fn evaluate_rule<'scan>(
 struct Evaluator<'scan, 'rule, 'mem, 'cb> {
     var_matches: Option<variable::VarMatches<'rule>>,
 
-    // Array of previous rules results.
-    //
-    // This only stores results of rules that are depended upon, not all rules.
-    previous_rules_results: &'rule [bool],
+    // List of dependency rules that matched.
+    matched_dependency_rules: &'rule MatchedDependencyRules,
 
     // Index of the currently selected variable.
     //
@@ -670,7 +686,7 @@ impl Evaluator<'_, '_, '_, '_> {
                 }
 
                 for index in &set.elements {
-                    let v = self.previous_rules_results[*index];
+                    let v = self.matched_dependency_rules.contains(*index);
                     if let Some(result) = selection.add_result_and_check(v) {
                         return Ok(Value::Boolean(result));
                     }
@@ -690,7 +706,9 @@ impl Evaluator<'_, '_, '_, '_> {
                 .map(Into::into)
                 .ok_or(PoisonKind::Undefined),
 
-            Expression::Rule(index) => Ok(Value::Boolean(self.previous_rules_results[*index])),
+            Expression::Rule(index) => Ok(Value::Boolean(
+                self.matched_dependency_rules.contains(*index),
+            )),
 
             Expression::Integer(v) => Ok(Value::Integer(*v)),
             Expression::Double(v) => Ok(Value::Float(*v)),

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -387,17 +387,18 @@ fn build_string_identifier(
     // with each rule, only to alleviate this very specific event. For
     // the moment, this is not considered to be worth the cost.
     for rule in scanner.global_rules.iter().chain(scanner.rules.iter()) {
-        if index + rule.nb_variables > variable_index {
+        if index + rule.variables.len() > variable_index {
+            let string_index = variable_index - index;
             return Some(StringIdentifier {
                 rule_namespace: scanner.namespaces[rule.namespace_index].as_ref(),
                 rule_name: &rule.name,
                 string_name: scanner
                     .bytes_pool
-                    .get_str(scanner.variables[variable_index].name),
-                string_index: variable_index - index,
+                    .get_str(rule.variables[string_index].name),
+                string_index,
             });
         }
-        index += rule.nb_variables;
+        index += rule.variables.len();
     }
     // Should technically be impossible to reach.
     debug_assert!(false);

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -10,7 +10,6 @@ use super::{
 };
 use crate::atoms::pick_atom_in_literal;
 use crate::compiler::CompilerProfile;
-use crate::compiler::variable::Variable;
 use crate::matcher::{AcMatchStatus, Matcher};
 use crate::memory::Region;
 
@@ -39,13 +38,13 @@ pub(crate) struct AcScan {
     non_handled_var_indexes: Box<[usize]>,
 }
 
-/// Details on a literal of a variable.
+/// Details on a literal of a matcher.
 #[derive(Debug)]
 struct LiteralInfo {
-    /// Index of the variable in the variable array.
-    variable_index: usize,
+    /// Index of the matcher in the matcher array.
+    matcher_index: usize,
 
-    /// Index of the literal for the variable.
+    /// Index of the literal for the matcher.
     literal_index: usize,
 
     /// Left and right offset for the slice picked in the Aho-Corasick.
@@ -53,23 +52,23 @@ struct LiteralInfo {
 }
 
 impl AcScan {
-    pub(crate) fn new(variables: &[Variable], profile: CompilerProfile) -> Self {
+    pub(crate) fn new(matchers: &[Matcher], profile: CompilerProfile) -> Self {
         let mut lits = Vec::new();
         let mut known_lits = HashMap::new();
         let mut aho_index_to_literal_info = Vec::new();
         let mut non_handled_var_indexes = Vec::new();
 
-        for (variable_index, var) in variables.iter().enumerate() {
-            if var.matcher.literals.is_empty() {
-                non_handled_var_indexes.push(variable_index);
+        for (matcher_index, matcher) in matchers.iter().enumerate() {
+            if matcher.literals.is_empty() {
+                non_handled_var_indexes.push(matcher_index);
             } else {
                 let mut known_literals_of_var = HashSet::new();
 
-                for (literal_index, lit) in var.matcher.literals.iter().enumerate() {
+                for (literal_index, lit) in matcher.literals.iter().enumerate() {
                     let (start, end) = pick_atom_in_literal(lit);
                     let mut atom = lit[start..(lit.len() - end)].to_vec();
                     let literal_info = LiteralInfo {
-                        variable_index,
+                        matcher_index,
                         literal_index,
                         slice_offset: (start, end),
                     };
@@ -92,7 +91,7 @@ impl AcScan {
                         // results in the same lowercase string. This shouldn't be done outside
                         // of the "nocase" scenario, since different cases will be validated
                         // properly against each literal.
-                        if var.matcher.modifiers.nocase {
+                        if matcher.modifiers.nocase {
                             dedup_atom.make_ascii_lowercase();
                         }
 
@@ -156,7 +155,7 @@ impl AcScan {
         region: &Region,
         scanner: &'scanner super::Inner,
         scan_data: &mut ScanData<'scanner, '_>,
-        matches: &mut [Vec<StringMatch>],
+        all_matches: &mut [Vec<StringMatch>],
     ) -> Result<(), ScanError> {
         #[cfg(feature = "profiling")]
         if let Some(stats) = scan_data.statistics.as_mut() {
@@ -169,18 +168,18 @@ impl AcScan {
             if scan_data.check_timeout() {
                 return Err(ScanError::Timeout);
             }
-            self.handle_possible_match(region, scanner, &mat, scan_data, matches)?;
+            self.handle_possible_match(region, scanner, &mat, scan_data, all_matches)?;
         }
 
         if !self.non_handled_var_indexes.is_empty() {
             #[cfg(feature = "profiling")]
             let start = std::time::Instant::now();
 
-            // For every "raw" variable, scan the memory for this variable.
-            for variable_index in &self.non_handled_var_indexes {
-                let var = &scanner.variables[*variable_index].matcher;
+            // For every "raw" matcher, scan the memory for this matcher.
+            for matcher_index in &self.non_handled_var_indexes {
+                let matcher = &scanner.matchers[*matcher_index];
 
-                scan_single_variable(region, var, scan_data, &mut matches[*variable_index]);
+                scan_single_matcher(region, matcher, scan_data, &mut all_matches[*matcher_index]);
             }
 
             #[cfg(feature = "profiling")]
@@ -198,15 +197,15 @@ impl AcScan {
         scanner: &'scanner super::Inner,
         mat: &aho_corasick::Match,
         scan_data: &mut ScanData<'scanner, '_>,
-        matches: &mut [Vec<StringMatch>],
+        all_matches: &mut [Vec<StringMatch>],
     ) -> Result<(), ScanError> {
         for literal_info in &self.aho_index_to_literal_info[mat.pattern()] {
             let LiteralInfo {
-                variable_index,
+                matcher_index,
                 literal_index,
                 slice_offset: (start_offset, end_offset),
             } = *literal_info;
-            let var = &scanner.variables[variable_index].matcher;
+            let matcher = &scanner.matchers[matcher_index];
 
             #[cfg(feature = "profiling")]
             if let Some(stats) = scan_data.statistics.as_mut() {
@@ -227,11 +226,11 @@ impl AcScan {
             let m = start..end;
 
             // Verify the literal is valid.
-            let Some(match_type) = var.confirm_ac_literal(region.mem, &m, literal_index) else {
+            let Some(match_type) = matcher.confirm_ac_literal(region.mem, &m, literal_index) else {
                 continue;
             };
 
-            let var_matches = &mut matches[variable_index];
+            let var_matches = &mut all_matches[matcher_index];
 
             // Shorten the mem to prevent new matches on the same starting byte.
             // For example, for `a.*?bb`, and input `abbb`, this can happen:
@@ -251,12 +250,12 @@ impl AcScan {
             // share the same start.
             let mut start_position = 0;
             if let Some(mat) = var_matches.last() {
-                if mat.base == region.start && !var.has_greedy_reverse_validator() {
+                if mat.base == region.start && !matcher.has_greedy_reverse_validator() {
                     start_position = mat.offset + 1;
                 }
             }
 
-            let res = var.process_ac_match(region.mem, m, start_position, match_type);
+            let res = matcher.process_ac_match(region.mem, m, start_position, match_type);
 
             #[cfg(feature = "profiling")]
             {
@@ -275,14 +274,14 @@ impl AcScan {
                             scan_data.params.match_max_length,
                             0,
                         );
-                        add_match(var, new_match, var_matches);
+                        add_match(matcher, new_match, var_matches);
                     }
                 }
                 AcMatchStatus::Single(m) => {
-                    let xor_key = var.get_xor_key(literal_index);
+                    let xor_key = matcher.get_xor_key(literal_index);
                     let new_match =
                         StringMatch::new(region, m, scan_data.params.match_max_length, xor_key);
-                    add_match(var, new_match, var_matches);
+                    add_match(matcher, new_match, var_matches);
                 }
             }
 
@@ -290,11 +289,11 @@ impl AcScan {
                 var_matches.truncate(scan_data.params.string_max_nb_matches as usize);
                 if (scan_data.params.callback_events & CallbackEvents::STRING_REACHED_MATCH_LIMIT).0
                     != 0
-                    && scan_data.string_reached_match_limit.insert(variable_index)
+                    && scan_data.string_reached_match_limit.insert(matcher_index)
                 {
                     if let Some(cb) = &mut scan_data.callback {
                         if let Some(string_identifier) =
-                            build_string_identifier(scanner, variable_index)
+                            build_string_identifier(scanner, matcher_index)
                         {
                             match (cb)(ScanEvent::StringReachedMatchLimit(string_identifier)) {
                                 ScanCallbackResult::Continue => (),
@@ -310,7 +309,7 @@ impl AcScan {
     }
 }
 
-fn add_match(var: &Matcher, new_match: StringMatch, var_matches: &mut Vec<StringMatch>) {
+fn add_match(matcher: &Matcher, new_match: StringMatch, var_matches: &mut Vec<StringMatch>) {
     // XXX: If the left HIR has greedy repetitions, then the reverse validator
     // may give matches that replaces existing matches.
     //
@@ -322,7 +321,7 @@ fn add_match(var: &Matcher, new_match: StringMatch, var_matches: &mut Vec<String
     // To handle this, we search into the existing matches if there are existing matches
     // at the same offset. If there are, we replace them, since the longest match always
     // wins.
-    if var.has_greedy_reverse_validator() {
+    if matcher.has_greedy_reverse_validator() {
         match var_matches
             .binary_search_by_key(&(new_match.base + new_match.offset), |m| m.base + m.offset)
         {
@@ -334,7 +333,7 @@ fn add_match(var: &Matcher, new_match: StringMatch, var_matches: &mut Vec<String
     }
 }
 
-fn scan_single_variable(
+fn scan_single_matcher(
     region: &Region,
     matcher: &Matcher,
     scan_data: &mut ScanData,
@@ -352,7 +351,7 @@ fn scan_single_variable(
                     region,
                     mat,
                     scan_data.params.match_max_length,
-                    // No xor key, since this function is only used for regex variables
+                    // No xor key, since this function is only used for regex matchers
                     0,
                 ));
 
@@ -369,7 +368,7 @@ fn scan_single_variable(
 
 fn build_string_identifier(
     scanner: &super::Inner,
-    variable_index: usize,
+    matcher_index: usize,
 ) -> Option<StringIdentifier<'_>> {
     let mut index = 0;
     // Go through all the rules of the scanner to find the right one.
@@ -382,13 +381,13 @@ fn build_string_identifier(
     // the rules should not take that long.
     //
     // A solution to improve this would be to store in each rule the index
-    // of its first variable, which would make a binary search through
+    // of its first matcher, which would make a binary search through
     // the rules possible. However, this means an additional word to store
     // with each rule, only to alleviate this very specific event. For
     // the moment, this is not considered to be worth the cost.
     for rule in scanner.global_rules.iter().chain(scanner.rules.iter()) {
-        if index + rule.variables.len() > variable_index {
-            let string_index = variable_index - index;
+        if index + rule.variables.len() > matcher_index {
+            let string_index = matcher_index - index;
             return Some(StringIdentifier {
                 rule_namespace: scanner.namespaces[rule.namespace_index].as_ref(),
                 rule_name: &rule.name,
@@ -414,7 +413,7 @@ mod tests {
     fn test_types_traits() {
         test_type_traits_non_clonable(AcScan::new(&[], CompilerProfile::Speed));
         test_type_traits_non_clonable(LiteralInfo {
-            variable_index: 0,
+            matcher_index: 0,
             literal_index: 0,
             slice_offset: (0, 0),
         });

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1860,8 +1860,9 @@ mod wire {
                 tags: Box::new([]),
                 metadatas: Box::new([]),
                 condition: Expression::Filesize,
-                is_private: false,
                 variables: Box::new([]),
+                is_private: false,
+                is_depended_upon: false,
             }];
             test_round_trip_custom_deser(&rules, |reader| deserialize_rules(&ctx, reader), &[0, 4]);
         }

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1120,9 +1120,6 @@ struct EvalContext {
     /// Variable matches. None if evaluation is done previous the scan is done.
     var_matches: Option<std::vec::IntoIter<Vec<StringMatch>>>,
 
-    /// Current index into the variables list.
-    var_index: usize,
-
     /// Results of "previous" rules.
     ///
     /// This is filled while iterating on rules and used when rules refer to the
@@ -1143,7 +1140,6 @@ impl EvalContext {
     ) -> Self {
         Self {
             var_matches: var_matches.map(Vec::into_iter),
-            var_index: 0,
             previous_results: Vec::with_capacity(nb_rules),
             namespace_disabled: vec![false; nb_namespaces],
         }
@@ -1193,9 +1189,7 @@ impl EvalContext {
         let var_matches: Option<Vec<_>> = self
             .var_matches
             .as_mut()
-            .map(|matches| matches.take(rule.nb_variables).collect());
-        let vars = &scanner.variables[self.var_index..(self.var_index + rule.nb_variables)];
-        self.var_index += rule.nb_variables;
+            .map(|matches| matches.take(rule.variables.len()).collect());
 
         let matched = if self.namespace_disabled[rule.namespace_index] {
             false
@@ -1215,13 +1209,8 @@ impl EvalContext {
         }
 
         if matched || scan_data.params.include_not_matched_rules {
-            let matched_rule = build_matched_rule(
-                rule,
-                vars,
-                scanner,
-                var_matches.unwrap_or_default(),
-                matched,
-            );
+            let matched_rule =
+                build_matched_rule(rule, scanner, var_matches.unwrap_or_default(), matched);
             match &mut scan_data.callback {
                 Some(cb) if call_callback => {
                     let mut result = ScanCallbackResult::Continue;
@@ -1403,7 +1392,6 @@ impl ScanData<'_, '_> {
 
 fn build_matched_rule<'scanner>(
     rule: &'scanner Rule,
-    variables: &'scanner [Variable],
     scanner: &'scanner Inner,
     var_matches: Vec<Vec<StringMatch>>,
     matched: bool,
@@ -1415,13 +1403,13 @@ fn build_matched_rule<'scanner>(
         metadatas: &rule.metadatas,
         matches: var_matches
             .into_iter()
-            .zip(variables.iter())
-            .filter(|(_, var)| !var.is_private)
+            .zip(rule.variables.iter())
             .filter(|(matches, _)| !matches.is_empty())
+            .filter(|(_, var)| !var.is_private)
             .map(|(matches, var)| StringMatches {
                 name: scanner.bytes_pool.get_str(var.name),
                 matches,
-                has_xor_modifier: var.matcher.modifiers.xor_start.is_some(),
+                has_xor_modifier: var.has_xor_modifier,
             })
             .collect(),
         matched,
@@ -1871,9 +1859,9 @@ mod wire {
                 namespace_index: 0,
                 tags: Box::new([]),
                 metadatas: Box::new([]),
-                nb_variables: 0,
                 condition: Expression::Filesize,
                 is_private: false,
+                variables: Box::new([]),
             }];
             test_round_trip_custom_deser(&rules, |reader| deserialize_rules(&ctx, reader), &[0, 4]);
         }

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use crate::bytes_pool::{BytesPool, BytesSymbol, StringSymbol};
 use crate::compiler::external_symbol::{ExternalSymbol, ExternalValue};
 use crate::compiler::rule::Rule;
-use crate::compiler::variable::Variable;
 use crate::evaluator::{self, EvalError, evaluate_rule};
+use crate::matcher::Matcher;
 use crate::memory::{FragmentedMemory, Memory, Region};
 use crate::module::{Module, ModuleData, ModuleUserData};
 use crate::timeout::TimeoutChecker;
@@ -187,7 +187,7 @@ impl Scanner {
         let Compiler {
             rules,
             global_rules,
-            variables,
+            matchers,
             namespaces,
             imported_modules,
             external_symbols,
@@ -197,7 +197,7 @@ impl Scanner {
         } = compiler;
         let namespaces = namespaces.into_iter().map(|v| v.name).collect();
 
-        let ac_scan = ac_scan::AcScan::new(&variables, profile);
+        let ac_scan = ac_scan::AcScan::new(&matchers, profile);
 
         let mut external_symbols_values = Vec::with_capacity(external_symbols.len());
         let mut external_symbols_map = HashMap::with_capacity(external_symbols.len());
@@ -214,7 +214,7 @@ impl Scanner {
             inner: Arc::new(Inner {
                 rules: rules.into_boxed_slice(),
                 global_rules: global_rules.into_boxed_slice(),
-                variables: variables.into_boxed_slice(),
+                matchers: matchers.into_boxed_slice(),
                 ac_scan,
                 modules: imported_modules.into_boxed_slice(),
                 external_symbols_map,
@@ -776,10 +776,10 @@ struct Inner {
     /// evaluated.
     global_rules: Box<[Rule]>,
 
-    /// Compiled variables.
+    /// Matchers for compiled variables.
     ///
     /// Those are stored in the order the rules have been compiled in.
-    variables: Box<[Variable]>,
+    matchers: Box<[Matcher]>,
 
     /// Regex set of all variables used in the rules.
     ///
@@ -1043,7 +1043,7 @@ impl Inner {
         mem: &mut Memory,
         scan_data: &mut ScanData<'scanner, '_>,
     ) -> Result<Vec<Vec<StringMatch>>, ScanError> {
-        let mut matches = vec![Vec::new(); self.variables.len()];
+        let mut matches = vec![Vec::new(); self.matchers.len()];
 
         #[cfg(feature = "profiling")]
         let start = std::time::Instant::now();
@@ -1505,9 +1505,9 @@ mod wire {
     use std::io;
     use std::sync::Arc;
 
+    use crate::matcher::Matcher;
     use crate::wire::{Deserialize, Serialize};
 
-    use crate::compiler::variable::Variable;
     use crate::compiler::{CompilerProfile, ExternalValue};
     use crate::module::{Module, ModuleUserData, StaticValue};
     use crate::wire::DeserializeContext;
@@ -1583,7 +1583,7 @@ mod wire {
             self.external_symbols_map.serialize(writer)?;
             self.namespaces.serialize(writer)?;
             self.bytes_pool.serialize(writer)?;
-            self.variables.serialize(writer)?;
+            self.matchers.serialize(writer)?;
             serialize_modules(&self.modules, writer)?;
             self.global_rules.serialize(writer)?;
             self.rules.serialize(writer)?;
@@ -1599,7 +1599,7 @@ mod wire {
         let external_symbols_map = <HashMap<Box<str>, usize>>::deserialize_reader(reader)?;
         let namespaces = <Vec<String>>::deserialize_reader(reader)?;
         let bytes_pool = BytesPool::deserialize_reader(reader)?;
-        let variables = <Vec<Variable>>::deserialize_reader(reader)?;
+        let matchers = <Vec<Matcher>>::deserialize_reader(reader)?;
         let modules = deserialize_modules(params.modules, reader)?;
 
         let ctx = DeserializeContext {
@@ -1612,12 +1612,12 @@ mod wire {
         let rules = deserialize_rules(&ctx, reader)?;
 
         let profile = CompilerProfile::deserialize_reader(reader)?;
-        let ac_scan = AcScan::new(&variables, profile);
+        let ac_scan = AcScan::new(&matchers, profile);
 
         Ok(Inner {
             rules: rules.into_boxed_slice(),
             global_rules: global_rules.into_boxed_slice(),
-            variables: variables.into_boxed_slice(),
+            matchers: matchers.into_boxed_slice(),
             ac_scan,
             modules: modules.into_boxed_slice(),
             external_symbols_map,
@@ -1727,7 +1727,7 @@ mod wire {
                     external_symbols_map: HashMap::new(),
                     namespaces: Box::new([]),
                     bytes_pool: BytesPoolBuilder::default().into_pool(),
-                    variables: Box::new([]),
+                    matchers: Box::new([]),
                     modules: Box::new([Box::new(Math)]),
                     global_rules: Box::new([]),
                     rules: Box::new([]),
@@ -1775,7 +1775,7 @@ mod wire {
                     .collect(),
                 namespaces: Box::new(["abc".into()]),
                 bytes_pool: BytesPoolBuilder::default().into_pool(),
-                variables: Box::new([]),
+                matchers: Box::new([]),
                 modules: Box::new([Box::new(Math), Box::new(Time)]),
                 global_rules: Box::new([]),
                 rules: Box::new([]),
@@ -1807,7 +1807,7 @@ mod wire {
             assert_eq!(inner.external_symbols_map, inner2.external_symbols_map);
             assert_eq!(inner.namespaces, inner2.namespaces);
             assert_eq!(inner.bytes_pool, inner2.bytes_pool);
-            assert_eq!(inner.variables, inner2.variables);
+            assert_eq!(inner.matchers, inner2.matchers);
             assert_eq!(inner2.modules.len(), 2);
             assert_eq!(inner2.modules[0].get_name(), "math");
             assert_eq!(inner2.modules[1].get_name(), "time");

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::bytes_pool::{BytesPool, BytesSymbol, StringSymbol};
 use crate::compiler::external_symbol::{ExternalSymbol, ExternalValue};
 use crate::compiler::rule::Rule;
-use crate::evaluator::{self, EvalError, evaluate_rule};
+use crate::evaluator::{self, EvalError, MatchedDependencyRules, evaluate_rule};
 use crate::matcher::Matcher;
 use crate::memory::{FragmentedMemory, Memory, Region};
 use crate::module::{Module, ModuleData, ModuleUserData};
@@ -937,8 +937,7 @@ impl Inner {
         // which variables have no miss at all.
         let var_matches = self.do_memory_scan(&mut mem, scan_data)?;
 
-        let mut eval_ctx =
-            EvalContext::new(Some(var_matches), self.rules.len(), self.namespaces.len());
+        let mut eval_ctx = EvalContext::new(Some(var_matches), self.namespaces.len());
 
         #[cfg(feature = "profiling")]
         let start = std::time::Instant::now();
@@ -982,8 +981,8 @@ impl Inner {
         scan_data.handle_already_matched_rules_and_callback()?;
 
         // Evaluate all non global rules.
-        for rule in &self.rules {
-            match eval_ctx.eval_non_global_rule(self, rule, &mut mem, scan_data, true) {
+        for (rule_index, rule) in self.rules.iter().enumerate() {
+            match eval_ctx.eval_non_global_rule(self, rule, rule_index, &mut mem, scan_data, true) {
                 Ok(()) => (),
                 Err(EvalError::Undecidable) => unreachable!(),
                 Err(EvalError::Timeout) => return Err(ScanError::Timeout),
@@ -1007,7 +1006,7 @@ impl Inner {
         mem: &mut Memory,
         scan_data: &mut ScanData<'scanner, '_>,
     ) -> Result<(), EvalError> {
-        let mut eval_ctx = EvalContext::new(None, self.rules.len(), self.namespaces.len());
+        let mut eval_ctx = EvalContext::new(None, self.namespaces.len());
 
         // First, check global rules
         let mut has_unknown_globals = false;
@@ -1031,8 +1030,8 @@ impl Inner {
         }
 
         // Then, if all global rules matched, the normal rules
-        for rule in &self.rules {
-            eval_ctx.eval_non_global_rule(self, rule, mem, scan_data, false)?;
+        for (rule_index, rule) in self.rules.iter().enumerate() {
+            eval_ctx.eval_non_global_rule(self, rule, rule_index, mem, scan_data, false)?;
         }
 
         Ok(())
@@ -1120,11 +1119,8 @@ struct EvalContext {
     /// Variable matches. None if evaluation is done previous the scan is done.
     var_matches: Option<std::vec::IntoIter<Vec<StringMatch>>>,
 
-    /// Results of "previous" rules.
-    ///
-    /// This is filled while iterating on rules and used when rules refer to the
-    /// result of previous rules.
-    previous_results: Vec<bool>,
+    /// List of dependency rules that matched.
+    matched_dependency_rules: MatchedDependencyRules,
 
     /// Is a namespace "disabled" or not.
     ///
@@ -1133,14 +1129,10 @@ struct EvalContext {
 }
 
 impl EvalContext {
-    fn new(
-        var_matches: Option<Vec<Vec<StringMatch>>>,
-        nb_rules: usize,
-        nb_namespaces: usize,
-    ) -> Self {
+    fn new(var_matches: Option<Vec<Vec<StringMatch>>>, nb_namespaces: usize) -> Self {
         Self {
             var_matches: var_matches.map(Vec::into_iter),
-            previous_results: Vec::with_capacity(nb_rules),
+            matched_dependency_rules: MatchedDependencyRules::default(),
             namespace_disabled: vec![false; nb_namespaces],
         }
     }
@@ -1169,12 +1161,15 @@ impl EvalContext {
         &mut self,
         scanner: &'scanner Inner,
         rule: &'scanner Rule,
+        rule_index: usize,
         mem: &mut Memory,
         scan_data: &mut ScanData<'scanner, '_>,
         call_callback: bool,
     ) -> Result<(), EvalError> {
         let res = self.eval_rule_inner(scanner, rule, mem, scan_data, call_callback)?;
-        self.previous_results.push(res);
+        if res && rule.is_depended_upon {
+            self.matched_dependency_rules.insert(rule_index);
+        }
         Ok(())
     }
 
@@ -1197,7 +1192,7 @@ impl EvalContext {
             evaluate_rule(
                 rule,
                 var_matches.as_deref(),
-                &self.previous_results,
+                &self.matched_dependency_rules,
                 &scanner.bytes_pool,
                 mem,
                 scan_data,
@@ -1991,25 +1986,26 @@ mod tests {
             callback: None,
             string_reached_match_limit: HashSet::new(),
         };
-        let mut previous_results = Vec::new();
+        let mut matched_dependency_rules = MatchedDependencyRules::default();
         let rules = &scanner.inner.rules;
-        for rule in &rules[..(rules.len() - 1)] {
-            previous_results.push(
-                evaluate_rule(
-                    rule,
-                    None,
-                    &previous_results,
-                    &scanner.inner.bytes_pool,
-                    &mut mem,
-                    &mut scan_data,
-                )
-                .unwrap(),
-            );
+        for (rule_index, rule) in rules[..(rules.len() - 1)].iter().enumerate() {
+            let res = evaluate_rule(
+                rule,
+                None,
+                &matched_dependency_rules,
+                &scanner.inner.bytes_pool,
+                &mut mem,
+                &mut scan_data,
+            )
+            .unwrap();
+            if res && rule.is_depended_upon {
+                matched_dependency_rules.insert(rule_index);
+            }
         }
         let last_res = evaluate_rule(
             &rules[rules.len() - 1],
             None,
-            &previous_results,
+            &matched_dependency_rules,
             &scanner.inner.bytes_pool,
             &mut mem,
             &mut scan_data,


### PR DESCRIPTION
Some refactoring to simplify the code, and an optimization: instead of creating a Vec<bool> of the size of all the rules in the scanner, reduce it to a Vec<usize> of only:

- rules that are depended upon
- rules that match

This drastically reduces the size of this Vec with it being empty in most cases, given:

- rules generally do not match
- rules dependency is a seldom used feature