### PR TITLE
Support alternations in simple validator

### DIFF
--- a/boreal/src/matcher/analysis.rs
+++ b/boreal/src/matcher/analysis.rs
@@ -15,9 +15,6 @@ pub struct HirAnalysis {
     // Contains word boundaries.
     pub has_classes: bool,
 
-    // Contains alternations.
-    pub has_alternations: bool,
-
     // Number of alternative literals covering the regex.
     //
     // Only set if the regex can be entirely expressed as this literals alternation.
@@ -34,7 +31,6 @@ pub fn analyze_hir(hir: &Hir, dot_all: bool) -> HirAnalysis {
             has_greedy_repetitions: false,
             has_word_boundaries: false,
             has_classes: false,
-            has_alternations: false,
 
             nb_alt_literals: Some(1),
             alt_stack: Vec::new(),
@@ -52,7 +48,6 @@ struct HirAnalyser {
     has_greedy_repetitions: bool,
     has_word_boundaries: bool,
     has_classes: bool,
-    has_alternations: bool,
 
     /// Current count of the number of literals needed to cover the HIR.
     ///
@@ -125,7 +120,6 @@ impl Visitor for HirAnalyser {
                     branches_nb_alt_literals: Some(0),
                 });
                 self.nb_alt_literals = Some(1);
-                self.has_alternations = true;
             }
         }
 
@@ -165,7 +159,6 @@ impl Visitor for HirAnalyser {
             has_greedy_repetitions: self.has_greedy_repetitions,
             has_word_boundaries: self.has_word_boundaries,
             has_classes: self.has_classes,
-            has_alternations: self.has_alternations,
             nb_alt_literals: self.nb_alt_literals,
         }
     }
@@ -259,27 +252,23 @@ mod tests {
         assert!(res.has_greedy_repetitions);
         assert!(!res.has_word_boundaries);
         assert!(!res.has_classes);
-        assert!(!res.has_alternations);
 
         let res = analyze_expr(r"\b[Ww]o(r|R)d\b", false);
         assert!(!res.has_start_or_end_line);
         assert!(!res.has_greedy_repetitions);
         assert!(res.has_word_boundaries);
         assert!(res.has_classes);
-        assert!(res.has_alternations);
 
         let res = analyze_expr(r"{ 51 [-3] ( ?A ?? AF | FA ) }", false);
         assert!(!res.has_start_or_end_line);
         assert!(!res.has_greedy_repetitions);
         assert!(!res.has_word_boundaries);
         assert!(!res.has_classes);
-        assert!(res.has_alternations);
 
         let res = analyze_expr(r"\Ba{1,3}?$", false);
         assert!(res.has_start_or_end_line);
         assert!(!res.has_greedy_repetitions);
         assert!(res.has_word_boundaries);
         assert!(!res.has_classes);
-        assert!(!res.has_alternations);
     }
 }

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -16,7 +16,6 @@ pub(crate) struct SimpleValidator {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-#[allow(variant_size_differences)]
 enum SimpleNode {
     // Byte to match
     Byte(u8),
@@ -30,8 +29,20 @@ enum SimpleNode {
     JumpRange(u8, u8),
     // Dot, any byte but '\n'
     Dot,
-    // Alternation
-    Alternation(Box<[Box<[SimpleNode]>]>),
+    // Start of an alternation.
+    //
+    // The value is the total length of the alternation.
+    //
+    // `[Alternation(N), <N nodes>, ...rest...]`
+    //
+    // Instead those N nodes, each branch is indicated by an `AltBranch` node.
+    Alternation(u16),
+    // Start of an alternation branch.
+    //
+    // The value is the length of the branch.
+    //
+    // `[AltBranch(N), <N nodes>, ...rest...]`
+    AltBranch(u8),
 }
 
 impl SimpleValidator {
@@ -163,18 +174,26 @@ fn check_nodes<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Option<&'a [u
                 }
                 return None;
             }
-            SimpleNode::Alternation(alts) => {
-                for alt in alts {
-                    if let Some(rest) = check_nodes(alt, mem) {
+            SimpleNode::Alternation(length) => {
+                let nodes_after_alt = &nodes[usize::from(*length)..];
+
+                while let Some(SimpleNode::AltBranch(branch_length)) = split_off_first(&mut nodes) {
+                    let branch_length = usize::from(*branch_length);
+                    let (branch_nodes, rest_nodes) = nodes.split_at(branch_length);
+
+                    if let Some(rest) = check_nodes(branch_nodes, mem) {
                         // Validate the rest, and try another branch if it
                         // fails. See for example `(a|ab)c`, on input `abc`.
-                        if let Some(end) = check_nodes(nodes, rest) {
+                        if let Some(end) = check_nodes(nodes_after_alt, rest) {
                             return Some(end);
                         }
                     }
+                    nodes = rest_nodes;
                 }
                 return None;
             }
+            // Handled in SimpleNode::Alternation, should not appear on its own.
+            SimpleNode::AltBranch(_) => return None,
         }
     }
 }
@@ -232,16 +251,24 @@ fn check_nodes_reverse<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Optio
                 }
                 return None;
             }
