### PR TITLE
feat: use u32 for bytes pool addressing

### DIFF
--- a/boreal/src/bytes_pool.rs
+++ b/boreal/src/bytes_pool.rs
@@ -34,15 +34,15 @@ pub(crate) struct BytesPool {
 /// Symbol for a bytes string stored in a bytes intern pool.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct BytesSymbol {
-    from: usize,
-    to: usize,
+    from: u32,
+    to: u32,
 }
 
 /// Symbol for a string stored in a bytes intern pool.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StringSymbol {
-    from: usize,
-    to: usize,
+    from: u32,
+    to: u32,
 }
 
 impl BytesPool {
@@ -54,8 +54,8 @@ impl BytesPool {
         self.buffer.extend(v);
 
         BytesSymbol {
-            from,
-            to: self.buffer.len(),
+            from: convert_to_u32(from),
+            to: convert_to_u32(self.buffer.len()),
         }
     }
 
@@ -67,25 +67,40 @@ impl BytesPool {
         self.buffer.extend(v.as_bytes());
 
         StringSymbol {
-            from,
-            to: self.buffer.len(),
+            from: convert_to_u32(from),
+            to: convert_to_u32(self.buffer.len()),
         }
     }
 
     /// Get a byte string from the pool
     pub(crate) fn get(&self, symbol: BytesSymbol) -> &[u8] {
-        &self.buffer[symbol.from..symbol.to]
+        let (from, to) = (symbol.from as usize, symbol.to as usize);
+
+        &self.buffer[from..to]
     }
 
     /// Get a string from the pool
     pub(crate) fn get_str(&self, symbol: StringSymbol) -> &str {
+        let (from, to) = (symbol.from as usize, symbol.to as usize);
+
         // Safety:
         // - A StringSymbol can only be constructed from `insert_str`
         // - Once a symbol is created, it is guaranteed that the indexes in the symbol
         //   will always refer to the same bytes (the buffer can only grow).
         // It is thus safe to rebuild the string from the stored bytes.
-        unsafe { std::str::from_utf8_unchecked(&self.buffer[symbol.from..symbol.to]) }
+        unsafe { std::str::from_utf8_unchecked(&self.buffer[from..to]) }
     }
+}
+
+#[inline(always)]
+fn convert_to_u32(v: usize) -> u32 {
+    // Convert by saturating to u32::MAX.
+    //
+    // This makes the symbol unusable, but the fact the pool
+    // is full will be detected afterwards to make the compilation fail.
+    // This keeps the code simple rather than forcing every caller of
+    // this function to handle the error case.
+    v.try_into().ok().unwrap_or(u32::MAX)
 }
 
 /// A builder for the [`BytesPool`] object.
@@ -100,6 +115,11 @@ pub(crate) struct BytesPoolBuilder {
     bytes_map: HashMap<Vec<u8>, BytesSymbol>,
     /// Map of string symbols already added in the pool.
     str_map: HashMap<String, StringSymbol>,
+
+    /// Size limit for the pool.
+    ///
+    /// Only used in testing
+    pub(crate) limit: Option<usize>,
 }
 
 impl BytesPoolBuilder {
@@ -136,6 +156,13 @@ impl BytesPoolBuilder {
         self.pool.buffer.shrink_to_fit();
         self.pool
     }
+
+    /// Is the pool full.
+    pub(crate) fn is_full(&self) -> bool {
+        let limit = self.limit.unwrap_or(u32::MAX as usize);
+
+        self.pool.buffer.len() >= limit
+    }
 }
 
 #[cfg(feature = "serialize")]
@@ -170,8 +197,8 @@ mod wire {
 
     impl Deserialize for StringSymbol {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let from = usize::deserialize_reader(reader)?;
-            let to = usize::deserialize_reader(reader)?;
+            let from = u32::deserialize_reader(reader)?;
+            let to = u32::deserialize_reader(reader)?;
             Ok(Self { from, to })
         }
     }
@@ -186,8 +213,8 @@ mod wire {
 
     impl Deserialize for BytesSymbol {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
-            let from = usize::deserialize_reader(reader)?;
-            let to = usize::deserialize_reader(reader)?;
+            let from = u32::deserialize_reader(reader)?;
+            let to = u32::deserialize_reader(reader)?;
             Ok(Self { from, to })
         }
     }
@@ -207,8 +234,8 @@ mod wire {
             );
             test_round_trip(&BytesPool { buffer: Vec::new() }, &[2]);
 
-            test_round_trip(&StringSymbol { from: 23, to: 2 }, &[0, 8]);
-            test_round_trip(&BytesSymbol { from: 3, to: 8 }, &[0, 8]);
+            test_round_trip(&StringSymbol { from: 23, to: 2 }, &[0, 4]);
+            test_round_trip(&BytesSymbol { from: 3, to: 8 }, &[0, 4]);
         }
     }
 }

--- a/boreal/src/bytes_pool.rs
+++ b/boreal/src/bytes_pool.rs
@@ -28,7 +28,7 @@ use std::collections::HashMap;
 /// symbol can be a single usize.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct BytesPool {
