### PR TITLE
fix: cap some length during deserialization

### DIFF
--- a/boreal/src/compiler/expression.rs
+++ b/boreal/src/compiler/expression.rs
@@ -1641,6 +1641,11 @@ mod wire {
         let len = usize::try_from(len).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, format!("length too big: {len}"))
         })?;
+
+        // Cap the length to avoid preallocating too much, since the value
+        // is not sanitized.
+        let len = std::cmp::min(len, 1024);
+
         let mut exprs = Vec::with_capacity(len);
         for _ in 0..len {
             exprs.push(deserialize_expr(ctx, reader)?);

--- a/boreal/src/compiler/module.rs
+++ b/boreal/src/compiler/module.rs
@@ -760,6 +760,11 @@ mod wire {
         let len = usize::try_from(len).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, format!("length too big: {len}"))
         })?;
+
+        // Cap the length to avoid preallocating too much, since the value
+        // is not sanitized.
+        let len = std::cmp::min(len, 1024);
+
         let mut expressions = Vec::with_capacity(len);
         for _ in 0..len {
             expressions.push(Expression::deserialize(ctx, reader)?);

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -1650,9 +1650,15 @@ mod wire {
         reader: &mut R,
     ) -> io::Result<Vec<Rule>> {
         let len = u32::deserialize_reader(reader)?;
+
         let len = usize::try_from(len).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, format!("length too big: {len}"))
         })?;
+
+        // Cap the length to avoid preallocating too much, since the value
+        // is not sanitized.
+        let len = std::cmp::min(len, 1024);
+
         let mut rules = Vec::with_capacity(len);
         for _ in 0..len {
             rules.push(Rule::deserialize(ctx, reader)?);
@@ -1685,6 +1691,11 @@ mod wire {
         let len = usize::try_from(len).map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, format!("length too big: {len}"))
         })?;
+
+        // Cap the length to avoid preallocating too much, since the value
+        // is not sanitized.
+        let len = std::cmp::min(len, 1024);
+
         let mut modules = Vec::with_capacity(len);
         for _ in 0..len {
             let name = String::deserialize_reader(reader)?;


### PR DESCRIPTION
Some Vec of objects are deserialized manually rather than through the Vec deserialize impl from borsh. For those, the length retrieved from the input was passed directly to Vec::with_capacity, leading to potential huge allocations.

To avoid this, the pre alloc is now done on min(len, 1024). If there are more elements, the vec will realloc, and there are no longer any risks of allocating too much from a faulty len value.