-            SimpleNode::Alternation(alts) => {
-                for alt in alts {
-                    if let Some(rest) = check_nodes_reverse(alt, mem) {
-                        if let Some(end) = check_nodes_reverse(nodes, rest) {
+            SimpleNode::Alternation(length) => {
+                let nodes_after_alt = &nodes[usize::from(*length)..];
+
+                while let Some(SimpleNode::AltBranch(branch_length)) = split_off_first(&mut nodes) {
+                    let branch_length = usize::from(*branch_length);
+                    let (branch_nodes, rest_nodes) = nodes.split_at(branch_length);
+
+                    if let Some(rest) = check_nodes_reverse(branch_nodes, mem) {
+                        if let Some(end) = check_nodes_reverse(nodes_after_alt, rest) {
                             return Some(end);
                         }
                     }
+                    nodes = rest_nodes;
                 }
                 return None;
             }
+            // Handled in SimpleNode::Alternation, should not appear on its own.
+            SimpleNode::AltBranch(_) => return None,
         }
     }
 }
@@ -373,18 +400,33 @@ impl SimpleValidatorBuilder {
                 }
 
                 self.in_alternation = true;
-                let mut branches = Vec::with_capacity(alts.len());
-                let current_stack = std::mem::take(&mut self.nodes);
+                let mut current_stack = std::mem::take(&mut self.nodes);
+                let alt_node_index = current_stack.len();
+                // Placeholder value 0, will be replaced once
+                // all branches are saved.
+                current_stack.push(SimpleNode::Alternation(0));
+
                 for alt in alts {
                     if !self.add_hir(alt) {
                         return false;
                     }
-                    let nodes = std::mem::take(&mut self.nodes);
-                    branches.push(nodes.into_boxed_slice());
+                    let branch_nodes = std::mem::take(&mut self.nodes);
+
+                    // Insert the branch nodes in the stack with
+                    // an AltBranch node first.
+                    let Ok(nb_branch_nodes) = u8::try_from(branch_nodes.len()) else {
+                        return false;
+                    };
+                    current_stack.push(SimpleNode::AltBranch(nb_branch_nodes));
+                    current_stack.extend(branch_nodes);
                 }
+
+                let Ok(alt_total_length) = u16::try_from(current_stack.len() - alt_node_index - 1)
+                else {
+                    return false;
+                };
+                current_stack[alt_node_index] = SimpleNode::Alternation(alt_total_length);
                 self.nodes = current_stack;
-                self.nodes
-                    .push(SimpleNode::Alternation(branches.into_boxed_slice()));
                 self.in_alternation = false;
 
                 true
@@ -499,9 +541,13 @@ mod wire {
                     m.serialize(writer)?;
                     n.serialize(writer)?;
                 }
-                Self::Alternation(alts) => {
+                Self::Alternation(len) => {
                     6_u8.serialize(writer)?;
-                    alts.serialize(writer)?;
+                    len.serialize(writer)?;
+                }
+                Self::AltBranch(len) => {
+                    7_u8.serialize(writer)?;
+                    len.serialize(writer)?;
                 }
             }
 
@@ -532,10 +578,12 @@ mod wire {
                     Ok(Self::JumpRange(m, n))
                 }
                 6 => {
-                    let alts = <Vec<Vec<SimpleNode>>>::deserialize_reader(reader)?;
-                    Ok(Self::Alternation(
-                        alts.into_iter().map(Vec::into_boxed_slice).collect(),
-                    ))
+                    let len = u16::deserialize_reader(reader)?;
+                    Ok(Self::Alternation(len))
+                }
+                7 => {
+                    let len = u8::deserialize_reader(reader)?;
+                    Ok(Self::AltBranch(len))
                 }
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -577,6 +625,8 @@ mod wire {
             test_round_trip(&SimpleNode::Jump(23), &[0, 1]);
             test_round_trip(&SimpleNode::Dot, &[0]);
             test_round_trip(&SimpleNode::JumpRange(12, 23), &[0, 1, 2]);
+            test_round_trip(&SimpleNode::Alternation(12), &[0, 1]);
+            test_round_trip(&SimpleNode::AltBranch(12), &[0, 1]);
 
             test_invalid_deserialization::<SimpleNode>(b"\x10");
         }
@@ -766,18 +816,23 @@ mod tests {
         };
 
         test_build(
-            "{ ( AA ?? BB | CC | DD EE ) }",
+            "{ 00 ( AA ?? BB | CC | DD EE ) 11 }",
             mods,
             false,
-            Some(&[SimpleNode::Alternation(Box::new([
-                Box::new([
-                    SimpleNode::Byte(b'\xAA'),
-                    SimpleNode::Jump(1),
-                    SimpleNode::Byte(b'\xBB'),
-                ]),
-                Box::new([SimpleNode::Byte(b'\xCC')]),
-                Box::new([SimpleNode::Byte(b'\xDD'), SimpleNode::Byte(b'\xEE')]),
-            ]))]),
+            Some(&[
+                SimpleNode::Byte(b'\x00'),
+                SimpleNode::Alternation(9),
+                SimpleNode::AltBranch(3),
+                SimpleNode::Byte(b'\xAA'),
+                SimpleNode::Jump(1),
+                SimpleNode::Byte(b'\xBB'),
+                SimpleNode::AltBranch(1),
+                SimpleNode::Byte(b'\xCC'),
+                SimpleNode::AltBranch(2),
+                SimpleNode::Byte(b'\xDD'),
+                SimpleNode::Byte(b'\xEE'),
+                SimpleNode::Byte(b'\x11'),
+            ]),
         );
 
         // Imbricated is rejected
@@ -797,14 +852,15 @@ mod tests {
             "{ ( AA | BB [3-3] CC ) }",
             mods,
             false,
-            Some(&[SimpleNode::Alternation(Box::new([
-                Box::new([SimpleNode::Byte(b'\xAA')]),
-                Box::new([
-                    SimpleNode::Byte(b'\xBB'),
-                    SimpleNode::Jump(3),
-                    SimpleNode::Byte(b'\xCC'),
-                ]),
-            ]))]),
+            Some(&[
+                SimpleNode::Alternation(6),
+                SimpleNode::AltBranch(1),
+                SimpleNode::Byte(b'\xAA'),
+                SimpleNode::AltBranch(3),
+                SimpleNode::Byte(b'\xBB'),
+                SimpleNode::Jump(3),
+                SimpleNode::Byte(b'\xCC'),
+            ]),
         );
     }
 
