### PR TITLE
Several boreal-py improvements

### DIFF
--- a/boreal-cli/tests/cli.rs
+++ b/boreal-cli/tests/cli.rs
@@ -2223,25 +2223,38 @@ struct BinHelper {
 
 impl BinHelper {
     fn run(arg: &str) -> Self {
-        // Path to current exe
-        let path = std::env::current_exe().unwrap();
-        // Path to "deps" dir
-        let path = path.parent().unwrap();
-        // Path to parent of deps dir, ie destination of build artifacts
-        let path = path.parent().unwrap();
-        // Now select the bin helper
-        let path = path.join(if cfg!(windows) {
+        // Path to current dir
+        let current_exe = std::env::current_exe().unwrap();
+        let starting_dir = current_exe.parent().unwrap();
+
+        let filename = if cfg!(windows) {
             "boreal-test-helpers.exe"
         } else {
             "boreal-test-helpers"
-        });
-        if !path.exists() {
-            panic!(
-                "File {} not found. \
-                You need to compile the `boreal-test-helpers` crate to run this test",
-                path.display()
-            );
+        };
+
+        // Search for boreal-test-helpers in parents until finding it.
+        let path;
+        let mut current_dir = starting_dir;
+        loop {
+            let attempt = current_dir.join(filename);
+            if attempt.exists() && attempt.is_file() {
+                path = attempt;
+                break;
+            }
+            match current_dir.parent() {
+                Some(parent) => current_dir = parent,
+                None => {
+                    panic!(
+                        "File {} not found in any parent from {}. \
+                Did you compile the `boreal-test-helpers` crate before runnning this test",
+                        filename,
+                        starting_dir.display()
+                    );
+                }
+            }
         }
+
         let mut child = std::process::Command::new(path)
             .arg(arg)
             .stdout(std::process::Stdio::piped())

--- a/boreal-py/src/lib.rs
+++ b/boreal-py/src/lib.rs
@@ -453,13 +453,15 @@ fn build_compiler(profile: Option<&CompilerProfile>) -> compiler::Compiler {
             Some(CompilerProfile::Memory) => ::boreal::compiler::CompilerProfile::Memory,
         })
         .add_module(::boreal::module::Console::with_callback(|log| {
-            // XXX: when targetting python 3.12 or above, this could be simplified
-            // by using the "%.*s" format, avoiding the CString conversion.
-            if let Ok(cstr) = CString::new(log) {
-                // Safety: see <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromFormat>
-                // for the format. A '%s" expects a c-string pointer, which has just been built.
-                unsafe { ffi::PySys_FormatStdout(c"%s\n".as_ptr(), cstr.as_ptr()) }
-            }
+            Python::attach(|_py| {
+                // XXX: when targetting python 3.12 or above, this could be simplified
+                // by using the "%.*s" format, avoiding the CString conversion.
+                if let Ok(cstr) = CString::new(log) {
+                    // Safety: see <https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromFormat>
+                    // for the format. A '%s" expects a c-string pointer, which has just been built.
+                    unsafe { ffi::PySys_FormatStdout(c"%s\n".as_ptr(), cstr.as_ptr()) }
+                }
+            });
         }))
         .build()
 }

--- a/boreal-py/src/rule.rs
+++ b/boreal-py/src/rule.rs
@@ -96,7 +96,7 @@ fn convert_metadata_value<'py>(
 ) -> Result<Bound<'py, PyAny>, PyErr> {
     Ok(match value {
         MetadataValue::Bytes(v) => {
-            let bytes = scanner.get_bytes_symbol(v).to_vec().into_pyobject(py)?;
+            let bytes = scanner.get_bytes_symbol(v).into_pyobject(py)?;
             // XXX: Yara forces a string conversion here, losing data in the
             // process. Prefer using the right type here.
             if YARA_PYTHON_COMPATIBILITY.load(Ordering::SeqCst) {

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -10,7 +10,9 @@ use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 
 use ::boreal::module::{Console, ConsoleData, Value};
-use ::boreal::scanner::{self, CallbackEvents, FragmentedScanMode, ScanCallbackResult, ScanEvent};
+use ::boreal::scanner::{
+    self, CallbackEvents, FragmentedScanMode, ScanCallbackResult, ScanEvent, ScanParams,
+};
 
 use crate::rule_match::Match;
 use crate::rule_string::RuleString;
@@ -265,8 +267,12 @@ impl Scanner {
             params = params.match_max_length(value);
         }
         let fast = if YARA_PYTHON_COMPATIBILITY.load(Ordering::SeqCst) {
-            // Default value in libyara
-            params = params.string_max_nb_matches(1_000_000);
+            // Default value in libyara. Only set it if not already modified.
+            if params.get_string_max_nb_matches()
+                == ScanParams::default().get_string_max_nb_matches()
+            {
+                params = params.string_max_nb_matches(1_000_000);
+            }
             // In compat mode, default to false for fast mode
             fast.unwrap_or(false)
         } else {

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -618,29 +618,30 @@ impl<'s> CallbackHandler<'s> {
         matched: bool,
     ) -> PyResult<ScanCallbackResult> {
         Python::attach(|py| {
-            let m = Match::new(py, self.scanner, rule, self.allow_duplicate_metadata)?;
-
-            let ret = match &self.callback {
-                Some(cb) => {
+            match &self.callback {
+                Some(cb)
                     if (matched && (self.which & CALLBACK_MATCHES) != 0)
-                        || (!matched && (self.which & CALLBACK_NON_MATCHES) != 0)
-                    {
-                        let rule = match_to_callback_dict(py, &m, matched)?;
-                        convert_callback_return_value(py, &cb.call1(py, (rule,))?)
-                    } else {
-                        ScanCallbackResult::Continue
-                    }
-                }
-                None => ScanCallbackResult::Continue,
-            };
+                        || (!matched && (self.which & CALLBACK_NON_MATCHES) != 0) =>
+                {
+                    let m = Match::new(py, self.scanner, rule, self.allow_duplicate_metadata)?;
+                    let rule = match_to_callback_dict(py, &m, matched)?;
 
-            // Always save the match: even if a callback is used, the matches
-            // are returned from the match function call.
-            // But, only the real matches are saved, not the "non match"...
-            if matched {
-                self.matches.push(m);
+                    if matched {
+                        self.matches.push(m);
+                    }
+                    Ok(convert_callback_return_value(py, &cb.call1(py, (rule,))?))
+                }
+                _ => {
+                    // Save matches: even if a callback is used, the matches
+                    // are returned from the match function call.
+                    if matched {
+                        let m = Match::new(py, self.scanner, rule, self.allow_duplicate_metadata)?;
+                        self.matches.push(m);
+                    }
+
+                    Ok(ScanCallbackResult::Continue)
+                }
             }
-            Ok(ret)
         })
     }
 }

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -161,6 +161,7 @@ impl Scanner {
     ))]
     fn r#match(
         &self,
+        py: Python,
         filepath: Option<&str>,
         data: Option<&Bound<'_, PyAny>>,
         pid: Option<u32>,
@@ -291,25 +292,32 @@ impl Scanner {
         );
         let res = match (filepath, data, pid) {
             (Some(filepath), None, None) => {
-                if self.use_mmap.load(Ordering::SeqCst) {
-                    // Safety: unsafe because of mmap semantics, but opted in by
-                    // setting the use_mmap param to true.
-                    unsafe {
-                        scanner.scan_file_memmap_with_callback(filepath, |event| {
+                py.detach(|| {
+                    if self.use_mmap.load(Ordering::SeqCst) {
+                        // Safety: unsafe because of mmap semantics, but opted in by
+                        // setting the use_mmap param to true.
+                        unsafe {
+                            scanner.scan_file_memmap_with_callback(filepath, |event| {
+                                cb_handler.handle_event(event)
+                            })
+                        }
+                    } else {
+                        scanner.scan_file_with_callback(filepath, |event| {
                             cb_handler.handle_event(event)
                         })
                     }
-                } else {
-                    scanner
-                        .scan_file_with_callback(filepath, |event| cb_handler.handle_event(event))
-                }
+                })
             }
             (None, Some(data), None) => {
                 if let Ok(s) = data.extract::<&[u8]>() {
-                    scanner.scan_mem_with_callback(s, |event| cb_handler.handle_event(event))
+                    py.detach(|| {
+                        scanner.scan_mem_with_callback(s, |event| cb_handler.handle_event(event))
+                    })
                 } else if let Ok(s) = data.extract::<&str>() {
-                    scanner.scan_mem_with_callback(s.as_bytes(), |event| {
-                        cb_handler.handle_event(event)
+                    py.detach(|| {
+                        scanner.scan_mem_with_callback(s.as_bytes(), |event| {
+                            cb_handler.handle_event(event)
+                        })
                     })
                 } else {
                     return Err(PyTypeError::new_err(
@@ -317,9 +325,9 @@ impl Scanner {
                     ));
                 }
             }
-            (None, None, Some(pid)) => {
+            (None, None, Some(pid)) => py.detach(|| {
                 scanner.scan_process_with_callback(pid, |event| cb_handler.handle_event(event))
-            }
+            }),
             _ => {
                 return Err(PyTypeError::new_err(
                     "one of filepath, data or pid must be passed",

--- a/boreal-py/src/scanner.rs
+++ b/boreal-py/src/scanner.rs
@@ -4,10 +4,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use parking_lot::Mutex;
-use pyo3::create_exception;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
+use pyo3::{create_exception, intern};
 
 use ::boreal::module::{Console, ConsoleData, Value};
 use ::boreal::scanner::{
@@ -659,12 +659,12 @@ fn match_to_callback_dict<'py>(
 ) -> Result<Bound<'py, PyDict>, PyErr> {
     let d = PyDict::new(py);
 
-    d.set_item("rule", &m.rule)?;
-    d.set_item("namespace", &m.namespace)?;
-    d.set_item("meta", m.meta.clone_ref(py))?;
-    d.set_item("tags", m.tags.clone_ref(py))?;
-    d.set_item("strings", m.strings.clone_ref(py))?;
-    d.set_item("matches", matched)?;
+    d.set_item(intern!(py, "rule"), &m.rule)?;
+    d.set_item(intern!(py, "namespace"), &m.namespace)?;
+    d.set_item(intern!(py, "meta"), m.meta.clone_ref(py))?;
+    d.set_item(intern!(py, "tags"), m.tags.clone_ref(py))?;
+    d.set_item(intern!(py, "strings"), m.strings.clone_ref(py))?;
+    d.set_item(intern!(py, "matches"), matched)?;
 
     Ok(d)
 }

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -1081,6 +1081,31 @@ rule a {
         )
 
 
+@pytest.mark.global_config(yara_compat_mode=True)
+def test_string_max_nb_matches_yara_compat():
+    # Test that in yara mode, if string_max_nb_matches is modified,
+    # the modified value is used.
+    with utils.YaraCompatibilityMode():
+        # Only run on boreal, yara does not support this
+        rules = boreal.compile(source="""
+            rule a {
+                strings:
+                    $ = "abc"
+                condition:
+                    any of them
+            }""")
+
+        # Simply check setting those parameters work. All those
+        # parameters are properly tested in the boreal crate.
+        rules.set_params(
+            string_max_nb_matches=1,
+        )
+        # Check string_max_nb_matches to ensure parameters are properly set.
+        results = rules.match(data="abc abc")
+        s = results[0].strings[0]
+        assert len(s.instances) == 1
+
+
 def test_max_match_data():
     rules = boreal.compile(source="""
     rule a {

--- a/boreal-py/tests/test_scanner.py
+++ b/boreal-py/tests/test_scanner.py
@@ -4,7 +4,9 @@ import platform
 import os
 import pytest
 import subprocess
+import sys
 import tempfile
+import threading
 from . import utils
 
 MODULES = utils.modules()
@@ -206,9 +208,7 @@ def test_match_scan_failed(module, is_yara):
             rules.match(pid=99999999)
 
 
-@pytest.mark.parametrize('module', MODULES)
-def test_match_timeout(module):
-    rules = module.compile(source="""
+INFINITE_LOOP_RULE = """
 rule a {
     condition:
         for all i in (0..9223372036854775807) : (
@@ -220,12 +220,55 @@ rule a {
                 )
             )
         )
-}""")
+}"""
+
+
+@pytest.mark.parametrize('module', MODULES)
+def test_match_timeout(module):
+    rules = module.compile(source=INFINITE_LOOP_RULE)
 
     with pytest.raises(module.TimeoutError):
         # Unfortunately, we cannot go below 1 second as this is the smallest timeout value
         # in the yara api
         rules.match(data='', timeout=1)
+
+
+@pytest.mark.parametrize('module', MODULES)
+def test_match_releases_gil(module):
+    rules = module.compile(source=INFINITE_LOOP_RULE)
+
+    counter = 0
+    stop = threading.Event()
+
+    def spin():
+        nonlocal counter
+        while not stop.is_set():
+            counter += 1
+
+    try:
+        # Shrink the interval between GIL switch checks. This ensures
+        # not a lot of work is done in the spin thread before entering the
+        # match call. If the GIL was not released, the counter would thus
+        # be quite small. A larger value would let the spin thread run
+        # much more, and it would be harder to measure if the match call
+        # does release the GIL or not.
+        previous_interval = sys.getswitchinterval()
+        sys.setswitchinterval(0.0001)
+
+        thread = threading.Thread(target=spin)
+        thread.start()
+
+        with pytest.raises(module.TimeoutError):
+            rules.match(data='', timeout=1)
+    finally:
+        stop.set()
+        thread.join()
+        sys.setswitchinterval(previous_interval)
+
+    # If the gil was properly released during the match call, both the
+    # match and the spin thread could run concurrently, so the counter
+    # should be large.
+    assert counter > 100_000
 
 
 @pytest.mark.parametrize('module', MODULES)

--- a/boreal/tests/it/utils.rs
+++ b/boreal/tests/it/utils.rs
@@ -1279,25 +1279,38 @@ pub struct BinHelper {
 
 impl BinHelper {
     pub fn run(arg: &str) -> Self {
-        // Path to current exe
-        let path = std::env::current_exe().unwrap();
-        // Path to "deps" dir
-        let path = path.parent().unwrap();
-        // Path to parent of deps dir, ie destination of build artifacts
-        let path = path.parent().unwrap();
-        // Now select the bin helper
-        let path = path.join(if cfg!(windows) {
+        // Path to current dir
+        let current_exe = std::env::current_exe().unwrap();
+        let starting_dir = current_exe.parent().unwrap();
+
+        let filename = if cfg!(windows) {
             "boreal-test-helpers.exe"
         } else {
             "boreal-test-helpers"
-        });
-        if !path.exists() {
-            panic!(
-                "File {} not found. \
-                You need to compile the `boreal-test-helpers` crate to run this test",
-                path.display()
-            );
+        };
+
+        // Search for boreal-test-helpers in parents until finding it.
+        let path;
+        let mut current_dir = starting_dir;
+        loop {
+            let attempt = current_dir.join(filename);
+            if attempt.exists() && attempt.is_file() {
+                path = attempt;
+                break;
+            }
+            match current_dir.parent() {
+                Some(parent) => current_dir = parent,
+                None => {
+                    panic!(
+                        "File {} not found in any parent from {}. \
+                Did you compile the `boreal-test-helpers` crate before runnning this test",
+                        filename,
+                        starting_dir.display()
+                    );
+                }
+            }
         }
+
         let mut child = std::process::Command::new(path)
             .arg(arg)
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
- Release the GIL before launching scans on normal builds, allowing other threads to run while the scan is ongoing
- Use the custom string_max_nb_matches if set manually even if yara compatibility mode is enabled
- Several ram improvements to avoid allocating or building python objects if not required.