### PR TITLE
feat: don't call Instant::now if statistics not enabled

### DIFF
--- a/boreal/src/scanner/ac_scan.rs
+++ b/boreal/src/scanner/ac_scan.rs
@@ -173,7 +173,10 @@ impl AcScan {
 
         if !self.non_handled_var_indexes.is_empty() {
             #[cfg(feature = "profiling")]
-            let start = std::time::Instant::now();
+            let start = scan_data
+                .statistics
+                .as_ref()
+                .map(|_| std::time::Instant::now());
 
             // For every "raw" matcher, scan the memory for this matcher.
             for matcher_index in &self.non_handled_var_indexes {
@@ -184,7 +187,9 @@ impl AcScan {
 
             #[cfg(feature = "profiling")]
             if let Some(stats) = scan_data.statistics.as_mut() {
-                stats.raw_regexes_eval_duration += start.elapsed();
+                if let Some(start) = start {
+                    stats.raw_regexes_eval_duration += start.elapsed();
+                }
             }
         }
 
@@ -212,7 +217,10 @@ impl AcScan {
                 stats.nb_ac_matches += 1;
             }
             #[cfg(feature = "profiling")]
-            let start_instant = std::time::Instant::now();
+            let start_instant = scan_data
+                .statistics
+                .as_ref()
+                .map(|_| std::time::Instant::now());
 
             // Upscale to the original literal shape before feeding it to the matcher verification
             // function.
@@ -260,7 +268,9 @@ impl AcScan {
             #[cfg(feature = "profiling")]
             {
                 if let Some(stats) = scan_data.statistics.as_mut() {
-                    stats.ac_confirm_duration += start_instant.elapsed();
+                    if let Some(start) = start_instant {
+                        stats.ac_confirm_duration += start.elapsed();
+                    }
                 }
             }
 

--- a/boreal/src/scanner/mod.rs
+++ b/boreal/src/scanner/mod.rs
@@ -903,13 +903,18 @@ impl Inner {
 
         if can_use_no_scan_optimization(&mem, scan_data) {
             #[cfg(feature = "profiling")]
-            let start = std::time::Instant::now();
+            let start = scan_data
+                .statistics
+                .as_ref()
+                .map(|_| std::time::Instant::now());
 
             let res = self.evaluate_without_matches(&mut mem, scan_data);
 
             #[cfg(feature = "profiling")]
             if let Some(stats) = scan_data.statistics.as_mut() {
-                stats.no_scan_eval_duration = start.elapsed();
+                if let Some(start) = start {
+                    stats.no_scan_eval_duration = start.elapsed();
+                }
             }
 
             match res {
@@ -940,7 +945,10 @@ impl Inner {
         let mut eval_ctx = EvalContext::new(Some(var_matches), self.namespaces.len());
 
         #[cfg(feature = "profiling")]
-        let start = std::time::Instant::now();
+        let start = scan_data
+            .statistics
+            .as_ref()
+            .map(|_| std::time::Instant::now());
 
         // First, evaluate global rules.
         for rule in &self.global_rules {
@@ -970,7 +978,9 @@ impl Inner {
             scan_data.rules.clear();
             #[cfg(feature = "profiling")]
             if let Some(stats) = scan_data.statistics.as_mut() {
-                stats.rules_eval_duration = start.elapsed();
+                if let Some(start) = start {
+                    stats.rules_eval_duration = start.elapsed();
+                }
             }
             return Ok(());
         }
@@ -992,7 +1002,9 @@ impl Inner {
 
         #[cfg(feature = "profiling")]
         if let Some(stats) = scan_data.statistics.as_mut() {
-            stats.rules_eval_duration = start.elapsed();
+            if let Some(start) = start {
+                stats.rules_eval_duration = start.elapsed();
+            }
         }
         Ok(())
     }
@@ -1045,7 +1057,10 @@ impl Inner {
         let mut matches = vec![Vec::new(); self.matchers.len()];
 
         #[cfg(feature = "profiling")]
-        let start = std::time::Instant::now();
+        let start = scan_data
+            .statistics
+            .as_ref()
+            .map(|_| std::time::Instant::now());
 
         match mem {
             Memory::Direct(mem) => {
@@ -1061,7 +1076,10 @@ impl Inner {
                 // Scan each region for all variables occurences.
                 while fragmented.obj.next(&fragmented.params).is_some() {
                     #[cfg(feature = "profiling")]
-                    let start_fetch = std::time::Instant::now();
+                    let start_fetch = scan_data
+                        .statistics
+                        .as_ref()
+                        .map(|_| std::time::Instant::now());
 
                     let Some(region) = fragmented.obj.fetch(&fragmented.params) else {
                         continue;
@@ -1069,7 +1087,9 @@ impl Inner {
 
                     #[cfg(feature = "profiling")]
                     if let Some(stats) = scan_data.statistics.as_mut() {
-                        stats.fetch_memory_duration += start_fetch.elapsed();
+                        if let Some(start_fetch) = start_fetch {
+                            stats.fetch_memory_duration += start_fetch.elapsed();
+                        }
                     }
 
                     self.ac_scan
@@ -1104,7 +1124,9 @@ impl Inner {
 
         #[cfg(feature = "profiling")]
         if let Some(stats) = scan_data.statistics.as_mut() {
-            stats.ac_duration = start.elapsed();
+            if let Some(start) = start {
+                stats.ac_duration = start.elapsed();
+            }
         }
 
         Ok(matches)


### PR DESCRIPTION
If the profiling feature is enabled, starting timers would be created even if no statistics were asked for and those timers would be unused. This isn't great as those Instant::now() calls are not free.

This MR thus changes the behavior to only call Instant::now() if statistics are enabled.

Note that this MR changes nothing if profiling feature is not enabled, in which case all this code is not included.