@@ -1042,5 +1098,28 @@ mod tests {
         assert_eq!(vrev.find_anchored_rev(b"\xBB\xAA", 0, 2), None);
         assert_eq!(vrev.find_anchored_rev(b"\xDD\xBB\xAA", 0, 3), None);
         assert_eq!(vrev.find_anchored_rev(b"\xCC\xBB\xAA", 0, 3), Some(0));
+    }
+
+    #[test]
+    fn test_simple_validator_alternations_limit() {
+        let mods = Modifiers::default();
+
+        // No more than u8::max branches
+        let mut expr = String::new();
+        expr.push_str("(a");
+        for _ in 0..u8::MAX {
+            expr.push_str("|a");
+        }
+        expr.push(')');
+        test_build(&expr, mods, false, None);
+
+        // A single branch cannot be longer than u8::max
+        let mut expr = String::new();
+        expr.push_str("(a|");
+        for _ in 0..=u8::MAX {
+            expr.push('a');
+        }
+        expr.push_str("|a)");
+        test_build(&expr, mods, false, None);
     }
 }

--- a/boreal/src/matcher/validator/simple.rs
+++ b/boreal/src/matcher/validator/simple.rs
@@ -16,6 +16,7 @@ pub(crate) struct SimpleValidator {
 }
 
 #[derive(Debug, PartialEq, Eq)]