-    buffer: Vec<u8>,
+    pool: Box<[u8]>,
 }
 
 /// Symbol for a bytes string stored in a bytes intern pool.
@@ -46,37 +46,11 @@ pub struct StringSymbol {
 }
 
 impl BytesPool {
-    /// Insert bytes into the bytes pool.
-    ///
-    /// The returned symbol can then be used to retrieve those bytes from the pool.
-    fn insert(&mut self, v: &[u8]) -> BytesSymbol {
-        let from = self.buffer.len();
-        self.buffer.extend(v);
-
-        BytesSymbol {
-            from: convert_to_u32(from),
-            to: convert_to_u32(self.buffer.len()),
-        }
-    }
-
-    /// Insert a string into the bytes pool.
-    ///
-    /// The returned symbol can then be used to retrieve the string from the pool.
-    fn insert_str(&mut self, v: &str) -> StringSymbol {
-        let from = self.buffer.len();
-        self.buffer.extend(v.as_bytes());
-
-        StringSymbol {
-            from: convert_to_u32(from),
-            to: convert_to_u32(self.buffer.len()),
-        }
-    }
-
     /// Get a byte string from the pool
     pub(crate) fn get(&self, symbol: BytesSymbol) -> &[u8] {
         let (from, to) = (symbol.from as usize, symbol.to as usize);
 
-        &self.buffer[from..to]
+        &self.pool[from..to]
     }
 
     /// Get a string from the pool
@@ -86,9 +60,9 @@ impl BytesPool {
         // Safety:
         // - A StringSymbol can only be constructed from `insert_str`
         // - Once a symbol is created, it is guaranteed that the indexes in the symbol
-        //   will always refer to the same bytes (the buffer can only grow).
+        //   will always refer to the same bytes (the pool can only grow).
         // It is thus safe to rebuild the string from the stored bytes.
-        unsafe { std::str::from_utf8_unchecked(&self.buffer[from..to]) }
+        unsafe { std::str::from_utf8_unchecked(&self.pool[from..to]) }
     }
 }
 
