### PR TITLE
Move dfa cache in scan data

### DIFF
--- a/boreal/src/matcher/mod.rs
+++ b/boreal/src/matcher/mod.rs
@@ -1,7 +1,10 @@
-use std::{collections::HashSet, ops::Range};
+use std::collections::{HashMap, HashSet, hash_map};
+use std::ops::Range;
 
 use boreal_parser::rule::VariableModifiers;
+use regex_automata::hybrid::dfa;
 
+use crate::matcher::validator::dfa::DfaValidator;
 use crate::regex::Hir;
 
 mod analysis;
@@ -107,6 +110,25 @@ enum MatcherKind {
 
     /// The regex cannot confirm matches from AC literal matches.
     Raw(raw::RawMatcher),
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ValidatorCaches {
+    caches: HashMap<(usize, bool), dfa::Cache>,
+}
+
+impl ValidatorCaches {
+    fn get_or_insert(
+        &mut self,
+        index: usize,
+        reverse: bool,
+        validator: &DfaValidator,
+    ) -> &mut dfa::Cache {
+        match self.caches.entry((index, reverse)) {
+            hash_map::Entry::Occupied(o) => o.into_mut(),
+            hash_map::Entry::Vacant(v) => v.insert(validator.build_cache()),
+        }
+    }
 }
 
 impl Matcher {
@@ -316,6 +338,8 @@ impl Matcher {
         mat: Range<usize>,
         start_position: usize,
         match_type: MatchType,
+        matcher_index: usize,
+        caches: &mut ValidatorCaches,
     ) -> AcMatchStatus {
         match &self.kind {
             MatcherKind::Literals => {
@@ -326,7 +350,14 @@ impl Matcher {
                 }
             }
             MatcherKind::Atomized(validator) => {
-                match validator.validate_match(mem, mat, start_position, match_type) {
+                match validator.validate_match(
+                    mem,
+                    mat,
+                    start_position,
+                    match_type,
+                    matcher_index,
+                    caches,
+                ) {
                     Matches::None => AcMatchStatus::None,
                     Matches::Single(m) => {
                         if self.validate_fullword(mem, &m, match_type) {
@@ -663,5 +694,6 @@ mod tests {
         test_type_traits(MatchType::Ascii);
         test_type_traits_non_clonable(Matches::None);
         test_type_traits(AcMatchStatus::None);
+        test_type_traits_non_clonable(ValidatorCaches::default());
     }
 }

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -1,11 +1,12 @@
 use std::ops::Range;
 
+use crate::matcher::ValidatorCaches;
 use crate::regex::Hir;
 
 use super::analysis::{HirAnalysis, analyze_hir};
 use super::{MatchType, Matches, Modifiers};
 
-mod dfa;
+pub(crate) mod dfa;
 mod simple;
 
 // Maximum length against which a regex validator of a AC literal match will be run.
@@ -74,12 +75,25 @@ impl Validator {
         mat: Range<usize>,
         start_position: usize,
         match_type: MatchType,
+        matcher_index: usize,
+        caches: &mut ValidatorCaches,
     ) -> Matches {
         let end = match &self.forward {
             Some(validator) => {
                 let end =
                     std::cmp::min(mem.len(), mat.start.saturating_add(MAX_SPLIT_MATCH_LENGTH));
-                match validator.find_anchored_fwd(mem, mat.start, end, match_type) {
+
+                let res = match validator {
+                    HalfValidator::Simple(validator) => {
+                        validator.find_anchored_fwd(mem, mat.start, end)
+                    }
+                    HalfValidator::Dfa(validator) => {
+                        let cache = caches.get_or_insert(matcher_index, false, validator);
+                        validator.find_anchored_fwd(mem, mat.start, end, match_type, cache)
+                    }
+                };
+
+                match res {
                     Some(end) => end,
                     None => return Matches::None,
                 }
@@ -98,13 +112,30 @@ impl Validator {
                     start_position,
                     mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                 );
-                while let Some(s) = validator.find_anchored_rev(mem, start, mat.end, match_type) {
-                    matches.push(s..end);
-                    start = s + 1;
-                    if start > mat.end {
-                        break;
+
+                loop {
+                    let next = match validator {
+                        HalfValidator::Simple(validator) => {
+                            validator.find_anchored_rev(mem, start, mat.end)
+                        }
+                        HalfValidator::Dfa(validator) => {
+                            let cache = caches.get_or_insert(matcher_index, true, validator);
+                            validator.find_anchored_rev(mem, start, mat.end, match_type, cache)
+                        }
+                    };
+
+                    match next {
+                        Some(s) => {
+                            matches.push(s..end);
+                            start = s + 1;
+                            if start > mat.end {
+                                break;
+                            }
+                        }
+                        None => break,
                     }
                 }
+
                 Matches::Multiple(matches)
             }
         }
@@ -151,32 +182,6 @@ impl HalfValidator {
             None => Ok(Self::Dfa(dfa::DfaValidator::new(
                 hir, analysis, modifiers, reverse,
             )?)),
-        }
-    }
-
-    fn find_anchored_fwd(
-        &self,
-        haystack: &[u8],
-        start: usize,
-        end: usize,
-        match_type: MatchType,
-    ) -> Option<usize> {
-        match self {
-            Self::Simple(validator) => validator.find_anchored_fwd(haystack, start, end),
-            Self::Dfa(validator) => validator.find_anchored_fwd(haystack, start, end, match_type),
-        }
-    }
-
-    fn find_anchored_rev(
-        &self,
-        haystack: &[u8],
-        start: usize,
-        end: usize,
-        match_type: MatchType,
-    ) -> Option<usize> {
-        match self {
-            Self::Simple(validator) => validator.find_anchored_rev(haystack, start, end),
-            Self::Dfa(validator) => validator.find_anchored_rev(haystack, start, end, match_type),
         }
     }
 }

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -167,7 +167,7 @@ pub(super) enum HalfValidator {
     // Simplified validator for very simple regex expressions.
     Simple(simple::SimpleValidator),
     // Dfa validator, handling all the complex cases
-    Dfa(dfa::DfaValidator),
+    Dfa(Box<dfa::DfaValidator>),
 }
 
 impl HalfValidator {
@@ -179,9 +179,9 @@ impl HalfValidator {
     ) -> Result<Self, crate::regex::Error> {
         match simple::SimpleValidator::new(hir, analysis, modifiers, reverse) {
             Some(v) => Ok(Self::Simple(v)),
-            None => Ok(Self::Dfa(dfa::DfaValidator::new(
+            None => Ok(Self::Dfa(Box::new(dfa::DfaValidator::new(
                 hir, analysis, modifiers, reverse,
-            )?)),
+            )?))),
         }
     }
 }
@@ -267,7 +267,7 @@ mod wire {
             )?)),
             1 => {
                 let dfa = dfa::DfaValidator::deserialize(modifiers, reverse, reader)?;
-                Ok(HalfValidator::Dfa(dfa))
+                Ok(HalfValidator::Dfa(Box::new(dfa)))
             }
             v => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -334,7 +334,9 @@ mod wire {
                 &[0, 1],
             );
             test_round_trip_custom_deser(
-                &HalfValidator::Dfa(DfaValidator::new(&hir, &analysis, modifiers, false).unwrap()),
+                &HalfValidator::Dfa(Box::new(
+                    DfaValidator::new(&hir, &analysis, modifiers, false).unwrap(),
+                )),
                 |reader| deserialize_half_validator(modifiers, false, reader),
                 &[0, 1],
             );

--- a/boreal/src/matcher/validator.rs
+++ b/boreal/src/matcher/validator.rs
@@ -113,26 +113,19 @@ impl Validator {
                     mat.end.saturating_sub(MAX_SPLIT_MATCH_LENGTH),
                 );
 
-                loop {
-                    let next = match validator {
-                        HalfValidator::Simple(validator) => {
-                            validator.find_anchored_rev(mem, start, mat.end)
-                        }
-                        HalfValidator::Dfa(validator) => {
-                            let cache = caches.get_or_insert(matcher_index, true, validator);
-                            validator.find_anchored_rev(mem, start, mat.end, match_type, cache)
-                        }
-                    };
+                let mut iterator = match validator {
+                    HalfValidator::Simple(s) => ReverseMatchesIterator::Simple(s),
+                    HalfValidator::Dfa(validator) => {
+                        let cache = caches.get_or_insert(matcher_index, true, validator);
+                        ReverseMatchesIterator::Dfa(validator, cache)
+                    }
+                };
 
-                    match next {
-                        Some(s) => {
-                            matches.push(s..end);
-                            start = s + 1;
-                            if start > mat.end {
-                                break;
-                            }
-                        }
-                        None => break,
+                while let Some(s) = iterator.find_next(mem, start, mat.end, match_type) {
+                    matches.push(s..end);
+                    start = s + 1;
+                    if start > mat.end {
+                        break;
                     }
                 }
 
@@ -191,6 +184,26 @@ impl std::fmt::Display for HalfValidator {
         match self {
             Self::Simple(_) => write!(f, "Simple"),
             Self::Dfa(_) => write!(f, "Dfa"),
+        }
+    }
+}
+
+enum ReverseMatchesIterator<'a> {
+    Simple(&'a simple::SimpleValidator),
+    Dfa(&'a dfa::DfaValidator, &'a mut dfa::Cache),
+}
+
+impl ReverseMatchesIterator<'_> {
+    fn find_next(
+        &mut self,
+        haystack: &[u8],
+        start: usize,
+        end: usize,
+        match_type: MatchType,
+    ) -> Option<usize> {
+        match self {
+            Self::Simple(s) => s.find_anchored_rev(haystack, start, end),
+            Self::Dfa(dfa, cache) => dfa.find_anchored_rev(haystack, start, end, match_type, cache),
         }
     }
 }

--- a/boreal/src/matcher/validator/dfa.rs
+++ b/boreal/src/matcher/validator/dfa.rs
@@ -1,7 +1,9 @@
-use regex_automata::hybrid::dfa::{Builder, Cache, DFA};
+use regex_automata::hybrid::dfa::{Builder, DFA};
 use regex_automata::nfa::thompson;
 use regex_automata::util::syntax;
 use regex_automata::{Anchored, Input, MatchKind, PatternID};
+
+pub use regex_automata::hybrid::dfa::Cache;
 
 use crate::matcher::analysis::HirAnalysis;
 use crate::matcher::widener::widen_hir;

--- a/boreal/src/matcher/validator/dfa.rs
+++ b/boreal/src/matcher/validator/dfa.rs
@@ -1,9 +1,5 @@
-use std::panic::{RefUnwindSafe, UnwindSafe};
-use std::sync::Arc;
-
 use regex_automata::hybrid::dfa::{Builder, Cache, DFA};
 use regex_automata::nfa::thompson;
-use regex_automata::util::pool::Pool;
 use regex_automata::util::syntax;
 use regex_automata::{Anchored, Input, MatchKind, PatternID};
 
@@ -12,16 +8,10 @@ use crate::matcher::widener::widen_hir;
 use crate::matcher::{MatchType, Modifiers};
 use crate::regex::{Hir, regex_hir_to_string};
 
-type PoolCreateFn = Box<dyn Fn() -> Cache + Send + Sync + UnwindSafe + RefUnwindSafe>;
-
 #[derive(Debug)]
 pub(crate) struct DfaValidator {
     /// Anchored lazy DFA, used to validate an AC match.
-    dfa: Arc<DFA>,
-    // TODO: Taking the cache out of the pool when starting scanning (and putting them in the scan
-    // data) would avoid the get/drop on every validation, and only do it once per scan.
-    // Not sure how much improvements this would be, to test.
-    pool: Pool<Cache, PoolCreateFn>,
+    dfa: DFA,
 
     /// Use the custom wide routine to validate wide matches.
     ///
@@ -74,16 +64,10 @@ impl DfaValidator {
         } else {
             (regex_hir_to_string(hir), String::new())
         };
-        let dfa = Arc::new(build_dfa(&expr1, &expr2, modifiers, reverse)?);
-        let pool = {
-            let dfa = Arc::clone(&dfa);
-            let create: PoolCreateFn = Box::new(move || dfa.create_cache());
-            Pool::new(create)
-        };
+        let dfa = build_dfa(&expr1, &expr2, modifiers, reverse)?;
 
         Ok(Self {
             dfa,
-            pool,
             use_custom_wide_runner,
             #[cfg(feature = "serialize")]
             exprs: [expr1.into_boxed_str(), expr2.into_boxed_str()],
@@ -99,22 +83,25 @@ impl DfaValidator {
         wire::deserialize_dfa_validator(modifiers, reverse, reader)
     }
 
+    pub(crate) fn build_cache(&self) -> Cache {
+        self.dfa.create_cache()
+    }
+
     pub(crate) fn find_anchored_fwd(
         &self,
         haystack: &[u8],
         start: usize,
         end: usize,
         match_type: MatchType,
+        cache: &mut Cache,
     ) -> Option<usize> {
-        let mut cache = self.pool.get();
-
         if self.use_custom_wide_runner && match_type.is_wide() {
-            self.find_wide_anchored_fwd(&mut cache, haystack, start, end)
+            self.find_wide_anchored_fwd(cache, haystack, start, end)
         } else {
             let pattern_index = match_type_to_pattern_index(match_type);
             self.dfa
                 .try_search_fwd(
-                    &mut cache,
+                    cache,
                     &Input::new(haystack)
                         .span(start..end)
                         .anchored(Anchored::Pattern(pattern_index)),
@@ -131,16 +118,15 @@ impl DfaValidator {
         start: usize,
         end: usize,
         match_type: MatchType,
+        cache: &mut Cache,
     ) -> Option<usize> {
-        let mut cache = self.pool.get();
-
         if self.use_custom_wide_runner && match_type.is_wide() {
-            self.find_wide_anchored_rev(&mut cache, haystack, start, end)
+            self.find_wide_anchored_rev(cache, haystack, start, end)
         } else {
             let pattern_index = match_type_to_pattern_index(match_type);
             self.dfa
                 .try_search_rev(
-                    &mut cache,
+                    cache,
                     &Input::new(haystack)
                         .span(start..end)
                         .anchored(Anchored::Pattern(pattern_index)),
@@ -328,14 +314,13 @@ fn build_dfa(
 
 #[cfg(feature = "serialize")]
 mod wire {
-    use std::{io, sync::Arc};
+    use std::io;
 
     use crate::wire::{Deserialize, Serialize};
-    use regex_automata::util::pool::Pool;
 
     use crate::matcher::Modifiers;
 
-    use super::{DfaValidator, PoolCreateFn, build_dfa};
+    use super::{DfaValidator, build_dfa};
 
     impl Serialize for DfaValidator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
@@ -355,26 +340,18 @@ mod wire {
         let expr2 = String::deserialize_reader(reader)?;
         let use_custom_wide_runner = bool::deserialize_reader(reader)?;
 
-        let dfa = Arc::new(
-            build_dfa(&expr1, &expr2, modifiers, reverse).map_err(|err| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!(
-                        "unable to compile dfa with expressions \
+        let dfa = build_dfa(&expr1, &expr2, modifiers, reverse).map_err(|err| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unable to compile dfa with expressions \
                             `{expr1}`, `{expr2}`: {err:?}",
-                    ),
-                )
-            })?,
-        );
-        let pool = {
-            let dfa = Arc::clone(&dfa);
-            let create: PoolCreateFn = Box::new(move || dfa.create_cache());
-            Pool::new(create)
-        };
+                ),
+            )
+        })?;
 
         Ok(DfaValidator {
             dfa,
-            pool,
             use_custom_wide_runner,
             exprs: [expr1.into_boxed_str(), expr2.into_boxed_str()],
         })
@@ -424,10 +401,10 @@ mod tests {
 
     #[test]
     fn test_find_wide_anchored_fwd() {
-        fn build(expr: &str, ascii: bool) -> DfaValidator {
+        fn build(expr: &str, ascii: bool) -> (DfaValidator, Cache) {
             let hir = expr_to_hir(expr);
             let analysis = analyze_hir(&hir, false);
-            DfaValidator::new(
+            let validator = DfaValidator::new(
                 &hir,
                 &analysis,
                 Modifiers {
@@ -437,105 +414,119 @@ mod tests {
                 },
                 false,
             )
-            .unwrap()
+            .unwrap();
+            let cache = validator.build_cache();
+            (validator, cache)
         }
 
-        let validator = build(r"a\b", false);
+        let (validator, mut cache) = build(r"a\b", false);
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0.\0a\0.\0", 0, 10, MatchType::WideStandard),
+            validator.find_anchored_fwd(
+                b"a\0b\0.\0a\0.\0",
+                0,
+                10,
+                MatchType::WideStandard,
+                &mut cache
+            ),
             None
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0.\0a\0.\0", 6, 10, MatchType::WideStandard),
+            validator.find_anchored_fwd(
+                b"a\0b\0.\0a\0.\0",
+                6,
+                10,
+                MatchType::WideStandard,
+                &mut cache
+            ),
             Some(8)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard, &mut cache),
             Some(2)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0bb", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0bb", 0, 4, MatchType::WideStandard, &mut cache),
             Some(2)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b", 0, 3, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0b", 0, 3, MatchType::WideStandard, &mut cache),
             Some(2)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"aa\0", 0, 3, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"aa\0", 0, 3, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"aa\0", 1, 3, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"aa\0", 1, 3, MatchType::WideStandard, &mut cache),
             Some(3)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0.\0", 4, 4, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0b\0.\0", 4, 4, MatchType::WideStandard, &mut cache),
             None
         );
 
-        let validator = build(r"\bb", false);
+        let (validator, mut cache) = build(r"\bb", false);
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"b\0b\0", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"b\0b\0", 0, 4, MatchType::WideStandard, &mut cache),
             Some(2),
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"b\0b", 0, 3, MatchType::WideStandard),
-            Some(2),
+            validator.find_anchored_fwd(b"b\0b", 0, 3, MatchType::WideStandard, &mut cache),
+            Some(2)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"b\0b\0", 2, 4, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"b\0b\0", 2, 4, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_fwd(b".\0b\0", 2, 4, MatchType::WideStandard),
-            Some(4),
+            validator.find_anchored_fwd(b".\0b\0", 2, 4, MatchType::WideStandard, &mut cache),
+            Some(4)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"\0b\0", 1, 3, MatchType::WideStandard),
-            Some(3),
+            validator.find_anchored_fwd(b"\0b\0", 1, 3, MatchType::WideStandard, &mut cache),
+            Some(3)
         );
 
         // Ensure the validator does not confuse ascii and wide
-        let validator = build(r"a\x00b\b", true);
+        let (validator, mut cache) = build(r"a\x00b\b", true);
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b", 0, 3, MatchType::Ascii),
+            validator.find_anchored_fwd(b"a\0b", 0, 3, MatchType::Ascii, &mut cache),
             Some(3)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::Ascii),
+            validator.find_anchored_fwd(b"a\0b\0", 0, 4, MatchType::Ascii, &mut cache),
             Some(3)
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0b\0b\0", 0, 6, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0b\0b\0", 0, 6, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0\0\0b\0", 0, 6, MatchType::WideStandard),
-            Some(6),
+            validator.find_anchored_fwd(b"a\0\0\0b\0", 0, 6, MatchType::WideStandard, &mut cache),
+            Some(6)
         );
 
-        let validator = build(r"\b", false);
+        let (validator, mut cache) = build(r"\b", false);
         assert_eq!(
-            validator.find_anchored_fwd(b"", 0, 0, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"", 0, 0, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_fwd(b"a\0", 0, 2, MatchType::WideStandard, &mut cache),
             Some(0),
         );
     }
 
     #[test]
     fn test_find_wide_anchored_rev() {
-        fn build(expr: &str, ascii: bool) -> DfaValidator {
+        fn build(expr: &str, ascii: bool) -> (DfaValidator, Cache) {
             let hir = expr_to_hir(expr);
             let analysis = analyze_hir(&hir, false);
-            DfaValidator::new(
+            let validator = DfaValidator::new(
                 &hir,
                 &analysis,
                 Modifiers {
@@ -545,78 +536,98 @@ mod tests {
                 },
                 true,
             )
-            .unwrap()
+            .unwrap();
+            let cache = validator.build_cache();
+            (validator, cache)
         }
 
-        let validator = build(r"a\b", false);
+        let (validator, mut cache) = build(r"a\b", false);
         assert_eq!(
-            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 10, MatchType::WideStandard),
+            validator.find_anchored_rev(
+                b"a\0b\0.\0a\0.\0",
+                0,
+                10,
+                MatchType::WideStandard,
+                &mut cache
+            ),
             None
         );
         assert_eq!(
-            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 9, MatchType::WideStandard),
+            validator.find_anchored_rev(
+                b"a\0b\0.\0a\0.\0",
+                0,
+                9,
+                MatchType::WideStandard,
+                &mut cache
+            ),
             None
         );
         assert_eq!(
-            validator.find_anchored_rev(b"a\0b\0.\0a\0.\0", 0, 8, MatchType::WideStandard),
+            validator.find_anchored_rev(
+                b"a\0b\0.\0a\0.\0",
+                0,
+                8,
+                MatchType::WideStandard,
+                &mut cache
+            ),
             Some(6)
         );
         assert_eq!(
-            validator.find_anchored_rev(b"a\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_rev(b"a\0", 0, 2, MatchType::WideStandard, &mut cache),
             Some(0)
         );
         assert_eq!(
-            validator.find_anchored_rev(b"aa\0", 0, 3, MatchType::WideStandard),
+            validator.find_anchored_rev(b"aa\0", 0, 3, MatchType::WideStandard, &mut cache),
             Some(1),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"\0a\0", 0, 3, MatchType::WideStandard),
+            validator.find_anchored_rev(b"\0a\0", 0, 3, MatchType::WideStandard, &mut cache),
             Some(1),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"aa\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_rev(b"aa\0", 0, 2, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_rev(b"aa\0", 0, 1, MatchType::WideStandard),
+            validator.find_anchored_rev(b"aa\0", 0, 1, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_rev(b"", 0, 0, MatchType::WideStandard),
+            validator.find_anchored_rev(b"", 0, 0, MatchType::WideStandard, &mut cache),
             None,
         );
 
-        let validator = build(r"\bb", false);
+        let (validator, mut cache) = build(r"\bb", false);
         assert_eq!(
-            validator.find_anchored_rev(b"a\0b\0", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_rev(b"a\0b\0", 0, 4, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_rev(b".\0b\0", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_rev(b".\0b\0", 0, 4, MatchType::WideStandard, &mut cache),
             Some(2),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"b\0b\0", 0, 4, MatchType::WideStandard),
+            validator.find_anchored_rev(b"b\0b\0", 0, 4, MatchType::WideStandard, &mut cache),
             None,
         );
         assert_eq!(
-            validator.find_anchored_rev(b"b\0b\0", 2, 4, MatchType::WideStandard),
+            validator.find_anchored_rev(b"b\0b\0", 2, 4, MatchType::WideStandard, &mut cache),
             Some(2),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"b\0b\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_rev(b"b\0b\0", 0, 2, MatchType::WideStandard, &mut cache),
             Some(0),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"\0b\0", 0, 3, MatchType::WideStandard),
+            validator.find_anchored_rev(b"\0b\0", 0, 3, MatchType::WideStandard, &mut cache),
             Some(1),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"b\0", 0, 2, MatchType::WideStandard),
+            validator.find_anchored_rev(b"b\0", 0, 2, MatchType::WideStandard, &mut cache),
             Some(0),
         );
         assert_eq!(
-            validator.find_anchored_rev(b"b", 0, 1, MatchType::WideStandard),
+            validator.find_anchored_rev(b"b", 0, 1, MatchType::WideStandard, &mut cache),
             None,
         );
     }

--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -255,7 +255,14 @@ impl AcScan {
                 }
             }
 
-            let res = matcher.process_ac_match(region.mem, m, start_position, match_type);
+            let res = matcher.process_ac_match(
+                region.mem,
+                m,
+                start_position,
+                match_type,
+                matcher_index,
+                &mut scan_data.validator_caches,
+            );
 
             #[cfg(feature = "profiling")]
             {

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -7,7 +7,7 @@ use crate::bytes_pool::{BytesPool, BytesSymbol, StringSymbol};
 use crate::compiler::external_symbol::{ExternalSymbol, ExternalValue};
 use crate::compiler::rule::Rule;
 use crate::evaluator::{self, EvalError, MatchedDependencyRules, evaluate_rule};
-use crate::matcher::Matcher;
+use crate::matcher::{Matcher, ValidatorCaches};
 use crate::memory::{FragmentedMemory, Memory, Region};
 use crate::module::{Module, ModuleData, ModuleUserData};
 use crate::timeout::TimeoutChecker;
@@ -830,6 +830,7 @@ impl Inner {
             entrypoint: None,
             callback: None,
             string_reached_match_limit: HashSet::new(),
+            validator_caches: ValidatorCaches::default(),
         };
 
         let res = self.do_scan(mem, &mut scan_data);
@@ -870,6 +871,7 @@ impl Inner {
             entrypoint: None,
             callback: Some(callback),
             string_reached_match_limit: HashSet::new(),
+            validator_caches: ValidatorCaches::default(),
         };
 
         let res = self.do_scan(mem, &mut scan_data);
@@ -1298,6 +1300,9 @@ pub(crate) struct ScanData<'scanner, 'cb> {
     /// Only used if the callback is set and the relevant scan event is
     /// enabled.
     pub string_reached_match_limit: HashSet<usize>,
+
+    /// Caches used by validators.
+    pub(crate) validator_caches: ValidatorCaches,
 }
 
 impl std::fmt::Debug for ScanData<'_, '_> {
@@ -1985,6 +1990,7 @@ mod tests {
             entrypoint: None,
             callback: None,
             string_reached_match_limit: HashSet::new(),
+            validator_caches: ValidatorCaches::default(),
         };
         let mut matched_dependency_rules = MatchedDependencyRules::default();
         let rules = &scanner.inner.rules;
@@ -2543,6 +2549,7 @@ mod tests {
             process_memory: false,
             callback: Some(Box::new(|_evt| ScanCallbackResult::Continue)),
             string_reached_match_limit: HashSet::new(),
+            validator_caches: ValidatorCaches::default(),
         });
         test_type_traits_non_clonable(RulesIter {
             global_rules: [].iter(),


### PR DESCRIPTION
Instead of storing the DFA caches in the matchers in a thread local pool, store them in the ScanData, forcing recreation on new scan, and drop at the end.

This replaces caches that could only grow, with versions per thread, with temporary memory that is
released after the scan ends. Performance wise, it is unclear how much this has an impact. The cache is no longer shared between scans, but scans may not need the same caching. Redoing some benchmarks would be useful.