+#[allow(variant_size_differences)]
 enum SimpleNode {
     // Byte to match
     Byte(u8),
@@ -29,6 +30,8 @@ enum SimpleNode {
     JumpRange(u8, u8),
     // Dot, any byte but '\n'
     Dot,
+    // Alternation
+    Alternation(Box<[Box<[SimpleNode]>]>),
 }
 
 impl SimpleValidator {
@@ -47,7 +50,6 @@ impl SimpleValidator {
             // Some classes could be handled if there is a way to encode how to check them in as
             // few bytes as possible. But for the moment, this isn't really needed.
             || analysis.has_classes
-            || analysis.has_alternations
         {
             // TODO: handle fixed size repetitions.
             return None;
@@ -63,6 +65,7 @@ impl SimpleValidator {
             dot_all: modifiers.dot_all,
             reverse,
             combinations: 1,
+            in_alternation: false,
         };
         if !builder.add_hir(hir) {
             return None;
@@ -160,6 +163,18 @@ fn check_nodes<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Option<&'a [u
                 }
                 return None;
             }
+            SimpleNode::Alternation(alts) => {
+                for alt in alts {
+                    if let Some(rest) = check_nodes(alt, mem) {
+                        // Validate the rest, and try another branch if it
+                        // fails. See for example `(a|ab)c`, on input `abc`.
+                        if let Some(end) = check_nodes(nodes, rest) {
+                            return Some(end);
+                        }
+                    }
+                }
+                return None;
+            }
         }
     }
 }
@@ -217,6 +232,16 @@ fn check_nodes_reverse<'a>(mut nodes: &[SimpleNode], mut mem: &'a [u8]) -> Optio
                 }
                 return None;
             }
+            SimpleNode::Alternation(alts) => {
+                for alt in alts {
+                    if let Some(rest) = check_nodes_reverse(alt, mem) {
+                        if let Some(end) = check_nodes_reverse(nodes, rest) {
+                            return Some(end);
+                        }
+                    }
+                }
+                return None;
+            }
         }
     }
 }
@@ -238,12 +263,13 @@ struct SimpleValidatorBuilder {
     dot_all: bool,
     reverse: bool,
     combinations: u8,
+    in_alternation: bool,
 }
 
 impl SimpleValidatorBuilder {
     fn add_hir(&mut self, hir: &Hir) -> bool {
         match hir {
-            Hir::Alternation(_) | Hir::Assertion(_) | Hir::Class(_) => false,
+            Hir::Assertion(_) | Hir::Class(_) => false,
             Hir::Mask {
                 value,
                 mask,
@@ -334,6 +360,35 @@ impl SimpleValidatorBuilder {
                 }
                 true
             }
+            Hir::Alternation(alts) => {
+                // Refuse imbricated alternations
+                if self.in_alternation {
+                    return false;
+                }
+                let Ok(nb_alts) = u8::try_from(alts.len()) else {
+                    return false;
+                };
+                if !self.add_combinations(nb_alts) {
+                    return false;
+                }
+
+                self.in_alternation = true;
+                let mut branches = Vec::with_capacity(alts.len());
+                let current_stack = std::mem::take(&mut self.nodes);
+                for alt in alts {
+                    if !self.add_hir(alt) {
+                        return false;
+                    }
+                    let nodes = std::mem::take(&mut self.nodes);
+                    branches.push(nodes.into_boxed_slice());
+                }
+                self.nodes = current_stack;
+                self.nodes
+                    .push(SimpleNode::Alternation(branches.into_boxed_slice()));
+                self.in_alternation = false;
+
+                true
+            }
         }
     }
 
@@ -353,13 +408,35 @@ impl SimpleValidatorBuilder {
         }
     }
 