@@ -110,7 +84,7 @@ fn convert_to_u32(v: usize) -> u32 {
 #[derive(Default, Debug)]
 pub(crate) struct BytesPoolBuilder {
     /// The pool being constructed.
-    pool: BytesPool,
+    buffer: Vec<u8>,
     /// Map of bytes symbols already added in the pool.
     bytes_map: HashMap<Vec<u8>, BytesSymbol>,
     /// Map of string symbols already added in the pool.
@@ -125,13 +99,21 @@ pub(crate) struct BytesPoolBuilder {
 impl BytesPoolBuilder {
     /// Insert bytes into the bytes pool.
     ///
+    /// The returned symbol can then be used to retrieve those bytes from the pool.
     /// If the byte string was already added, the existing symbol will be returned.
     pub(crate) fn insert(&mut self, v: &[u8]) -> BytesSymbol {
         match self.bytes_map.get(v) {
             Some(v) => *v,
             None => {
-                let symbol = self.pool.insert(v);
+                let from = self.buffer.len();
+                self.buffer.extend(v);
+                let symbol = BytesSymbol {
+                    from: convert_to_u32(from),
+                    to: convert_to_u32(self.buffer.len()),
+                };
+
                 let _r = self.bytes_map.insert(v.to_vec(), symbol);
+
                 symbol
             }
         }
@@ -139,29 +121,39 @@ impl BytesPoolBuilder {
 
     /// Insert a string into the bytes pool.
     ///
+    /// The returned symbol can then be used to retrieve the string from the pool.
     /// If the string was already added, the existing symbol will be returned.
     pub(crate) fn insert_str(&mut self, v: &str) -> StringSymbol {
         match self.str_map.get(v) {
             Some(v) => *v,
             None => {
-                let symbol = self.pool.insert_str(v);
+                let from = self.buffer.len();
+                self.buffer.extend(v.as_bytes());
+
+                let symbol = StringSymbol {
+                    from: convert_to_u32(from),
+                    to: convert_to_u32(self.buffer.len()),
+                };
+
                 let _r = self.str_map.insert(v.to_owned(), symbol);
+
                 symbol
             }
         }
     }
 
     /// Build the final bytes pool object.
-    pub(crate) fn into_pool(mut self) -> BytesPool {
-        self.pool.buffer.shrink_to_fit();
-        self.pool
+    pub(crate) fn into_pool(self) -> BytesPool {
+        BytesPool {
+            pool: self.buffer.into_boxed_slice(),
+        }
     }
 
     /// Is the pool full.
     pub(crate) fn is_full(&self) -> bool {
         let limit = self.limit.unwrap_or(u32::MAX as usize);
 
-        self.pool.buffer.len() >= limit
+        self.buffer.len() >= limit
     }
 }
 
@@ -175,14 +167,16 @@ mod wire {
 
     impl Serialize for BytesPool {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
-            self.buffer.serialize(writer)
+            self.pool.serialize(writer)
         }
     }
 
     impl Deserialize for BytesPool {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+            let pool = <Vec<u8>>::deserialize_reader(reader)?;
+
             Ok(Self {
-                buffer: <Vec<u8>>::deserialize_reader(reader)?,
+                pool: pool.into_boxed_slice(),
             })
         }
     }
@@ -228,11 +222,11 @@ mod wire {
         fn test_wire_bytes_pool() {
             test_round_trip(
                 &BytesPool {
-                    buffer: b"abcedf".to_vec(),
+                    pool: b"abcedf".to_vec().into_boxed_slice(),
                 },
                 &[2, 6],
             );
-            test_round_trip(&BytesPool { buffer: Vec::new() }, &[2]);
+            test_round_trip(&BytesPool { pool: Box::new([]) }, &[2]);
 
             test_round_trip(&StringSymbol { from: 23, to: 2 }, &[0, 4]);
             test_round_trip(&BytesSymbol { from: 3, to: 8 }, &[0, 4]);

--- a/boreal/src/compiler/error.rs
+++ b/boreal/src/compiler/error.rs
@@ -270,6 +270,13 @@ pub enum CompilationError {
         limit: usize,
     },
 
+    /// The bytes pool is full and cannot contain more data.
+    ///
+    /// This error can happen when too many strings are being compiled.
+    /// Given the limit is 4GB, this shouldn't really happen in standard
+    /// usage.
+    BytesPoolFull,
+
     /// A bytes value is used as a boolean expression.
     ///
     /// This is a warning and not an error.
@@ -467,6 +474,10 @@ impl CompilationError {
             Self::TooManyStrings { span, limit } => Diagnostic::error()
                 .with_message(format!("the rule contains more than {limit} strings"))
                 .with_labels(vec![Label::primary((), span.clone())]),
+
+            Self::BytesPoolFull => {
+                Diagnostic::error().with_message("too much data added, bytes pool is full")
+            }
 
             Self::ImplicitBytesToBooleanCast { span } => Diagnostic::warning()
                 .with_message("implicit cast from a bytes value to a boolean")

--- a/boreal/src/compiler/rule.rs
+++ b/boreal/src/compiler/rule.rs
@@ -358,7 +358,7 @@ pub(super) fn compile_rule(
         matchers.push(matcher);
     }
 
-    Ok(CompiledRule {
+    let compiled_rule = CompiledRule {
         rule: Rule {
             name: rule.name.into_boxed_str(),
             namespace_index,
@@ -378,7 +378,19 @@ pub(super) fn compile_rule(
         warnings: compiler.warnings,
         rule_wildcard_uses: compiler.rule_wildcard_uses,
         rules_depended_upon: compiler.rules_depended_upon,
-    })
+    };
+
+    // Compilation adds data to an intern pool to reduce memory usage.
+    // Addressing into this pool uses u32 values, which means the pool
+    // must not grow larger than 4GB or the addressing becomes invalid.
+    //
+    // This is highly unlikely unless specially crafted to reach it.
+    // Regardless, this situation is detected here.
+    if compiler.bytes_pool.is_full() {
+        return Err(CompilationError::BytesPoolFull);
+    }
+
+    Ok(compiled_rule)
 }
 
 #[derive(Debug)]
@@ -553,7 +565,7 @@ mod wire {
                     name: pool.insert_str("ab"),
                     value: MetadataValue::Boolean(true),
                 },
-                &[0, 16],
+                &[0, 8],
             );
 
             test_invalid_deserialization::<MetadataValue>(b"\x05");
@@ -580,7 +592,7 @@ mod wire {
                     is_private: true,
                     has_xor_modifier: false,
                 },
-                &[0, 16, 17],
+                &[0, 8, 9],
             );
         }
     }

--- a/boreal/src/compiler/tests.rs
+++ b/boreal/src/compiler/tests.rs
@@ -270,6 +270,24 @@ fn test_compilation_variables() {
 }
 
 #[test]
+fn test_bytes_pool_limit() {
+    let mut compiler = Compiler::new();
+    compiler.bytes_pool.limit = Some(5);
+
+    let _r = compiler
+        .add_rules_str("rule a { strings: $foo = /a/ condition: $foo }")
+        .unwrap();
+    let err = compiler
+        .add_rules_str("rule b { strings: $bar = /a/ condition: $bar }")
+        .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "error: too much data added, bytes pool is full"
+    );
+}
+
+#[test]
 fn test_types_traits() {
     test_type_traits_non_clonable(Compiler::new());
     test_type_traits_non_clonable(Namespace::default());


### PR DESCRIPTION
Use u32 instead of usize, reducing the symbol objects from 16 bytes to 8, reducing memory usage of compiled rules.

This brings a potential situation of reaching this limit, not necessarily on real world use-cases (that would mean the compiled rules take at least 4GB of ram), but on adversarial use of the library. There is thus a new error detecting when the bytes pool reaches this limit.