### PR TITLE
Handle hex strings jumps in simple validator

### DIFF
--- a/boreal/src/matcher/analysis.rs
+++ b/boreal/src/matcher/analysis.rs
@@ -6,9 +6,6 @@ pub struct HirAnalysis {
     // Contains start or end line assertions.
     pub has_start_or_end_line: bool,
 
-    // Contains repetitions.
-    pub has_repetitions: bool,
-
     // Contains greedy repetitions.
     pub has_greedy_repetitions: bool,
 
@@ -34,7 +31,6 @@ pub fn analyze_hir(hir: &Hir, dot_all: bool) -> HirAnalysis {
             dot_all,
 
             has_start_or_end_line: false,
-            has_repetitions: false,
             has_greedy_repetitions: false,
             has_word_boundaries: false,
             has_classes: false,
@@ -53,7 +49,6 @@ struct HirAnalyser {
     dot_all: bool,
 
     has_start_or_end_line: bool,
-    has_repetitions: bool,
     has_greedy_repetitions: bool,
     has_word_boundaries: bool,
     has_classes: bool,
@@ -100,7 +95,6 @@ impl Visitor for HirAnalyser {
                 self.nb_alt_literals = None;
             }
             Hir::Repetition { greedy, .. } => {
-                self.has_repetitions = true;
                 if *greedy {
                     self.has_greedy_repetitions = true;
                 }
@@ -168,7 +162,6 @@ impl Visitor for HirAnalyser {
     fn finish(self) -> Self::Output {
         HirAnalysis {
             has_start_or_end_line: self.has_start_or_end_line,
-            has_repetitions: self.has_repetitions,
             has_greedy_repetitions: self.has_greedy_repetitions,
             has_word_boundaries: self.has_word_boundaries,
             has_classes: self.has_classes,
@@ -263,7 +256,6 @@ mod tests {
     fn test_flags() {
         let res = analyze_expr("^a32+", false);
         assert!(res.has_start_or_end_line);
-        assert!(res.has_repetitions);
         assert!(res.has_greedy_repetitions);
         assert!(!res.has_word_boundaries);
         assert!(!res.has_classes);
@@ -271,7 +263,6 @@ mod tests {
 
         let res = analyze_expr(r"\b[Ww]o(r|R)d\b", false);
         assert!(!res.has_start_or_end_line);
-        assert!(!res.has_repetitions);
         assert!(!res.has_greedy_repetitions);
         assert!(res.has_word_boundaries);
         assert!(res.has_classes);
@@ -279,7 +270,6 @@ mod tests {
 
         let res = analyze_expr(r"{ 51 [-3] ( ?A ?? AF | FA ) }", false);
         assert!(!res.has_start_or_end_line);
-        assert!(res.has_repetitions);
         assert!(!res.has_greedy_repetitions);
         assert!(!res.has_word_boundaries);
         assert!(!res.has_classes);
@@ -287,7 +277,6 @@ mod tests {
 
         let res = analyze_expr(r"\Ba{1,3}?$", false);
         assert!(res.has_start_or_end_line);
-        assert!(res.has_repetitions);
         assert!(!res.has_greedy_repetitions);
         assert!(res.has_word_boundaries);
         assert!(!res.has_classes);

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -273,15 +273,7 @@ fn add_hir_to_simple_nodes(
         }
         Hir::Dot => {
             if modifiers.dot_all {
-                if nodes.is_empty() {
-                    nodes.push(SimpleNode::Jump(1));
-                } else {
-                    let last_index = nodes.len() - 1;
-                    match &mut nodes[last_index] {
-                        SimpleNode::Jump(v) if *v < 255 => *v += 1,
-                        _ => nodes.push(SimpleNode::Jump(1)),
-                    }
-                }
+                add_jump(nodes, 1);
             } else {
                 nodes.push(SimpleNode::Dot);
             }
@@ -301,13 +293,13 @@ fn add_hir_to_simple_nodes(
                 return false;
             }
 
-            nodes.push(match kind {
-                RepetitionKind::ZeroOrOne => SimpleNode::JumpRange(0, 1),
+            match kind {
+                RepetitionKind::ZeroOrOne => nodes.push(SimpleNode::JumpRange(0, 1)),
                 RepetitionKind::Range(RepetitionRange::Exactly(m)) => {
                     let Ok(m) = u8::try_from(*m) else {
                         return false;
                     };
-                    SimpleNode::Jump(m)
+                    add_jump(nodes, m);
                 }
                 RepetitionKind::Range(RepetitionRange::Bounded(m, n)) => {
                     let Ok(m) = u8::try_from(*m) else {
@@ -318,14 +310,30 @@ fn add_hir_to_simple_nodes(
                     };
                     // TODO: check combination of jumps across the whole
                     // hir, which can multiply and make this pathologic.
-                    SimpleNode::JumpRange(m, n)
+                    nodes.push(SimpleNode::JumpRange(m, n));
                 }
                 // Unbounded jumps are not handled
                 RepetitionKind::ZeroOrMore
                 | RepetitionKind::OneOrMore
                 | RepetitionKind::Range(RepetitionRange::AtLeast(_)) => return false,
-            });
+            }
             true
+        }
+    }
+}
+
+fn add_jump(nodes: &mut Vec<SimpleNode>, jump_length: u8) {
+    if nodes.is_empty() {
+        nodes.push(SimpleNode::Jump(jump_length));
+    } else {
+        let last_index = nodes.len() - 1;
+        if let SimpleNode::Jump(value) = &mut nodes[last_index] {
+            match value.checked_add(jump_length) {
+                Some(new_value) => *value = new_value,
+                None => nodes.push(SimpleNode::Jump(jump_length)),
+            }
+        } else {
+            nodes.push(SimpleNode::Jump(jump_length));
         }
     }
 }

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -302,7 +302,11 @@ impl SimpleValidatorBuilder {
                 }
 
                 match kind {
-                    RepetitionKind::ZeroOrOne => self.nodes.push(SimpleNode::JumpRange(0, 1)),
+                    RepetitionKind::ZeroOrOne => {
+                        if !self.add_jump_range(0, 1) {
+                            return false;
+                        }
+                    }
                     RepetitionKind::Range(RepetitionRange::Exactly(m)) => {
                         let Ok(m) = u8::try_from(*m) else {
                             return false;
@@ -317,16 +321,11 @@ impl SimpleValidatorBuilder {
                             return false;
                         };
 
-                        // Cap the combinations of jumps. This does not distinguish
-                        // many small jumps from one bit jump, the goal is simply
-                        // to have a conservative cap to avoid any complications.
-                        let comb = max.saturating_sub(min) + 1;
-                        self.combinations = self.combinations.saturating_mul(comb);
-                        if self.combinations > 64 {
+                        if min == max {
+                            self.add_jump(min);
+                        } else if !self.add_jump_range(min, max) {
                             return false;
                         }
-
-                        self.nodes.push(SimpleNode::JumpRange(min, max));
                     }
                     // Unbounded jumps are not handled
                     RepetitionKind::ZeroOrMore
@@ -352,6 +351,20 @@ impl SimpleValidatorBuilder {
                 self.nodes.push(SimpleNode::Jump(jump_length));
             }
         }
+    }
+
+    fn add_jump_range(&mut self, min: u8, max: u8) -> bool {
+        // Cap the combinations of jumps. This does not distinguish
+        // many small jumps from one bit jump, the goal is simply
+        // to have a conservative cap to avoid any complications.
+        let comb = max.saturating_sub(min) + 1;
+        self.combinations = self.combinations.saturating_mul(comb);
+        if self.combinations > 64 {
+            return false;
+        }
+
+        self.nodes.push(SimpleNode::JumpRange(min, max));
+        true
     }
 }
 
@@ -515,29 +528,30 @@ mod tests {
         SimpleValidator::new(&hir, &analysis, modifiers, reverse)
     }
 
+    #[track_caller]
+    fn test_build(
+        expr: &str,
+        modifiers: Modifiers,
+        reverse: bool,
+        expected_nodes: Option<&[SimpleNode]>,
+    ) {
+        let v = build_validator(expr, modifiers, reverse);
+        assert_eq!(v.as_ref().map(|v| &*v.nodes), expected_nodes);
+    }
+
     #[test]
     fn test_simple_validator_build() {
-        fn test(
-            expr: &str,
-            modifiers: Modifiers,
-            reverse: bool,
-            expected_nodes: Option<&[SimpleNode]>,
-        ) {
-            let v = build_validator(expr, modifiers, reverse);
-            assert_eq!(v.as_ref().map(|v| &*v.nodes), expected_nodes);
-        }
-
         // Regex contains nodes that are not handled
-        test("a?", Modifiers::default(), false, None);
-        test("a|b", Modifiers::default(), false, None);
-        test("^a", Modifiers::default(), false, None);
-        test("a$", Modifiers::default(), false, None);
-        test(r"a\b", Modifiers::default(), false, None);
-        test(r"a\B", Modifiers::default(), false, None);
-        test(r"[aA]", Modifiers::default(), false, None);
+        test_build("a?", Modifiers::default(), false, None);
+        test_build("a|b", Modifiers::default(), false, None);
+        test_build("^a", Modifiers::default(), false, None);
+        test_build("a$", Modifiers::default(), false, None);
+        test_build(r"a\b", Modifiers::default(), false, None);
+        test_build(r"a\B", Modifiers::default(), false, None);
+        test_build(r"[aA]", Modifiers::default(), false, None);
 
         // Modifiers not handled
-        test(
+        test_build(
             r"a",
             Modifiers {
                 nocase: true,
@@ -546,7 +560,7 @@ mod tests {
             false,
             None,
         );
-        test(
+        test_build(
             r"a",
             Modifiers {
                 wide: true,
@@ -556,7 +570,7 @@ mod tests {
             None,
         );
 
-        test(
+        test_build(
             "a.()d",
             Modifiers::default(),
             false,
@@ -567,7 +581,7 @@ mod tests {
             ]),
         );
 
-        test(
+        test_build(
             "a.()d",
             Modifiers::default(),
             true,
@@ -578,7 +592,7 @@ mod tests {
             ]),
         );
 
-        test(
+        test_build(
             "..a.",
             Modifiers {
                 dot_all: true,
@@ -592,7 +606,7 @@ mod tests {
             ]),
         );
 
-        test(
+        test_build(
             &".".repeat(300),
             Modifiers {
                 dot_all: true,
@@ -601,7 +615,65 @@ mod tests {
             false,
             Some(&[SimpleNode::Jump(255), SimpleNode::Jump(45)]),
         );
+    }
 
+    #[test]
+    fn test_jumps() {
+        let mods = Modifiers {
+            dot_all: true,
+            ..Default::default()
+        };
+
+        // Greedy so rejected
+        test_build(".?", mods, false, None);
+
+        test_build(
+            "..??",
+            mods,
+            false,
+            Some(&[SimpleNode::Jump(1), SimpleNode::JumpRange(0, 1)]),
+        );
+        test_build(
+            ".{2}?.{3}?a.{4}?",
+            mods,
+            false,
+            Some(&[
+                SimpleNode::Jump(5),
+                SimpleNode::Byte(b'a'),
+                SimpleNode::Jump(4),
+            ]),
+        );
+        test_build(
+            ".{100}?.{100}?.{100}?.{100}?",
+            mods,
+            false,
+            Some(&[SimpleNode::Jump(200), SimpleNode::Jump(200)]),
+        );
+
+        test_build(".{300}?", mods, false, None);
+        test_build(".{300,400}?", mods, false, None);
+        test_build(".{100,400}?", mods, false, None);
+        test_build(
+            ".{0,7}?.{5,12}?",
+            mods,
+            false,
+            Some(&[SimpleNode::JumpRange(0, 7), SimpleNode::JumpRange(5, 12)]),
+        );
+        test_build(".{0,7}?.{5,13}?", mods, false, None);
+        test_build(
+            ".{0,31}?.??",
+            mods,
+            false,
+            Some(&[SimpleNode::JumpRange(0, 31), SimpleNode::JumpRange(0, 1)]),
+        );
+        test_build(".{0,32}?.??", mods, false, None);
+
+        test_build("a{2}", mods, false, None);
+        test_build("a{2}", mods, false, None);
+    }
+
+    #[test]
+    fn test_simple_validator_reject() {
         let mut builder = SimpleValidatorBuilder {
             nodes: Vec::new(),
             dot_all: false,

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -1,9 +1,10 @@
 //! Validator able to handle "simple" expressions.
 //!
-//! "Simple" expression means any expression that do not require branching or complex logic.
-//! Basically, any expression that can be resolved by simply checking each byte one by one.
-//!
-//! This mainly excludes alternations and repetitions.
+//! This is a hand-rolled validator on a subset of the regex HIR,
+//! which for those simpler expressions, allows avoiding building a full
+//! DFA matcher. This results in smaller memory usage and faster matching.
+use boreal_parser::regex::{RepetitionKind, RepetitionRange};
+
 use crate::matcher::Modifiers;
 use crate::matcher::analysis::HirAnalysis;
 use crate::regex::Hir;
@@ -24,6 +25,8 @@ enum SimpleNode {
     NegatedMask { value: u8, mask: u8 },
     // Jump over a number of bytes
     Jump(u8),
+    // Jump over a range of bytes, non-greedy
+    JumpRange(u8, u8),
     // Dot, any byte but '\n'
     Dot,
 }
@@ -36,7 +39,6 @@ impl SimpleValidator {
         reverse: bool,
     ) -> Option<Self> {
         if analysis.has_start_or_end_line
-            || analysis.has_repetitions
             || analysis.has_word_boundaries
             // Classes are not handled because the naive solution would be to use the class bitmap
             // as a new SimpleNode, which would make its size grow to more than 32 bytes, compared
@@ -74,12 +76,13 @@ impl SimpleValidator {
     ) -> Option<usize> {
         let mem = &haystack[start..end];
 
-        let mut index = 0;
-        for node in &self.nodes {
-            index += check_node(node, mem, index)?;
-        }
+        let after_match = check_nodes(&self.nodes, mem)?;
 
-        Some(start + index)
+        // For example:
+        // - mem: "abcdef"
+        // - after_match: "ef"
+        // Hence index of match end is mem.len() - after_match.len()
+        Some(start + mem.len() - after_match.len())
     }
 
     pub(crate) fn find_anchored_rev(
@@ -90,26 +93,139 @@ impl SimpleValidator {
     ) -> Option<usize> {
         let mem = &haystack[start..end];
 
-        let mut index = mem.len();
-        for node in &self.nodes {
-            index -= check_node(node, mem, index - 1)?;
-        }
+        let before_match = check_nodes_reverse(&self.nodes, mem)?;
 
-        Some(index + start)
+        // For example:
+        // - mem: "abcdef"
+        // - before_match: "ab"
+        // Hence index of match start is simply before_match.len()
+        Some(start + before_match.len())
     }
 }
 
-#[inline(always)]
-fn check_node(node: &SimpleNode, mem: &[u8], index: usize) -> Option<usize> {
-    let matched = match node {
-        SimpleNode::Jump(v) => return Some(usize::from(*v)),
-        SimpleNode::Dot => mem[index] != b'\n',
-        SimpleNode::Byte(a) => mem[index] == *a,
-        SimpleNode::Mask { value, mask } => (mem[index] & *mask) == *value,
-        SimpleNode::NegatedMask { value, mask } => (mem[index] & *mask) != *value,
-    };
+fn check_nodes<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Option<&'a [u8]> {
+    loop {
+        let Some(first) = split_off_first(&mut nodes) else {
+            return Some(mem);
+        };
 
-    if matched { Some(1) } else { None }
+        match first {
+            SimpleNode::Jump(v) => {
+                let len = usize::from(*v);
+
+                mem = mem.get(len..)?;
+            }
+            SimpleNode::Dot => {
+                let c = split_off_first(&mut mem)?;
+                if *c == b'\n' {
+                    return None;
+                }
+            }
+            SimpleNode::Byte(a) => {
+                let c = split_off_first(&mut mem)?;
+                if *c != *a {
+                    return None;
+                }
+            }
+            SimpleNode::Mask { value, mask } => {
+                let c = split_off_first(&mut mem)?;
+                if (*c & *mask) != *value {
+                    return None;
+                }
+            }
+            SimpleNode::NegatedMask { value, mask } => {
+                let c = split_off_first(&mut mem)?;
+                if (*c & *mask) == *value {
+                    return None;
+                }
+            }
+            SimpleNode::JumpRange(min, max) => {
+                // Non-greedy repetition: search from min to max
+                for jump_length in *min..=*max {
+                    let jump_length = usize::from(jump_length);
+
+                    // Can rethrow here: since jump_length increases on
+                    // each iteration, all future iterations will also
+                    // return None here.
+                    let mem2 = mem.get(jump_length..)?;
+
+                    if let Some(res) = check_nodes(nodes, mem2) {
+                        return Some(res);
+                    }
+                }
+                return None;
+            }
+        }
+    }
+}
+
+fn check_nodes_reverse<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Option<&'a [u8]> {
+    loop {
+        let Some(first) = split_off_first(&mut nodes) else {
+            return Some(mem);
+        };
+
+        match first {
+            SimpleNode::Jump(v) => {
+                let jump_len = usize::from(*v);
+                let new_len = mem.len().checked_sub(jump_len)?;
+
+                mem = mem.get(..new_len)?;
+            }
+            SimpleNode::Dot => {
+                let c = split_off_last(&mut mem)?;
+                if *c == b'\n' {
+                    return None;
+                }
+            }
+            SimpleNode::Byte(a) => {
+                let c = split_off_last(&mut mem)?;
+                if *c != *a {
+                    return None;
+                }
+            }
+            SimpleNode::Mask { value, mask } => {
+                let c = split_off_last(&mut mem)?;
+                if (*c & *mask) != *value {
+                    return None;
+                }
+            }
+            SimpleNode::NegatedMask { value, mask } => {
+                let c = split_off_last(&mut mem)?;
+                if (*c & *mask) == *value {
+                    return None;
+                }
+            }
+            SimpleNode::JumpRange(from, to) => {
+                // Reverse search, so look for "smallest" start first,
+                // ie biggest reverse jump first, and keep going.
+                // This allows finding multiple matches in the right order,
+                // and greediness can be handled on how multiple matches are
+                // handled.
+                for jump_len in (*from..=*to).rev() {
+                    let jump_len = usize::from(jump_len);
+                    if let Some(new_len) = mem.len().checked_sub(jump_len) {
+                        if let Some(res) = check_nodes_reverse(nodes, &mem[..new_len]) {
+                            return Some(res);
+                        }
+                    }
+                }
+                return None;
+            }
+        }
+    }
+}
+
+fn split_off_first<'a, T>(slice: &mut &'a [T]) -> Option<&'a T> {
+    let (first, rem) = slice.split_first()?;
+    *slice = rem;
+    Some(first)
+}
+
+fn split_off_last<'a, T>(slice: &mut &'a [T]) -> Option<&'a T> {
+    let (last, rem) = slice.split_last()?;
+    *slice = rem;
+    Some(last)
 }
 
 fn add_hir_to_simple_nodes(
@@ -119,7 +235,7 @@ fn add_hir_to_simple_nodes(
     nodes: &mut Vec<SimpleNode>,
 ) -> bool {
     match hir {
-        Hir::Alternation(_) | Hir::Assertion(_) | Hir::Class(_) | Hir::Repetition { .. } => false,
+        Hir::Alternation(_) | Hir::Assertion(_) | Hir::Class(_) => false,
         Hir::Mask {
             value,
             mask,
@@ -177,6 +293,40 @@ fn add_hir_to_simple_nodes(
             true
         }
         Hir::Group(hir) => add_hir_to_simple_nodes(hir, modifiers, reverse, nodes),
+        Hir::Repetition { hir, kind, greedy } => {
+            // Only handle non-greedy ".{...}" repetitions, with dot_all set. This
+            // means the repeated byte can just be ignored, and matches
+            // the [X-Y] jumps in hex strings.
+            if !matches!(&**hir, Hir::Dot) || !modifiers.dot_all || *greedy {
+                return false;
+            }
+
+            nodes.push(match kind {
+                RepetitionKind::ZeroOrOne => SimpleNode::JumpRange(0, 1),
+                RepetitionKind::Range(RepetitionRange::Exactly(m)) => {
+                    let Ok(m) = u8::try_from(*m) else {
+                        return false;
+                    };
+                    SimpleNode::Jump(m)
+                }
+                RepetitionKind::Range(RepetitionRange::Bounded(m, n)) => {
+                    let Ok(m) = u8::try_from(*m) else {
+                        return false;
+                    };
+                    let Ok(n) = u8::try_from(*n) else {
+                        return false;
+                    };
+                    // TODO: check combination of jumps across the whole
+                    // hir, which can multiply and make this pathologic.
+                    SimpleNode::JumpRange(m, n)
+                }
+                // Unbounded jumps are not handled
+                RepetitionKind::ZeroOrMore
+                | RepetitionKind::OneOrMore
+                | RepetitionKind::Range(RepetitionRange::AtLeast(_)) => return false,
+            });
+            true
+        }
     }
 }
 
@@ -229,6 +379,11 @@ mod wire {
                 Self::Dot => {
                     4_u8.serialize(writer)?;
                 }
+                Self::JumpRange(m, n) => {
+                    5_u8.serialize(writer)?;
+                    m.serialize(writer)?;
+                    n.serialize(writer)?;
+                }
             }
 
             Ok(())
@@ -252,6 +407,11 @@ mod wire {
                 }
                 3 => Ok(Self::Jump(u8::deserialize_reader(reader)?)),
                 4 => Ok(Self::Dot),
+                5 => {
+                    let m = u8::deserialize_reader(reader)?;
+                    let n = u8::deserialize_reader(reader)?;
+                    Ok(Self::JumpRange(m, n))
+                }
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("invalid discriminant when deserializing a simple node: {v}"),
@@ -291,8 +451,9 @@ mod wire {
             );
             test_round_trip(&SimpleNode::Jump(23), &[0, 1]);
             test_round_trip(&SimpleNode::Dot, &[0]);
+            test_round_trip(&SimpleNode::JumpRange(12, 23), &[0, 1, 2]);
 
-            test_invalid_deserialization::<SimpleNode>(b"\x05");
+            test_invalid_deserialization::<SimpleNode>(b"\x10");
         }
     }
 }
@@ -521,5 +682,37 @@ mod tests {
         assert_eq!(v2.find_anchored_fwd(b"a", 0, 1), Some(1));
         assert_eq!(v1.find_anchored_fwd(b"\n", 0, 1), None);
         assert_eq!(v2.find_anchored_fwd(b"\n", 0, 1), Some(1));
+    }
+
+    #[test]
+    fn test_simple_validator_jump_range() {
+        let mods = Modifiers {
+            dot_all: true,
+            ..Default::default()
+        };
+        let expr = "{ AA [0-2] BB }";
+        let v = build_validator(expr, mods, false).unwrap();
+        let vrev = build_validator(expr, mods, true).unwrap();
+
+        assert_eq!(v.find_anchored_fwd(b"\xAA", 0, 1), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB", 0, 1), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB", 0, 2), Some(2));
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB\xBB", 0, 3), Some(2));
+        assert_eq!(v.find_anchored_fwd(b"\xAA\x00\xBB", 0, 3), Some(3));
+        assert_eq!(v.find_anchored_fwd(b"\xAA\x00\x00\xBB", 0, 4), Some(4));
+        assert_eq!(v.find_anchored_fwd(b"\xAA\x00\x00\x00\xBB", 0, 5), None);
+
+        assert_eq!(v.find_anchored_fwd(b"\xAA\x00\xAA", 0, 3), None);
+        assert_eq!(v.find_anchored_fwd(b"\xBB\x00\xAA", 0, 3), None);
+
+        assert_eq!(vrev.find_anchored_rev(b"\xAA", 0, 1), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\xBB", 0, 1), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\xBB", 0, 2), Some(0));
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\xBB\xBB", 0, 3), Some(0));
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\xAA\xBB", 0, 3), Some(0));
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\xAA\xAA\xBB", 0, 4), Some(0));
+        assert_eq!(vrev.find_anchored_rev(b"\xBB\xAA\xAA\xBB", 0, 4), Some(1));
+
+        assert_eq!(vrev.find_anchored_rev(b"\xAA\x00\xAA", 0, 3), None);
     }
 }

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -12,8 +12,6 @@ use crate::regex::Hir;
 pub(crate) struct SimpleValidator {
     /// List of nodes to match
     nodes: Box<[SimpleNode]>,
-    /// Total length of the expression
-    length: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -63,13 +61,8 @@ impl SimpleValidator {
             return None;
         }
 
-        let length = nodes.iter().fold(0, |acc, node| match node {
-            SimpleNode::Jump(len) => acc + usize::from(*len),
-            _ => acc + 1,
-        });
         Some(Self {
             nodes: nodes.into_boxed_slice(),
-            length,
         })
     }
 
@@ -80,9 +73,6 @@ impl SimpleValidator {
         end: usize,
     ) -> Option<usize> {
         let mem = &haystack[start..end];
-        if mem.len() < self.length {
-            return None;
-        }
 
         let mut index = 0;
         for node in &self.nodes {
@@ -99,9 +89,6 @@ impl SimpleValidator {
         end: usize,
     ) -> Option<usize> {
         let mem = &haystack[start..end];
-        if mem.len() < self.length {
-            return None;
-        }
 
         let mut index = mem.len();
         for node in &self.nodes {
@@ -204,7 +191,6 @@ mod wire {
     impl Serialize for SimpleValidator {
         fn serialize<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
             self.nodes.serialize(writer)?;
-            self.length.serialize(writer)?;
             Ok(())
         }
     }
@@ -212,11 +198,9 @@ mod wire {
     impl Deserialize for SimpleValidator {
         fn deserialize_reader<R: io::Read>(reader: &mut R) -> io::Result<Self> {
             let nodes = <Vec<SimpleNode>>::deserialize_reader(reader)?;
-            let length = usize::deserialize_reader(reader)?;
 
             Ok(Self {
                 nodes: nodes.into_boxed_slice(),
-                length,
             })
         }
     }
@@ -286,9 +270,8 @@ mod wire {
             test_round_trip(
                 &SimpleValidator {
                     nodes: Box::new([SimpleNode::Byte(23), SimpleNode::Dot]),
-                    length: 23,
                 },
-                &[0, 1, 6, 12],
+                &[0, 1, 6],
             );
 
             test_round_trip(&SimpleNode::Byte(23), &[0, 1]);

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -58,13 +58,18 @@ impl SimpleValidator {
             return None;
         }
 
-        let mut nodes = Vec::new();
-        if !add_hir_to_simple_nodes(hir, modifiers, reverse, &mut nodes) {
+        let mut builder = SimpleValidatorBuilder {
+            nodes: Vec::new(),
+            dot_all: modifiers.dot_all,
+            reverse,
+            combinations: 1,
+        };
+        if !builder.add_hir(hir) {
             return None;
         }
 
         Some(Self {
-            nodes: nodes.into_boxed_slice(),
+            nodes: builder.nodes.into_boxed_slice(),
         })
     }
 
@@ -228,112 +233,124 @@ fn split_off_last<'a, T>(slice: &mut &'a [T]) -> Option<&'a T> {
     Some(last)
 }
 
-fn add_hir_to_simple_nodes(
-    hir: &Hir,
-    modifiers: Modifiers,
+struct SimpleValidatorBuilder {
+    nodes: Vec<SimpleNode>,
+    dot_all: bool,
     reverse: bool,
-    nodes: &mut Vec<SimpleNode>,
-) -> bool {
-    match hir {
-        Hir::Alternation(_) | Hir::Assertion(_) | Hir::Class(_) => false,
-        Hir::Mask {
-            value,
-            mask,
-            negated,
-        } => {
-            nodes.push(if *negated {
-                SimpleNode::NegatedMask {
-                    value: *value,
-                    mask: *mask,
-                }
-            } else {
-                SimpleNode::Mask {
-                    value: *value,
-                    mask: *mask,
-                }
-            });
-            true
-        }
-        Hir::Concat(hirs) => {
-            if reverse {
-                for h in hirs.iter().rev() {
-                    if !add_hir_to_simple_nodes(h, modifiers, reverse, nodes) {
-                        return false;
-                    }
-                }
-            } else {
-                for h in hirs {
-                    if !add_hir_to_simple_nodes(h, modifiers, reverse, nodes) {
-                        return false;
-                    }
-                }
-            }
-
-            true
-        }
-        Hir::Dot => {
-            if modifiers.dot_all {
-                add_jump(nodes, 1);
-            } else {
-                nodes.push(SimpleNode::Dot);
-            }
-            true
-        }
-        Hir::Empty => true,
-        Hir::Literal(b) => {
-            nodes.push(SimpleNode::Byte(*b));
-            true
-        }
-        Hir::Group(hir) => add_hir_to_simple_nodes(hir, modifiers, reverse, nodes),
-        Hir::Repetition { hir, kind, greedy } => {
-            // Only handle non-greedy ".{...}" repetitions, with dot_all set. This
-            // means the repeated byte can just be ignored, and matches
-            // the [X-Y] jumps in hex strings.
-            if !matches!(&**hir, Hir::Dot) || !modifiers.dot_all || *greedy {
-                return false;
-            }
-
-            match kind {
-                RepetitionKind::ZeroOrOne => nodes.push(SimpleNode::JumpRange(0, 1)),
-                RepetitionKind::Range(RepetitionRange::Exactly(m)) => {
-                    let Ok(m) = u8::try_from(*m) else {
-                        return false;
-                    };
-                    add_jump(nodes, m);
-                }
-                RepetitionKind::Range(RepetitionRange::Bounded(m, n)) => {
-                    let Ok(m) = u8::try_from(*m) else {
-                        return false;
-                    };
-                    let Ok(n) = u8::try_from(*n) else {
-                        return false;
-                    };
-                    // TODO: check combination of jumps across the whole
-                    // hir, which can multiply and make this pathologic.
-                    nodes.push(SimpleNode::JumpRange(m, n));
-                }
-                // Unbounded jumps are not handled
-                RepetitionKind::ZeroOrMore
-                | RepetitionKind::OneOrMore
-                | RepetitionKind::Range(RepetitionRange::AtLeast(_)) => return false,
-            }
-            true
-        }
-    }
+    combinations: u8,
 }
 
-fn add_jump(nodes: &mut Vec<SimpleNode>, jump_length: u8) {
-    if nodes.is_empty() {
-        nodes.push(SimpleNode::Jump(jump_length));
-    } else {
-        let last_index = nodes.len() - 1;
-        if let SimpleNode::Jump(value) = &mut nodes[last_index] {
-            match value.checked_add(jump_length) {
-                Some(new_value) => *value = new_value,
-                None => nodes.push(SimpleNode::Jump(jump_length)),
+impl SimpleValidatorBuilder {
+    fn add_hir(&mut self, hir: &Hir) -> bool {
+        match hir {
+            Hir::Alternation(_) | Hir::Assertion(_) | Hir::Class(_) => false,
+            Hir::Mask {
+                value,
+                mask,
+                negated,
+            } => {
+                self.nodes.push(if *negated {
+                    SimpleNode::NegatedMask {
+                        value: *value,
+                        mask: *mask,
+                    }
+                } else {
+                    SimpleNode::Mask {
+                        value: *value,
+                        mask: *mask,
+                    }
+                });
+                true
             }
+            Hir::Concat(hirs) => {
+                if self.reverse {
+                    for h in hirs.iter().rev() {
+                        if !self.add_hir(h) {
+                            return false;
+                        }
+                    }
+                } else {
+                    for h in hirs {
+                        if !self.add_hir(h) {
+                            return false;
+                        }
+                    }
+                }
+
+                true
+            }
+            Hir::Dot => {
+                if self.dot_all {
+                    self.add_jump(1);
+                } else {
+                    self.nodes.push(SimpleNode::Dot);
+                }
+                true
+            }
+            Hir::Empty => true,
+            Hir::Literal(b) => {
+                self.nodes.push(SimpleNode::Byte(*b));
+                true
+            }
+            Hir::Group(hir) => self.add_hir(hir),
+            Hir::Repetition { hir, kind, greedy } => {
+                // Only handle non-greedy ".{...}" repetitions, with dot_all set. This
+                // means the repeated byte can just be ignored, and matches
+                // the [X-Y] jumps in hex strings.
+                if !matches!(&**hir, Hir::Dot) || !self.dot_all || *greedy {
+                    return false;
+                }
+
+                match kind {
+                    RepetitionKind::ZeroOrOne => self.nodes.push(SimpleNode::JumpRange(0, 1)),
+                    RepetitionKind::Range(RepetitionRange::Exactly(m)) => {
+                        let Ok(m) = u8::try_from(*m) else {
+                            return false;
+                        };
+                        self.add_jump(m);
+                    }
+                    RepetitionKind::Range(RepetitionRange::Bounded(min, max)) => {
+                        let Ok(min) = u8::try_from(*min) else {
+                            return false;
+                        };
+                        let Ok(max) = u8::try_from(*max) else {
+                            return false;
+                        };
+
+                        // Cap the combinations of jumps. This does not distinguish
+                        // many small jumps from one bit jump, the goal is simply
+                        // to have a conservative cap to avoid any complications.
+                        let comb = max.saturating_sub(min) + 1;
+                        self.combinations = self.combinations.saturating_mul(comb);
+                        if self.combinations > 64 {
+                            return false;
+                        }
+
+                        self.nodes.push(SimpleNode::JumpRange(min, max));
+                    }
+                    // Unbounded jumps are not handled
+                    RepetitionKind::ZeroOrMore
+                    | RepetitionKind::OneOrMore
+                    | RepetitionKind::Range(RepetitionRange::AtLeast(_)) => return false,
+                }
+                true
+            }
+        }
+    }
+
+    fn add_jump(&mut self, jump_length: u8) {
+        if self.nodes.is_empty() {
+            self.nodes.push(SimpleNode::Jump(jump_length));
         } else {
-            nodes.push(SimpleNode::Jump(jump_length));
+            let last_index = self.nodes.len() - 1;
+            if let SimpleNode::Jump(value) = &mut self.nodes[last_index] {
+                match value.checked_add(jump_length) {
+                    Some(new_value) => *value = new_value,
+                    None => self.nodes.push(SimpleNode::Jump(jump_length)),
+                }
+            } else {
+                self.nodes.push(SimpleNode::Jump(jump_length));
+            }
         }
     }
 }
@@ -585,24 +602,34 @@ mod tests {
             Some(&[SimpleNode::Jump(255), SimpleNode::Jump(45)]),
         );
 
-        assert!(!add_hir_to_simple_nodes(
-            &Hir::Alternation(vec![Hir::Empty]),
-            Modifiers::default(),
-            false,
-            &mut Vec::new()
-        ));
-        assert!(!add_hir_to_simple_nodes(
-            &Hir::Concat(vec![Hir::Dot, Hir::Assertion(AssertionKind::StartLine)]),
-            Modifiers::default(),
-            false,
-            &mut Vec::new()
-        ));
-        assert!(!add_hir_to_simple_nodes(
-            &Hir::Concat(vec![Hir::Dot, Hir::Assertion(AssertionKind::StartLine)]),
-            Modifiers::default(),
-            true,
-            &mut Vec::new()
-        ));
+        let mut builder = SimpleValidatorBuilder {
+            nodes: Vec::new(),
+            dot_all: false,
+            reverse: false,
+            combinations: 1,
+        };
+        assert!(!builder.add_hir(&Hir::Alternation(vec![Hir::Empty]),));
+        assert!(!builder.add_hir(&Hir::Concat(vec![
+            Hir::Dot,
+            Hir::Assertion(AssertionKind::StartLine)
+        ]),));
+        assert!(!builder.add_hir(&Hir::Repetition {
+            hir: Box::new(Hir::Dot),
+            kind: RepetitionKind::Range(RepetitionRange::Bounded(0, 200)),
+            greedy: false,
+        }));
+        assert!(!builder.add_hir(&Hir::Concat(vec![
+            Hir::Repetition {
+                hir: Box::new(Hir::Dot),
+                kind: RepetitionKind::Range(RepetitionRange::Bounded(0, 40)),
+                greedy: false,
+            },
+            Hir::Repetition {
+                hir: Box::new(Hir::Dot),
+                kind: RepetitionKind::Range(RepetitionRange::Bounded(0, 40)),
+                greedy: false,
+            }
+        ],)));
     }
 
     #[test]


### PR DESCRIPTION
Add handling of the jumps as used in hex strings in the simple validator. This improves which expression this validator can handle, reducing usage of the DFA validator and thus reducing both memory consumption and scanning time.

On the signature-base repository for example, this brings the number of strings using the Dfa validator from 1765 to 651, and improve memory consumption and scanning time significantly.