+    fn add_combinations(&mut self, nb: u8) -> bool {
+        self.combinations = self.combinations.saturating_mul(nb);
+        self.combinations <= 64
+    }
+
     fn add_jump_range(&mut self, min: u8, max: u8) -> bool {
+        if self.in_alternation {
+            // Do not accept jump ranges in alternations. This makes
+            // the matching much more difficult.
+            //
+            // For example, see:
+            //
+            // { ( AA [0-1] BB | CC ) DD }
+            //
+            // The input `AA BB BB DD` should match, using the first branch
+            // and a jump of 1. However, the jump being non-greedy, the alt
+            // branch would actually match with a jum of 0 first, and would
+            // fail after validating the next node.
+            //
+            // Handling this would require backtracking in jump attempts
+            // inside the alternation, making this overly complex. So exclude
+            // those cases.
+            return false;
+        }
+
         // Cap the combinations of jumps. This does not distinguish
         // many small jumps from one bit jump, the goal is simply
         // to have a conservative cap to avoid any complications.
-        let comb = max.saturating_sub(min) + 1;
-        self.combinations = self.combinations.saturating_mul(comb);
-        if self.combinations > 64 {
+        if !self.add_combinations(max.saturating_sub(min) + 1) {
             return false;
         }
 
@@ -422,6 +499,10 @@ mod wire {
                     m.serialize(writer)?;
                     n.serialize(writer)?;
                 }
+                Self::Alternation(alts) => {
+                    6_u8.serialize(writer)?;
+                    alts.serialize(writer)?;
+                }
             }
 
             Ok(())
@@ -449,6 +530,12 @@ mod wire {
                     let m = u8::deserialize_reader(reader)?;
                     let n = u8::deserialize_reader(reader)?;
                     Ok(Self::JumpRange(m, n))
+                }
+                6 => {
+                    let alts = <Vec<Vec<SimpleNode>>>::deserialize_reader(reader)?;
+                    Ok(Self::Alternation(
+                        alts.into_iter().map(Vec::into_boxed_slice).collect(),
+                    ))
                 }
                 v => Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -543,7 +630,6 @@ mod tests {
     fn test_simple_validator_build() {
         // Regex contains nodes that are not handled
         test_build("a?", Modifiers::default(), false, None);
-        test_build("a|b", Modifiers::default(), false, None);
         test_build("^a", Modifiers::default(), false, None);
         test_build("a$", Modifiers::default(), false, None);
         test_build(r"a\b", Modifiers::default(), false, None);
@@ -673,14 +759,64 @@ mod tests {
     }
 
     #[test]
+    fn test_alternations() {
+        let mods = Modifiers {
+            dot_all: true,
+            ..Default::default()
+        };
+
+        test_build(
+            "{ ( AA ?? BB | CC | DD EE ) }",
+            mods,
+            false,
+            Some(&[SimpleNode::Alternation(Box::new([
+                Box::new([
+                    SimpleNode::Byte(b'\xAA'),
+                    SimpleNode::Jump(1),
+                    SimpleNode::Byte(b'\xBB'),
+                ]),
+                Box::new([SimpleNode::Byte(b'\xCC')]),
+                Box::new([SimpleNode::Byte(b'\xDD'), SimpleNode::Byte(b'\xEE')]),
+            ]))]),
+        );
+
+        // Imbricated is rejected
+        test_build("(a|b(c|d)e)", mods, false, None);
+        test_build("(b(c|d)e|a)", mods, false, None);
+
+        // Too many combinations is rejected
+        test_build("(0|1|2|3|4) (0|1|2|3|4) (5|6|7)", mods, false, None);
+
+        // Non fixed jumps is rejected
+        test_build("{ ( AA | BB [1-3] CC ) }", mods, false, None);
+        test_build("{ ( BB [1-3] CC | AA ) }", mods, false, None);
+        test_build("(a|cd??e)", mods, false, None);
+
+        // fixed jump is ok
+        test_build(
+            "{ ( AA | BB [3-3] CC ) }",
+            mods,
+            false,
+            Some(&[SimpleNode::Alternation(Box::new([
+                Box::new([SimpleNode::Byte(b'\xAA')]),
+                Box::new([
+                    SimpleNode::Byte(b'\xBB'),
+                    SimpleNode::Jump(3),
+                    SimpleNode::Byte(b'\xCC'),
+                ]),
+            ]))]),
+        );
+    }
+
+    #[test]
     fn test_simple_validator_reject() {
         let mut builder = SimpleValidatorBuilder {
             nodes: Vec::new(),
             dot_all: false,
             reverse: false,
             combinations: 1,
+            in_alternation: false,
         };
-        assert!(!builder.add_hir(&Hir::Alternation(vec![Hir::Empty]),));
         assert!(!builder.add_hir(&Hir::Concat(vec![
             Hir::Dot,
             Hir::Assertion(AssertionKind::StartLine)
@@ -821,5 +957,90 @@ mod tests {
         assert_eq!(vrev.find_anchored_rev(b"\xBB\xAA\xAA\xBB", 0, 4), Some(1));
 
         assert_eq!(vrev.find_anchored_rev(b"\xAA\x00\xAA", 0, 3), None);
+    }
+
+    #[test]
+    fn test_simple_validator_alternation() {
+        let mods = Modifiers::default();
+        let expr = "{ 00 ( AA ?? BB | CC | DD EE ) 11 ( 22 | 33 ) 44 }";
+        let v = build_validator(expr, mods, false).unwrap();
+        let vrev = build_validator(expr, mods, true).unwrap();
+
+        assert_eq!(
+            v.find_anchored_fwd(b"\x00\xAA\x00\xBB\x11\x22\x44", 0, 7),
+            Some(7)
+        );
+        assert_eq!(
+            vrev.find_anchored_rev(b"\x00\xAA\x00\xBB\x11\x22\x44", 0, 7),
+            Some(0)
+        );
+
+        assert_eq!(
+            v.find_anchored_fwd(b"\x00\xAA\x00\xBB\x11\x22\x44\x55", 0, 8),
+            Some(7)
+        );
+        assert_eq!(
+            vrev.find_anchored_rev(b"\x00\xAA\x00\xBB\x11\x22\x44\x55", 0, 8),
+            None
+        );
+
+        assert_eq!(
+            v.find_anchored_fwd(b"\xFF\x00\xAA\x00\xBB\x11\x22\x44", 0, 8),
+            None
+        );
+        assert_eq!(
+            vrev.find_anchored_rev(b"\xFF\x00\xAA\x00\xBB\x11\x22\x44", 0, 8),
+            Some(1)
+        );
+
+        assert_eq!(
+            v.find_anchored_fwd(b"\x00\xAA\x00\xBB\x11\x33\x44", 0, 7),
+            Some(7)
+        );
+        assert_eq!(
+            vrev.find_anchored_rev(b"\x00\xAA\x00\xBB\x11\x33\x44", 0, 7),
+            Some(0)
+        );
+
+        assert_eq!(
+            v.find_anchored_fwd(b"\x00\xDD\xEE\x11\x33\x44", 0, 6),
+            Some(6)
+        );
+        assert_eq!(
+            vrev.find_anchored_rev(b"\x00\xDD\xEE\x11\x33\x44", 0, 6),
+            Some(0)
+        );
+
+        assert_eq!(v.find_anchored_fwd(b"\x00\xCC\x11\x22\x44", 0, 5), Some(5));
+        assert_eq!(
+            vrev.find_anchored_rev(b"\x00\xCC\x11\x22\x44", 0, 5),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn test_simple_validator_alternation_backtrack() {
+        // This test that even if a branch is valid, we must test the rest
+        // of the nodes and backtrack to another branch if the rest fails.
+        let mods = Modifiers::default();
+        let expr = "{ ( AA | AA BB ) CC }";
+        let v = build_validator(expr, mods, false).unwrap();
+
+        assert_eq!(v.find_anchored_fwd(b"\xAA", 0, 1), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xDD", 0, 2), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xCC", 0, 2), Some(2));
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB", 0, 2), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB\xDD", 0, 3), None);
+        assert_eq!(v.find_anchored_fwd(b"\xAA\xBB\xCC", 0, 3), Some(3));
+
+        let expr = "{ CC ( AA | BB AA ) }";
+        let vrev = build_validator(expr, mods, true).unwrap();
+
+        assert_eq!(vrev.find_anchored_rev(b"\xAA", 0, 1), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xDD\xAA", 0, 2), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xCC\xAA", 0, 2), Some(0));
+        assert_eq!(vrev.find_anchored_rev(b"\xBB\xAA", 0, 2), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xDD\xBB\xAA", 0, 3), None);
+        assert_eq!(vrev.find_anchored_rev(b"\xCC\xBB\xAA", 0, 3), Some(0));
     }
 }


### PR DESCRIPTION
To improve the scope of what the simple validators accept, extend its capabilities with some alternations handling.

There are a few limitations to it:

- No variable-length part inside the alternation (like a jump range).
- No imbrication of alternations (which would allow variable-length parts as well).

This guarantees the alternation stays relatively easy to resolve,
and still allows covering most of how alternations are used in hex strings.

Extra care is taken to keep the size of the nodes used in the simple validator small by inlining
the alternation branch in a single allocation.